### PR TITLE
Change log.Fatal to log.Fatalf

### DIFF
--- a/examples/gsftp/main.go
+++ b/examples/gsftp/main.go
@@ -142,6 +142,6 @@ func main() {
 			log.Fatalf("unable to rename file: %v", err)
 		}
 	default:
-		log.Fatal("unknown subcommand: %v", cmd)
+		log.Fatalf("unknown subcommand: %v", cmd)
 	}
 }


### PR DESCRIPTION
The first argument is a format string, so this should likely be log.Fatalf.
