### PR TITLE
Handle osx returning EPERM not ENOTDIR

### DIFF
--- a/client_integration_darwin_test.go
+++ b/client_integration_darwin_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+const sftpServer = "/usr/libexec/sftp-server"
+
 func TestClientStatVFS(t *testing.T) {
 	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()

--- a/client_integration_linux_test.go
+++ b/client_integration_linux_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+const sftpServer = "/usr/lib/openssh/sftp-server"
+
 func TestClientStatVFS(t *testing.T) {
 	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -34,7 +34,7 @@ const (
 
 var testServerImpl = flag.Bool("testserver", false, "perform integration tests against sftp package server instance")
 var testIntegration = flag.Bool("integration", false, "perform integration tests against sftp server process")
-var testSftp = flag.String("sftp", "/usr/lib/openssh/sftp-server", "location of the sftp server binary")
+var testSftp = flag.String("sftp", sftpServer, "location of the sftp server binary")
 
 type delayedWrite struct {
 	t time.Time

--- a/other_test.go
+++ b/other_test.go
@@ -1,0 +1,5 @@
+// +build !linux,!darwin
+
+package sftp
+
+const sftpServer = "/usr/bin/false" // unsupported


### PR DESCRIPTION
Fixes #57

Also fix the integration tests to run on darwin by default.