### PR TITLE
server: use functional options for NewServer

### DIFF
--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -94,7 +94,17 @@ func testClientGoSvr(t testing.TB, readonly bool, delay time.Duration) (*Client,
 		t.Fatal(err)
 	}
 
-	server, err := NewServer(txPipeRd, rxPipeWr, os.Stderr, 0, readonly, ".")
+	options := []ServerOption{WithDebug(os.Stderr)}
+	if readonly {
+		options = append(options, ReadOnly())
+	}
+
+	server, err := NewServer(
+		txPipeRd,
+		rxPipeWr,
+		".",
+		options...,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/sftp-server/main.go
+++ b/examples/sftp-server/main.go
@@ -19,23 +19,19 @@ import (
 func main() {
 
 	var (
-		readOnly      bool
-		debugLevelStr string
-		debugLevel    int
-		debugStderr   bool
-		rootDir       string
+		readOnly    bool
+		debugStderr bool
+		rootDir     string
 	)
 
 	flag.BoolVar(&readOnly, "R", false, "read-only server")
 	flag.BoolVar(&debugStderr, "e", false, "debug to stderr")
-	flag.StringVar(&debugLevelStr, "l", "none", "debug level")
 	flag.StringVar(&rootDir, "root", "", "root directory")
 	flag.Parse()
 
 	debugStream := ioutil.Discard
 	if debugStderr {
 		debugStream = os.Stderr
-		debugLevel = 1
 	}
 
 	// An SSH server is represented by a ServerConfig, which holds
@@ -124,7 +120,13 @@ func main() {
 			}
 		}(requests)
 
-		server, err := sftp.NewServer(channel, channel, debugStream, debugLevel, readOnly, rootDir)
+		server, err := sftp.NewServer(
+			channel,
+			channel,
+			rootDir,
+			sftp.WithDebug(debugStream),
+			sftp.ReadOnly(),
+		)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -26,7 +27,6 @@ type Server struct {
 	out           io.WriteCloser
 	outMutex      *sync.Mutex
 	debugStream   io.Writer
-	debugLevel    int
 	readOnly      bool
 	rootDir       string
 	lastID        uint32
@@ -70,10 +70,12 @@ type serverRespondablePacket interface {
 	respond(svr *Server) error
 }
 
-// NewServer creates a new server instance around the provided streams.
-// Various debug output will be written to debugStream, with verbosity set by debugLevel
-// A subsequent call to Serve() is required.
-func NewServer(in io.Reader, out io.WriteCloser, debugStream io.Writer, debugLevel int, readOnly bool, rootDir string) (*Server, error) {
+// NewServer creates a new Server instance around the provided streams, serving
+// content from the directory specified by rootDir.  Optionally, ServerOption
+// functions may be specified to further configure the Server.
+//
+// A subsequent call to Serve() is required to begin serving files over SFTP.
+func NewServer(in io.Reader, out io.WriteCloser, rootDir string, options ...ServerOption) (*Server, error) {
 	if rootDir == "" {
 		wd, err := os.Getwd()
 		if err != nil {
@@ -82,20 +84,46 @@ func NewServer(in io.Reader, out io.WriteCloser, debugStream io.Writer, debugLev
 
 		rootDir = wd
 	}
-	return &Server{
+
+	s := &Server{
 		in:            in,
 		out:           out,
 		outMutex:      &sync.Mutex{},
-		debugStream:   debugStream,
-		debugLevel:    debugLevel,
-		readOnly:      readOnly,
+		debugStream:   ioutil.Discard,
 		rootDir:       rootDir,
 		pktChan:       make(chan rxPacket, sftpServerWorkerCount),
 		openFiles:     map[string]*os.File{},
 		openFilesLock: &sync.RWMutex{},
 		maxTxPacket:   1 << 15,
 		workerCount:   sftpServerWorkerCount,
-	}, nil
+	}
+
+	for _, o := range options {
+		if err := o(s); err != nil {
+			return nil, err
+		}
+	}
+
+	return s, nil
+}
+
+// A ServerOption is a function which applies configuration to a Server.
+type ServerOption func(*Server) error
+
+// WithDebug enables Server debugging output to the supplied io.Writer.
+func WithDebug(w io.Writer) func(*Server) error {
+	return func(s *Server) error {
+		s.debugStream = w
+		return nil
+	}
+}
+
+// ReadOnly configures a Server to serve files in read-only mode.
+func ReadOnly() func(*Server) error {
+	return func(s *Server) error {
+		s.readOnly = true
+		return nil
+	}
 }
 
 type rxPacket struct {

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -294,7 +294,12 @@ func (chsvr *sshSessionChannelServer) handleSubsystem(req *ssh.Request) error {
 		return cmd.Wait()
 	}
 
-	sftpServer, err := NewServer(chsvr.ch, chsvr.ch, sftpServerDebugStream, 0, false, ".")
+	sftpServer, err := NewServer(
+		chsvr.ch,
+		chsvr.ch,
+		".",
+		WithDebug(sftpServerDebugStream),
+	)
 	if err != nil {
 		return err
 	}

--- a/server_standalone/main.go
+++ b/server_standalone/main.go
@@ -14,24 +14,26 @@ import (
 
 func main() {
 	var (
-		readOnly      bool
-		debugLevelStr string
-		debugLevel    int
-		debugStderr   bool
+		readOnly    bool
+		debugStderr bool
 	)
 
 	flag.BoolVar(&readOnly, "R", false, "read-only server")
 	flag.BoolVar(&debugStderr, "e", false, "debug to stderr")
-	flag.StringVar(&debugLevelStr, "l", "none", "debug level")
 	flag.Parse()
 
 	debugStream := ioutil.Discard
 	if debugStderr {
 		debugStream = os.Stderr
-		debugLevel = 1
 	}
 
-	svr, _ := sftp.NewServer(os.Stdin, os.Stdout, debugStream, debugLevel, readOnly, "")
+	svr, _ := sftp.NewServer(
+		os.Stdin,
+		os.Stdout,
+		"",
+		sftp.WithDebug(debugStream),
+		sftp.ReadOnly(),
+	)
 	if err := svr.Serve(); err != nil {
 		fmt.Fprintf(debugStream, "sftp server completed with error: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
Removed `debugLevel` because it wasn't used anywhere as well.

r: @davecheney 