### PR TITLE
Add sftp.NewClientFromIO()

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,6 +40,20 @@ func NewClient(conn *ssh.Client) (*Client, error) {
 	return sftp, sftp.recvVersion()
 }
 
+// NewClientPipe creates a new SFTP client given a Reader and a WriteCloser.
+// This can be used for connecting to an SFTP server over TCP/TLS or by using
+// the system's ssh client program (e.g. via exec.Command).
+func NewClientPipe(rd io.Reader, wr io.WriteCloser) (*Client, error) {
+	sftp := &Client{
+		w: wr,
+		r: rd,
+	}
+	if err := sftp.sendInit(); err != nil {
+		return nil, err
+	}
+	return sftp, sftp.recvVersion()
+}
+
 // Client represents an SFTP session on a *ssh.ClientConn SSH connection.
 // Multiple Clients can be active on a single SSH connection, and a Client
 // may be called concurrently from multiple Goroutines.

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -52,10 +52,12 @@ func testClient(t *testing.T, readonly bool) (*Client, *exec.Cmd) {
 	if err := cmd.Start(); err != nil {
 		t.Skipf("could not start sftp-server process: %v", err)
 	}
-	sftp := &Client{
-		w: pw,
-		r: pr,
+
+	sftp, err := NewClientPipe(pr, pw)
+	if err != nil {
+		t.Fatal(err)
 	}
+
 	if err := sftp.sendInit(); err != nil {
 		defer cmd.Wait()
 		t.Fatal(err)

--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,10 @@
 package sftp_test
 
 import (
+	"fmt"
 	"log"
+	"os"
+	"os/exec"
 
 	"code.google.com/p/go.crypto/ssh"
 
@@ -40,4 +43,49 @@ func Example(conn *ssh.Client) {
 		log.Fatal(err)
 	}
 	log.Println(fi)
+}
+
+func ExampleNewClientPipe() {
+	// Connect to a remote host and request the sftp subsystem via the 'ssh'
+	// command.  This assumes that passwordless login is correctly configured.
+	cmd := exec.Command("ssh", "example.com", "-s", "sftp")
+
+	// send errors from ssh to stderr
+	cmd.Stderr = os.Stderr
+
+	// get stdin and stdout
+	wr, err := cmd.StdinPipe()
+	if err != nil {
+		log.Fatal(err)
+	}
+	rd, err := cmd.StdoutPipe()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// start the process
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer cmd.Wait()
+
+	// open the SFTP session
+	client, err := sftp.NewClientPipe(rd, wr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// read a directory
+	list, err := client.ReadDir("/")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// print contents
+	for _, item := range list {
+		fmt.Println(item.Name())
+	}
+
+	// close the connection
+	client.Close()
 }


### PR DESCRIPTION
This method returns a Client from a pair of pipes.  This can be used for
connecting to an SFTP server over TCP/TLS or by using the system's ssh
client program (e.g. via exec.Command).
