### PR TITLE
Make c.sendRequest concurrent

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -64,7 +64,6 @@ func unmarshalString(b []byte) (string, []byte) {
 }
 
 // sendPacket marshals p according to RFC 4234.
-
 func sendPacket(w io.Writer, m encoding.BinaryMarshaler) error {
 	bb, err := m.MarshalBinary()
 	if err != nil {
@@ -142,6 +141,8 @@ func (p sshFxpReaddirPacket) MarshalBinary() ([]byte, error) {
 	return marshalIdString(ssh_FXP_READDIR, p.Id, p.Handle)
 }
 
+func (p sshFxpReaddirPacket) id() uint32 { return p.Id }
+
 type sshFxpOpendirPacket struct {
 	Id   uint32
 	Path string
@@ -151,10 +152,14 @@ func (p sshFxpOpendirPacket) MarshalBinary() ([]byte, error) {
 	return marshalIdString(ssh_FXP_OPENDIR, p.Id, p.Path)
 }
 
+func (p sshFxpOpendirPacket) id() uint32 { return p.Id }
+
 type sshFxpLstatPacket struct {
 	Id   uint32
 	Path string
 }
+
+func (p sshFxpLstatPacket) id() uint32 { return p.Id }
 
 func (p sshFxpLstatPacket) MarshalBinary() ([]byte, error) {
 	return marshalIdString(ssh_FXP_LSTAT, p.Id, p.Path)
@@ -164,6 +169,8 @@ type sshFxpFstatPacket struct {
 	Id     uint32
 	Handle string
 }
+
+func (p sshFxpFstatPacket) id() uint32 { return p.Id }
 
 func (p sshFxpFstatPacket) MarshalBinary() ([]byte, error) {
 	return marshalIdString(ssh_FXP_FSTAT, p.Id, p.Handle)
@@ -178,10 +185,14 @@ func (p sshFxpClosePacket) MarshalBinary() ([]byte, error) {
 	return marshalIdString(ssh_FXP_CLOSE, p.Id, p.Handle)
 }
 
+func (p sshFxpClosePacket) id() uint32 { return p.Id }
+
 type sshFxpRemovePacket struct {
 	Id       uint32
 	Filename string
 }
+
+func (p sshFxpRemovePacket) id() uint32 { return p.Id }
 
 func (p sshFxpRemovePacket) MarshalBinary() ([]byte, error) {
 	return marshalIdString(ssh_FXP_REMOVE, p.Id, p.Filename)
@@ -192,6 +203,8 @@ type sshFxpRmdirPacket struct {
 	Path string
 }
 
+func (p sshFxpRmdirPacket) id() uint32 { return p.Id }
+
 func (p sshFxpRmdirPacket) MarshalBinary() ([]byte, error) {
 	return marshalIdString(ssh_FXP_RMDIR, p.Id, p.Path)
 }
@@ -200,6 +213,8 @@ type sshFxpReadlinkPacket struct {
 	Id   uint32
 	Path string
 }
+
+func (p sshFxpReadlinkPacket) id() uint32 { return p.Id }
 
 func (p sshFxpReadlinkPacket) MarshalBinary() ([]byte, error) {
 	return marshalIdString(ssh_FXP_READLINK, p.Id, p.Path)
@@ -211,6 +226,8 @@ type sshFxpOpenPacket struct {
 	Pflags uint32
 	Flags  uint32 // ignored
 }
+
+func (p sshFxpOpenPacket) id() uint32 { return p.Id }
 
 func (p sshFxpOpenPacket) MarshalBinary() ([]byte, error) {
 	l := 1 + 4 +
@@ -233,6 +250,8 @@ type sshFxpReadPacket struct {
 	Len    uint32
 }
 
+func (p sshFxpReadPacket) id() uint32 { return p.Id }
+
 func (p sshFxpReadPacket) MarshalBinary() ([]byte, error) {
 	l := 1 + 4 + // type(byte) + uint32
 		4 + len(p.Handle) +
@@ -252,6 +271,8 @@ type sshFxpRenamePacket struct {
 	Oldpath string
 	Newpath string
 }
+
+func (p sshFxpRenamePacket) id() uint32 { return p.Id }
 
 func (p sshFxpRenamePacket) MarshalBinary() ([]byte, error) {
 	l := 1 + 4 + // type(byte) + uint32
@@ -273,6 +294,8 @@ type sshFxpWritePacket struct {
 	Length uint32
 	Data   []byte
 }
+
+func (s sshFxpWritePacket) id() uint32 { return s.Id }
 
 func (s sshFxpWritePacket) MarshalBinary() ([]byte, error) {
 	l := 1 + 4 + // type(byte) + uint32
@@ -296,6 +319,8 @@ type sshFxpMkdirPacket struct {
 	Flags uint32 // ignored
 }
 
+func (p sshFxpMkdirPacket) id() uint32 { return p.Id }
+
 func (p sshFxpMkdirPacket) MarshalBinary() ([]byte, error) {
 	l := 1 + 4 + // type(byte) + uint32
 		4 + len(p.Path) +
@@ -316,6 +341,8 @@ type sshFxpSetstatPacket struct {
 	Attrs interface{}
 }
 
+func (p sshFxpSetstatPacket) id() uint32 { return p.Id }
+
 func (p sshFxpSetstatPacket) MarshalBinary() ([]byte, error) {
 	l := 1 + 4 + // type(byte) + uint32
 		4 + len(p.Path) +
@@ -334,6 +361,8 @@ type sshFxpStatvfsPacket struct {
 	Id   uint32
 	Path string
 }
+
+func (p sshFxpStatvfsPacket) id() uint32 { return p.Id }
 
 func (p sshFxpStatvfsPacket) MarshalBinary() ([]byte, error) {
 	l := 1 + 4 + // type(byte) + uint32


### PR DESCRIPTION
This is an attempt to permit overlapping requests.

Update #32 
Update #24 

For each request sent, we spin off a goroutine to send the request for us
then handle _a_ response. That goroutine will try to dispatch the request
to the original sender. As every request is initiated from the client, there
will always be a matching number of replies from the server so eventally
every worker goroutine will process a request and exit.