### PR TITLE
server: remote rootDir parameter, as it does nothing

### DIFF
--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -102,7 +102,6 @@ func testClientGoSvr(t testing.TB, readonly bool, delay time.Duration) (*Client,
 	server, err := NewServer(
 		txPipeRd,
 		rxPipeWr,
-		".",
 		options...,
 	)
 	if err != nil {

--- a/examples/sftp-server/main.go
+++ b/examples/sftp-server/main.go
@@ -21,12 +21,10 @@ func main() {
 	var (
 		readOnly    bool
 		debugStderr bool
-		rootDir     string
 	)
 
 	flag.BoolVar(&readOnly, "R", false, "read-only server")
 	flag.BoolVar(&debugStderr, "e", false, "debug to stderr")
-	flag.StringVar(&rootDir, "root", "", "root directory")
 	flag.Parse()
 
 	debugStream := ioutil.Discard
@@ -123,7 +121,6 @@ func main() {
 		server, err := sftp.NewServer(
 			channel,
 			channel,
-			rootDir,
 			sftp.WithDebug(debugStream),
 			sftp.ReadOnly(),
 		)

--- a/server.go
+++ b/server.go
@@ -29,7 +29,6 @@ type Server struct {
 	outMutex      *sync.Mutex
 	debugStream   io.Writer
 	readOnly      bool
-	rootDir       string
 	lastID        uint32
 	pktChan       chan rxPacket
 	openFiles     map[string]*os.File
@@ -74,26 +73,16 @@ type serverRespondablePacket interface {
 }
 
 // NewServer creates a new Server instance around the provided streams, serving
-// content from the directory specified by rootDir.  Optionally, ServerOption
+// content from the root of the filesystem.  Optionally, ServerOption
 // functions may be specified to further configure the Server.
 //
 // A subsequent call to Serve() is required to begin serving files over SFTP.
-func NewServer(in io.Reader, out io.WriteCloser, rootDir string, options ...ServerOption) (*Server, error) {
-	if rootDir == "" {
-		wd, err := os.Getwd()
-		if err != nil {
-			return nil, err
-		}
-
-		rootDir = wd
-	}
-
+func NewServer(in io.Reader, out io.WriteCloser, options ...ServerOption) (*Server, error) {
 	s := &Server{
 		in:            in,
 		out:           out,
 		outMutex:      &sync.Mutex{},
 		debugStream:   ioutil.Discard,
-		rootDir:       rootDir,
 		pktChan:       make(chan rxPacket, sftpServerWorkerCount),
 		openFiles:     map[string]*os.File{},
 		openFilesLock: &sync.RWMutex{},

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -297,7 +297,6 @@ func (chsvr *sshSessionChannelServer) handleSubsystem(req *ssh.Request) error {
 	sftpServer, err := NewServer(
 		chsvr.ch,
 		chsvr.ch,
-		".",
 		WithDebug(sftpServerDebugStream),
 	)
 	if err != nil {

--- a/server_standalone/main.go
+++ b/server_standalone/main.go
@@ -30,7 +30,6 @@ func main() {
 	svr, _ := sftp.NewServer(
 		os.Stdin,
 		os.Stdout,
-		"",
 		sftp.WithDebug(debugStream),
 		sftp.ReadOnly(),
 	)


### PR DESCRIPTION
Remove it until it is actually implemented.

r: @davecheney 