### PR TITLE
Add statvfs@openssh.com extension request

### DIFF
--- a/client.go
+++ b/client.go
@@ -453,7 +453,7 @@ func (c *Client) StatVFS(path string) (*StatVFS, error) {
 
 		// the resquest failed
 		case ssh_FXP_STATUS:
-			return nil, errors.New("statvfs@openssh.com failure")
+			return nil, errors.New(fxp(ssh_FXP_STATUS).String())
 
 		default:
 			return nil, unimplementedPacketErr(typ)

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"testing"
 	"testing/quick"
+	"syscall"
 
 	"github.com/kr/fs"
 )
@@ -895,4 +896,40 @@ func BenchmarkWrite1MiB(b *testing.B) {
 
 func BenchmarkWrite4MiB(b *testing.B) {
 	benchmarkWrite(b, 4*1024*1024)
+}
+
+func TestClientStatVFS(t *testing.T) {
+	sftp, cmd := testClient(t, READWRITE)
+	defer cmd.Wait()
+	defer sftp.Close()
+
+	vfs, err := sftp.StatVFS("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get system stats
+	s := syscall.Statfs_t{}
+	err = syscall.Statfs("/", &s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check some stats
+	if (vfs.Frsize != uint64(s.Frsize)) {
+		t.Fatal("fr_size does not match")
+	}
+
+	if (vfs.Bsize != uint64(s.Bsize)) {
+		t.Fatal("f_bsize does not match")
+	}
+
+	if (vfs.Namemax != uint64(s.Namelen)) {
+		t.Fatal("f_namemax does not match")
+	}
+
+	if (vfs.Bavail != s.Bavail) {
+		t.Fatal("f_bavail does not match")
+	}
+
 }

--- a/packet.go
+++ b/packet.go
@@ -329,3 +329,45 @@ func (p sshFxpSetstatPacket) MarshalBinary() ([]byte, error) {
 	b = marshal(b, p.Attrs)
 	return b, nil
 }
+
+type sshFxpStatvfsPacket struct {
+	Id uint32
+	Path string
+}
+
+func (p sshFxpStatvfsPacket) MarshalBinary() ([]byte, error) {
+	l := 1 + 4 + // type(byte) + uint32
+		len(p.Path) + 
+		len("statvfs@openssh.com")
+
+
+	b := make([]byte, 0, l)
+	b = append(b, ssh_FXP_EXTENDED)
+	b = marshalUint32(b, p.Id)
+	b = marshalString(b, "statvfs@openssh.com")
+	b = marshalString(b, p.Path)
+	return b, nil
+}
+
+type StatVFS struct {
+	Id uint32
+	Bsize uint64		/* file system block size */
+	Frsize uint64		/* fundamental fs block size */
+	Blocks uint64		/* number of blocks (unit f_frsize) */
+	Bfree uint64		/* free blocks in file system */
+	Bavail uint64		/* free blocks for non-root */
+	Files uint64		/* total file inodes */
+	Ffree uint64		/* free file inodes */
+	Favail uint64		/* free file inodes for to non-root */
+	Fsid uint64			/* file system id */
+	Flag uint64			/* bit mask of f_flag values */
+	Namemax uint64		/* maximum filename length */
+}
+
+func (p *StatVFS) TotalSpace() uint64 {
+	return p.Frsize * p.Blocks
+}
+
+func (p *StatVFS) FreeSpace() uint64 {
+	return p.Frsize * p.Bfree
+}


### PR DESCRIPTION
Adding the ablity to send a statvfs@openssh.com extension request to the server.
See http://www.opensource.apple.com/source/OpenSSH/OpenSSH-175/openssh/PROTOCOL?txt section 3.4 for further information.