### PR TITLE
Increase throughput

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,7 +58,7 @@ func NewClientPipe(rd io.Reader, wr io.WriteCloser, opts ...func(*Client) error)
 		w:         wr,
 		r:         rd,
 		maxPacket: 1 << 15,
-		inflight:  make(map[uint32]chan result),
+		inflight:  make(map[uint32]chan<- result),
 	}
 	if err := sftp.applyOptions(opts...); err != nil {
 		wr.Close()
@@ -83,8 +83,8 @@ type Client struct {
 	maxPacket int // max packet size read or written.
 	nextid    uint32
 
-	mu       sync.Mutex             // ensures only on request is in flight to the server at once
-	inflight map[uint32]chan result // outstanding requests
+	mu       sync.Mutex               // ensures only on request is in flight to the server at once
+	inflight map[uint32]chan<- result // outstanding requests
 }
 
 // Close closes the SFTP session.
@@ -353,35 +353,6 @@ func (c *Client) open(path string, pflags uint32) (*File, error) {
 	}
 }
 
-// readAt reads len(buf) bytes from the remote file indicated by handle starting
-// from offset.
-func (c *Client) readAt(handle string, offset uint64, buf []byte) (uint32, error) {
-	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpReadPacket{
-		Id:     id,
-		Handle: handle,
-		Offset: offset,
-		Len:    uint32(len(buf)),
-	})
-	if err != nil {
-		return 0, err
-	}
-	switch typ {
-	case ssh_FXP_DATA:
-		sid, data := unmarshalUint32(data)
-		if sid != id {
-			return 0, &unexpectedIdErr{id, sid}
-		}
-		l, data := unmarshalUint32(data)
-		n := copy(buf, data[:l])
-		return uint32(n), nil
-	case ssh_FXP_STATUS:
-		return 0, eofOrErr(unmarshalStatus(id, data))
-	default:
-		return 0, unimplementedPacketErr(typ)
-	}
-}
-
 // close closes a handle handle previously returned in the response
 // to SSH_FXP_OPEN or SSH_FXP_OPENDIR. The handle becomes invalid
 // immediately after this request has been sent.
