### PR TITLE
Fixed write errors not bubbling up correctly

### DIFF
--- a/client.go
+++ b/client.go
@@ -521,7 +521,7 @@ func (c *Client) writeAt(handle string, offset uint64, buf []byte) (uint32, erro
 	switch typ {
 	case ssh_FXP_STATUS:
 		if err := okOrErr(unmarshalStatus(id, data)); err != nil {
-			return 0, nil
+			return 0, err
 		}
 		return uint32(len(buf)), nil
 	default:


### PR DESCRIPTION
Errors returned by the SFTP server during a write operation were not being bubbled up correctly.

An easy way to repro is the following:
1. Create a tiny `tmpfs` filesystem:

``` bash
mkdir /tmp/test
sudo mount -t tmpfs -o size=1M tmpfs /tmp/test
```
1. Try uploading a file larger than 1MB via SFTP:

``` go
// Note: client is an *ssh.Client connected to localhost,
// /tmp/2M.bin is a 2MB file

ftp, err := sftp.NewClient(client)
if err != nil {
    panic(err)
}

defer ftp.Close()

data, err := ioutil.ReadFile("/tmp/2M.bin")
if err != nil {
    panic(err)
}

file, err := ftp.Create("/tmp/test/2M.bin")
if err != nil {
    panic(err)
}

defer file.Close()

// BUG: This call blocks forever.
_, err = file.Write(data)
```
