### PR TITLE
make the StatusError language tag optional

### DIFF
--- a/client.go
+++ b/client.go
@@ -1110,7 +1110,7 @@ func unmarshalStatus(id uint32, data []byte) error {
 	}
 	code, data := unmarshalUint32(data)
 	msg, data := unmarshalString(data)
-	lang, _ := unmarshalString(data)
+	lang, _, _ := unmarshalStringSafe(data)
 	return &StatusError{
 		Code: code,
 		msg:  msg,

--- a/client_test.go
+++ b/client_test.go
@@ -73,3 +73,14 @@ func TestFlags(t *testing.T) {
 		}
 	}
 }
+
+func TestMissingLangTag(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fail()
+		}
+	}()
+	buf := marshalUint32([]byte{}, 0)
+	buf = marshalStatus(buf, StatusError{})
+	_ = unmarshalStatus(0, buf[:len(buf)-4])
+}


### PR DESCRIPTION
Be more lenient with servers that don't implement the language tag part of status messages. Addresses issue #52