### PR TITLE
Small fix for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The Walker interface for directory traversal is heavily inspired by Keith Rarick
 roadmap
 -------
 
- * currently all traffic with the server is seralised, this can be improved by allowing overlapping requests/responses.
- * there is way too much duplication in the Client methods. If there was an unmarshal(interface{}) method this would reduce a heap of the duplication.
- * implement integration tests by talking directly to a real opensftp-server process. This shouldn't be too difficult to implement with a small refactoring to the sftp.NewClient method. These tests should be gated on an -sftp.integration test flag. _in progress_
+ * Currently all traffic with the server is serialized, this can be improved by allowing overlapping requests/responses.
+ * There is way too much duplication in the Client methods. If there was an unmarshal(interface{}) method this would reduce a heap of the duplication.
+ * Implement integration tests by talking directly to a real opensftp-server process. This shouldn't be too difficult to implement with a small refactoring to the sftp.NewClient method. These tests should be gated on an -sftp.integration test flag. _in progress_
 
 contributing
 ------------


### PR DESCRIPTION
- Fix a typo seralised -> serialized
- Start each sentence with uppercase.
