### PR TITLE
Remove unneeded field from Mkdir and Open requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -307,7 +307,6 @@ func (c *Client) open(path string, pflags uint32) (*File, error) {
 		Path   string
 		Pflags uint32
 		Flags  uint32 // ignored
-		Size   uint64 // ignored
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -580,7 +579,6 @@ func (c *Client) Mkdir(path string) error {
 		Id    uint32
 		Path  string
 		Flags uint32 // ignored
-		Size  uint64 // ignored
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()


### PR DESCRIPTION
The size field in the attributes struct should only be provided in a request if
the appropriate flag is set.

In particular, the first two fields of the attributes struct is defined as:

```
uint32   flags
uint64   size           present only if flag SSH_FILEXFER_ATTR_SIZE
```

Since the implementation uses the default flags value of zero, the size field
should not be transmitted. This causes an issue in older versions of the
OpenSSH SFTP server, which manifests as a hang while receiving the response.