@@ -543,17 +514,21 @@ type idmarshaler interface {
 
 func (c *Client) sendRequest(p idmarshaler) (byte, []byte, error) {
 	ch := make(chan result)
-	go func() {
-		c.mu.Lock()
-		c.inflight[p.id()] = ch
-		err := sendPacket(c.w, p)
-		c.mu.Unlock()
-		if err != nil {
-			ch <- result{err: err}
-			return
-		}
+	c.dispatchRequest(ch, p)
+	s := <-ch
+	return s.typ, s.data, s.err
+}
 
-		// another goroutine may pick up the lock here
+func (c *Client) dispatchRequest(ch chan<- result, p idmarshaler) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inflight[p.id()] = ch
+	err := sendPacket(c.w, p)
+	if err != nil {
+		go func() { ch <- result{err: err} }()
+		return
+	}
+	go func() {
 		c.mu.Lock()
 		typ, data, err := recvPacket(c.r)
 		if err != nil {
@@ -578,33 +553,6 @@ func (c *Client) sendRequest(p idmarshaler) (byte, []byte, error) {
 		}
 		ch1 <- result{typ: typ, data: data}
 	}()
-	s := <-ch
-	return s.typ, s.data, s.err
-}
-
-// writeAt writes len(buf) bytes from the remote file indicated by handle starting
-// from offset.
-func (c *Client) writeAt(handle string, offset uint64, buf []byte) (uint32, error) {
-	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpWritePacket{
-		Id:     id,
-		Handle: handle,
-		Offset: offset,
-		Length: uint32(len(buf)),
-		Data:   buf,
-	})
-	if err != nil {
-		return 0, err
-	}
-	switch typ {
-	case ssh_FXP_STATUS:
-		if err := okOrErr(unmarshalStatus(id, data)); err != nil {
-			return 0, err
-		}
-		return uint32(len(buf)), nil
-	default:
-		return 0, unimplementedPacketErr(typ)
-	}
 }
 
 // Creates the specified directory. An error will be returned if a file or
@@ -652,21 +600,101 @@ func (f *File) Close() error {
 	return f.c.close(f.handle)
 }
 
+const maxConcurrentRequests = 64
+
 // Read reads up to len(b) bytes from the File. It returns the number of
 // bytes read and an error, if any. EOF is signaled by a zero count with
 // err set to io.EOF.
 func (f *File) Read(b []byte) (int, error) {
-	var read int
-	for len(b) > 0 {
-		n, err := f.c.readAt(f.handle, f.offset, b[:min(len(b), f.c.maxPacket)])
-		f.offset += uint64(n)
-		read += int(n)
-		if err != nil {
-			return read, err
-		}
-		b = b[n:]
+	// Split the read into multiple maxPacket sized concurrent reads
+	// bounded by maxConcurrentRequests. This allows reads with a suitably
+	// large buffer to transfer data at a much faster rate due to
+	// overlapping round trip times.
+	inFlight := 0
+	desiredInFlight := 1
+	offset := f.offset
+	ch := make(chan result)
+	type inflightRead struct {
+		b      []byte
+		offset uint64
 	}
-	return read, nil
+	reqs := map[uint32]inflightRead{}
+	type offsetErr struct {
+		offset uint64
+		err    error
+	}
+	var firstErr offsetErr
+
+	sendReq := func(b []byte, offset uint64) {
+		reqId := f.c.nextId()
+		f.c.dispatchRequest(ch, sshFxpReadPacket{
+			Id:     reqId,
+			Handle: f.handle,
+			Offset: offset,
+			Len:    uint32(len(b)),
+		})
+		inFlight++
+		reqs[reqId] = inflightRead{b: b, offset: offset}
+	}
+
+	var read int
+	for len(b) > 0 || inFlight > 0 {
+		for inFlight < desiredInFlight && len(b) > 0 && firstErr.err == nil {
+			l := min(len(b), f.c.maxPacket)
+			rb := b[:l]
+			sendReq(rb, offset)
+			offset += uint64(l)
+			b = b[l:]
+		}
+
+		if inFlight == 0 {
+			break
+		}
+		select {
+		case res := <-ch:
+			inFlight--
+			if res.err != nil {
+				firstErr = offsetErr{offset: 0, err: res.err}
+				break
+			}
+			reqId, data := unmarshalUint32(res.data)
+			req, ok := reqs[reqId]
+			if !ok {
+				firstErr = offsetErr{offset: 0, err: fmt.Errorf("sid: %v not found", reqId)}
+				break
+			}
+			delete(reqs, reqId)
+			switch res.typ {
+			case ssh_FXP_STATUS:
+				if firstErr.err == nil || req.offset < firstErr.offset {
+					firstErr = offsetErr{offset: req.offset, err: eofOrErr(unmarshalStatus(reqId, res.data))}
+					break
+				}
+			case ssh_FXP_DATA:
+				l, data := unmarshalUint32(data)
+				n := copy(req.b, data[:l])
+				read += n
+				if n < len(req.b) {
+					sendReq(req.b[l:], req.offset+uint64(l))
+				}
+				if desiredInFlight < maxConcurrentRequests {
+					desiredInFlight++
+				}
+			default:
+				firstErr = offsetErr{offset: 0, err: unimplementedPacketErr(res.typ)}
+				break
+			}
+		}
+	}
+	// If the error is anything other than EOF, then there
+	// may be gaps in the data copied to the buffer so it's
+	// best to return 0 so the caller can't make any
+	// incorrect assumptions about the state of the buffer.
+	if firstErr.err != nil && firstErr.err != io.EOF {
+		read = 0
+	}
+	f.offset += uint64(read)
+	return read, firstErr.err
 }
 
 // Stat returns the FileInfo structure describing file. If there is an
@@ -683,17 +711,67 @@ func (f *File) Stat() (os.FileInfo, error) {
 // written and an error, if any. Write returns a non-nil error when n !=
 // len(b).
 func (f *File) Write(b []byte) (int, error) {
-	var written int
-	for len(b) > 0 {
-		n, err := f.c.writeAt(f.handle, f.offset, b[:min(len(b), f.c.maxPacket)])
-		f.offset += uint64(n)
-		written += int(n)
-		if err != nil {
-			return written, err
+	// Split the write into multiple maxPacket sized concurrent writes
+	// bounded by maxConcurrentRequests. This allows writes with a suitably
+	// large buffer to transfer data at a much faster rate due to
+	// overlapping round trip times.
+	inFlight := 0
+	desiredInFlight := 1
+	offset := f.offset
+	ch := make(chan result)
+	var firstErr error
+	written := len(b)
+	for len(b) > 0 || inFlight > 0 {
+		for inFlight < desiredInFlight && len(b) > 0 && firstErr == nil {
+			l := min(len(b), f.c.maxPacket)
+			rb := b[:l]
+			f.c.dispatchRequest(ch, sshFxpWritePacket{
+				Id:     f.c.nextId(),
+				Handle: f.handle,
+				Offset: offset,
+				Length: uint32(len(rb)),
+				Data:   rb,
+			})
+			inFlight++
+			offset += uint64(l)
+			b = b[l:]
 		}
-		b = b[n:]
+
+		if inFlight == 0 {
+			break
+		}
+		select {
+		case res := <-ch:
+			inFlight--
+			if res.err != nil {
+				firstErr = res.err
+				break
+			}
+			switch res.typ {
+			case ssh_FXP_STATUS:
+				id, _ := unmarshalUint32(res.data)
+				err := okOrErr(unmarshalStatus(id, res.data))
+				if err != nil && firstErr == nil {
+					firstErr = err
+					break
+				}
+				if desiredInFlight < maxConcurrentRequests {
+					desiredInFlight++
+				}
+			default:
+				firstErr = unimplementedPacketErr(res.typ)
+				break
+			}
+		}
 	}
-	return written, nil
+	// If error is non-nil, then there may be gaps in the data written to
+	// the file so it's best to return 0 so the caller can't make any
+	// incorrect assumptions about the state of the file.
+	if firstErr != nil {
+		written = 0
+	}
+	f.offset += uint64(written)
+	return written, firstErr
 }
 
 // Seek implements io.Seeker by setting the client offset for the next Read or

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -112,14 +112,6 @@ func testClient(t testing.TB, readonly bool, delay time.Duration) (*Client, *exe
 		t.Fatal(err)
 	}
 
-	if err := sftp.sendInit(); err != nil {
-		defer cmd.Wait()
-		t.Fatal(err)
-	}
-	if err := sftp.recvVersion(); err != nil {
-		defer cmd.Wait()
-		t.Fatal(err)
-	}
 	return sftp, cmd
 }
 

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -17,13 +17,15 @@ import (
 	"syscall"
 	"testing"
 	"testing/quick"
+	"time"
 
 	"github.com/kr/fs"
 )
 
 const (
-	READONLY  = true
-	READWRITE = false
+	READONLY                = true
+	READWRITE               = false
+	NO_DELAY  time.Duration = 0
 
 	debuglevel = "ERROR" // set to "DEBUG" for debugging
 )
@@ -31,9 +33,57 @@ const (
 var testIntegration = flag.Bool("integration", false, "perform integration tests against sftp server process")
 var testSftp = flag.String("sftp", "/usr/lib/openssh/sftp-server", "location of the sftp server binary")
 
+type delayedWrite struct {
+	t time.Time
+	b []byte
+}
+
+// delayedWriter wraps a writer and artificially delays the write. This is
+// meant to mimic connections with various latencies. Error's returned from the
+// underlying writer will panic so this should only be used over reliable
+// connections.
+type delayedWriter struct {
+	w      io.WriteCloser
+	ch     chan delayedWrite
+	closed chan struct{}
+}
+
+func newDelayedWriter(w io.WriteCloser, delay time.Duration) io.WriteCloser {
+	ch := make(chan delayedWrite, 128)
+	closed := make(chan struct{})
+	go func() {
+		for writeMsg := range ch {
+			time.Sleep(writeMsg.t.Add(delay).Sub(time.Now()))
+			n, err := w.Write(writeMsg.b)
+			if err != nil {
+				panic("write error")
+			}
+			if n < len(writeMsg.b) {
+				panic("showrt write")
+			}
+		}
+		w.Close()
+		close(closed)
+	}()
+	return delayedWriter{w: w, ch: ch, closed: closed}
+}
+
+func (w delayedWriter) Write(b []byte) (int, error) {
+	bcopy := make([]byte, len(b))
+	copy(bcopy, b)
+	w.ch <- delayedWrite{t: time.Now(), b: bcopy}
+	return len(b), nil
+}
+
+func (w delayedWriter) Close() error {
+	close(w.ch)
+	<-w.closed
+	return nil
+}
+
 // testClient returns a *Client connected to a localy running sftp-server
 // the *exec.Cmd returned must be defer Wait'd.
-func testClient(t testing.TB, readonly bool) (*Client, *exec.Cmd) {
+func testClient(t testing.TB, readonly bool, delay time.Duration) (*Client, *exec.Cmd) {
 	if !*testIntegration {
 		t.Skip("skipping intergration test")
 	}
@@ -45,6 +95,9 @@ func testClient(t testing.TB, readonly bool) (*Client, *exec.Cmd) {
 	pw, err := cmd.StdinPipe()
 	if err != nil {
 		t.Fatal(err)
+	}
+	if delay > NO_DELAY {
+		pw = newDelayedWriter(pw, delay)
 	}
 	pr, err := cmd.StdoutPipe()
 	if err != nil {
@@ -71,7 +124,7 @@ func testClient(t testing.TB, readonly bool) (*Client, *exec.Cmd) {
 }
 
 func TestNewClient(t *testing.T) {
-	sftp, cmd := testClient(t, READONLY)
+	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()
 
 	if err := sftp.Close(); err != nil {
@@ -80,7 +133,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestClientLstat(t *testing.T) {
-	sftp, cmd := testClient(t, READONLY)
+	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -106,7 +159,7 @@ func TestClientLstat(t *testing.T) {
 }
 
 func TestClientLstatMissing(t *testing.T) {
-	sftp, cmd := testClient(t, READONLY)
+	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -123,7 +176,7 @@ func TestClientLstatMissing(t *testing.T) {
 }
 
 func TestClientMkdir(t *testing.T) {
-	sftp, cmd := testClient(t, READWRITE)
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -141,7 +194,7 @@ func TestClientMkdir(t *testing.T) {
 }
 
 func TestClientOpen(t *testing.T) {
-	sftp, cmd := testClient(t, READONLY)
+	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -200,7 +253,7 @@ func (s seek) end(t *testing.T, r io.ReadSeeker) {
 }
 
 func TestClientSeek(t *testing.T) {
-	sftp, cmd := testClient(t, READONLY)
+	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -244,7 +297,7 @@ func TestClientSeek(t *testing.T) {
 }
 
 func TestClientCreate(t *testing.T) {
-	sftp, cmd := testClient(t, READWRITE)
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -263,7 +316,7 @@ func TestClientCreate(t *testing.T) {
 }
 
 func TestClientAppend(t *testing.T) {
-	sftp, cmd := testClient(t, READWRITE)
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -282,7 +335,7 @@ func TestClientAppend(t *testing.T) {
 }
 
 func TestClientCreateFailed(t *testing.T) {
-	sftp, cmd := testClient(t, READONLY)
+	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -303,7 +356,7 @@ func TestClientCreateFailed(t *testing.T) {
 }
 
 func TestClientFileStat(t *testing.T) {
-	sftp, cmd := testClient(t, READONLY)
+	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -334,7 +387,7 @@ func TestClientFileStat(t *testing.T) {
 }
 
 func TestClientRemove(t *testing.T) {
-	sftp, cmd := testClient(t, READWRITE)
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -351,7 +404,7 @@ func TestClientRemove(t *testing.T) {
 }
 
 func TestClientRemoveDir(t *testing.T) {
-	sftp, cmd := testClient(t, READWRITE)
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -368,7 +421,7 @@ func TestClientRemoveDir(t *testing.T) {
 }
 
 func TestClientRemoveFailed(t *testing.T) {
-	sftp, cmd := testClient(t, READONLY)
+	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -385,7 +438,7 @@ func TestClientRemoveFailed(t *testing.T) {
 }
 
 func TestClientRename(t *testing.T) {
-	sftp, cmd := testClient(t, READWRITE)
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -406,7 +459,7 @@ func TestClientRename(t *testing.T) {
 }
 
 func TestClientReadLine(t *testing.T) {
-	sftp, cmd := testClient(t, READWRITE)
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -450,7 +503,7 @@ var clientReadTests = []struct {
 }
 
 func TestClientRead(t *testing.T) {
-	sftp, cmd := testClient(t, READONLY)
+	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -538,7 +591,7 @@ var clientWriteTests = []struct {
 }
 
 func TestClientWrite(t *testing.T) {
-	sftp, cmd := testClient(t, READWRITE)
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -665,7 +718,7 @@ func mark(path string, info os.FileInfo, err error, errors *[]error, clear bool)
 }
 
 func TestClientWalk(t *testing.T) {
-	sftp, cmd := testClient(t, READONLY)
+	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -748,11 +801,11 @@ func TestClientWalk(t *testing.T) {
 	}
 }
 
-func benchmarkRead(b *testing.B, bufsize int) {
+func benchmarkRead(b *testing.B, bufsize int, delay time.Duration) {
 	size := 10*1024*1024 + 123 // ~10MiB
 
 	// open sftp client
-	sftp, cmd := testClient(b, READONLY)
+	sftp, cmd := testClient(b, READONLY, delay)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -787,38 +840,50 @@ func benchmarkRead(b *testing.B, bufsize int) {
 }
 
 func BenchmarkRead1k(b *testing.B) {
-	benchmarkRead(b, 1*1024)
+	benchmarkRead(b, 1*1024, NO_DELAY)
 }
 
 func BenchmarkRead16k(b *testing.B) {
-	benchmarkRead(b, 16*1024)
+	benchmarkRead(b, 16*1024, NO_DELAY)
 }
 
 func BenchmarkRead32k(b *testing.B) {
-	benchmarkRead(b, 32*1024)
+	benchmarkRead(b, 32*1024, NO_DELAY)
 }
 
 func BenchmarkRead128k(b *testing.B) {
-	benchmarkRead(b, 128*1024)
+	benchmarkRead(b, 128*1024, NO_DELAY)
 }
 
 func BenchmarkRead512k(b *testing.B) {
-	benchmarkRead(b, 512*1024)
+	benchmarkRead(b, 512*1024, NO_DELAY)
 }
 
 func BenchmarkRead1MiB(b *testing.B) {
-	benchmarkRead(b, 1024*1024)
+	benchmarkRead(b, 1024*1024, NO_DELAY)
 }
 
 func BenchmarkRead4MiB(b *testing.B) {
-	benchmarkRead(b, 4*1024*1024)
+	benchmarkRead(b, 4*1024*1024, NO_DELAY)
 }
 
-func benchmarkWrite(b *testing.B, bufsize int) {
+func BenchmarkRead4MiBDelay10Msec(b *testing.B) {
+	benchmarkRead(b, 4*1024*1024, 10*time.Millisecond)
+}
+
+func BenchmarkRead4MiBDelay50Msec(b *testing.B) {
+	benchmarkRead(b, 4*1024*1024, 50*time.Millisecond)
+}
+
+func BenchmarkRead4MiBDelay150Msec(b *testing.B) {
+	benchmarkRead(b, 4*1024*1024, 150*time.Millisecond)
+}
+
+func benchmarkWrite(b *testing.B, bufsize int, delay time.Duration) {
 	size := 10*1024*1024 + 123 // ~10MiB
 
 	// open sftp client
-	sftp, cmd := testClient(b, false)
+	sftp, cmd := testClient(b, false, delay)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -871,35 +936,47 @@ func benchmarkWrite(b *testing.B, bufsize int) {
 }
 
 func BenchmarkWrite1k(b *testing.B) {
-	benchmarkWrite(b, 1*1024)
+	benchmarkWrite(b, 1*1024, NO_DELAY)
 }
 
 func BenchmarkWrite16k(b *testing.B) {
-	benchmarkWrite(b, 16*1024)
+	benchmarkWrite(b, 16*1024, NO_DELAY)
 }
 
 func BenchmarkWrite32k(b *testing.B) {
-	benchmarkWrite(b, 32*1024)
+	benchmarkWrite(b, 32*1024, NO_DELAY)
 }
 
 func BenchmarkWrite128k(b *testing.B) {
-	benchmarkWrite(b, 128*1024)
+	benchmarkWrite(b, 128*1024, NO_DELAY)
 }
 
 func BenchmarkWrite512k(b *testing.B) {
-	benchmarkWrite(b, 512*1024)
+	benchmarkWrite(b, 512*1024, NO_DELAY)
 }
 
 func BenchmarkWrite1MiB(b *testing.B) {
-	benchmarkWrite(b, 1024*1024)
+	benchmarkWrite(b, 1024*1024, NO_DELAY)
 }
 
 func BenchmarkWrite4MiB(b *testing.B) {
-	benchmarkWrite(b, 4*1024*1024)
+	benchmarkWrite(b, 4*1024*1024, NO_DELAY)
+}
+
+func BenchmarkWrite4MiBDelay10Msec(b *testing.B) {
+	benchmarkWrite(b, 4*1024*1024, 10*time.Millisecond)
+}
+
+func BenchmarkWrite4MiBDelay50Msec(b *testing.B) {
+	benchmarkWrite(b, 4*1024*1024, 50*time.Millisecond)
+}
+
+func BenchmarkWrite4MiBDelay150Msec(b *testing.B) {
+	benchmarkWrite(b, 4*1024*1024, 150*time.Millisecond)
 }
 
 func TestClientStatVFS(t *testing.T) {
-	sftp, cmd := testClient(t, READWRITE)
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
 
@@ -932,4 +1009,157 @@ func TestClientStatVFS(t *testing.T) {
 		t.Fatal("f_bavail does not match")
 	}
 
+}
+
+func benchmarkCopyDown(b *testing.B, fileSize int64, delay time.Duration) {
+	// Create a temp file and fill it with zero's.
+	src, err := ioutil.TempFile("", "sftptest")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer src.Close()
+	srcFilename := src.Name()
+	defer os.Remove(srcFilename)
+	zero, err := os.Open("/dev/zero")
+	if err != nil {
+		b.Fatal(err)
+	}
+	n, err := io.Copy(src, io.LimitReader(zero, fileSize))
+	if err != nil {
+		b.Fatal(err)
+	}
+	if n < fileSize {
+		b.Fatal("short copy")
+	}
+	zero.Close()
+	src.Close()
+
+	sftp, cmd := testClient(b, READONLY, delay)
+	defer cmd.Wait()
+	defer sftp.Close()
+	b.ResetTimer()
+	b.SetBytes(fileSize)
+
+	for i := 0; i < b.N; i++ {
+		dst, err := ioutil.TempFile("", "sftptest")
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer os.Remove(dst.Name())
+
+		src, err := sftp.Open(srcFilename)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer src.Close()
+		n, err := io.Copy(dst, src)
+		if err != nil {
+			b.Fatalf("copy error: %v", err)
+		}
+		if n < fileSize {
+			b.Fatal("unable to copy all bytes")
+		}
+		dst.Close()
+		fi, err := os.Stat(dst.Name())
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if fi.Size() != fileSize {
+			b.Fatalf("wrong file size: want %d, got %d", fileSize, fi.Size())
+		}
+		os.Remove(dst.Name())
+	}
+}
+
+func BenchmarkCopyDown10MiBDelay10Msec(b *testing.B) {
+	benchmarkCopyDown(b, 10*1024*1024, 10*time.Millisecond)
+}
+
+func BenchmarkCopyDown10MiBDelay50Msec(b *testing.B) {
+	benchmarkCopyDown(b, 10*1024*1024, 50*time.Millisecond)
+}
+
+func BenchmarkCopyDown10MiBDelay150Msec(b *testing.B) {
+	benchmarkCopyDown(b, 10*1024*1024, 150*time.Millisecond)
+}
+
+func benchmarkCopyUp(b *testing.B, fileSize int64, delay time.Duration) {
+	// Create a temp file and fill it with zero's.
+	src, err := ioutil.TempFile("", "sftptest")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer src.Close()
+	srcFilename := src.Name()
+	defer os.Remove(srcFilename)
+	zero, err := os.Open("/dev/zero")
+	if err != nil {
+		b.Fatal(err)
+	}
+	n, err := io.Copy(src, io.LimitReader(zero, fileSize))
+	if err != nil {
+		b.Fatal(err)
+	}
+	if n < fileSize {
+		b.Fatal("short copy")
+	}
+	zero.Close()
+	src.Close()
+
+	sftp, cmd := testClient(b, false, delay)
+	defer cmd.Wait()
+	defer sftp.Close()
+
+	b.ResetTimer()
+	b.SetBytes(fileSize)
+
+	for i := 0; i < b.N; i++ {
+		tmp, err := ioutil.TempFile("", "sftptest")
+		if err != nil {
+			b.Fatal(err)
+		}
+		tmp.Close()
+		defer os.Remove(tmp.Name())
+
+		dst, err := sftp.Create(tmp.Name())
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer dst.Close()
+		src, err := os.Open(srcFilename)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer src.Close()
+		n, err := io.Copy(dst, src)
+		if err != nil {
+			b.Fatalf("copy error: %v", err)
+		}
+		if n < fileSize {
+			b.Fatal("unable to copy all bytes")
+		}
+
+		fi, err := os.Stat(tmp.Name())
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if fi.Size() != fileSize {
+			b.Fatalf("wrong file size: want %d, got %d", fileSize, fi.Size())
+		}
+		os.Remove(tmp.Name())
+	}
+}
+
+func BenchmarkCopyUp10MiBDelay10Msec(b *testing.B) {
+	benchmarkCopyUp(b, 10*1024*1024, 10*time.Millisecond)
+}
+
+func BenchmarkCopyUp10MiBDelay50Msec(b *testing.B) {
+	benchmarkCopyUp(b, 10*1024*1024, 50*time.Millisecond)
+}
+
+func BenchmarkCopyUp10MiBDelay150Msec(b *testing.B) {
+	benchmarkCopyUp(b, 10*1024*1024, 150*time.Millisecond)
 }


### PR DESCRIPTION
I was running into the same problem as described in #15 and it appears fd0's work in #24 has been dropped. I've created a new patchset that merges cleanly with current head and provides an ~20x throughput increase for large file transfers. I've included the benchmark output in each of the commit messages to give an idea what impact each individual change has.