### PR TITLE
Fix travis-ci status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ sftp
 
 The `sftp` package provides support for file system operations on remote ssh servers using the SFTP subsystem.
 
-[!"unix status")](https://travis-ci.org/pkg/sftp.svg)
+!["unix status"](https://travis-ci.org/pkg/sftp.svg)
 
 usage and examples
 ------------------
 
 See [godoc.org/github.com/pkg/sftp](http://godoc.org/github.com/pkg/sftp) for examples and usage.
 
-The basic operation of the package mirrors the facilities of the [os](http://golang.org/pkg/os) package. 
+The basic operation of the package mirrors the facilities of the [os](http://golang.org/pkg/os) package.
 
 The Walker interface for directory traversal is heavily inspired by Keith Rarick's [fs](http://godoc.org/github.com/kr/fs) package.
 


### PR DESCRIPTION
The travis-ci status image in the README was broken due to a super simple markdown error, so I fixed it.

Also VS code automatically stripped whitespace from the end of line 13.