### PR TITLE
add serverside StatVFS function, implemented for darwin and linux

### DIFF
--- a/server.go
+++ b/server.go
@@ -171,6 +171,8 @@ func (svr *Server) sftpServerWorker() error {
 		case ssh_FXP_SYMLINK:
 			pkt = &sshFxpSymlinkPacket{}
 			readonly = false
+		case ssh_FXP_EXTENDED:
+			pkt = &sshFxpExtendedPacket{}
 		default:
 			return errors.Errorf("unhandled packet type: %s", p.pktType)
 		}
@@ -182,6 +184,8 @@ func (svr *Server) sftpServerWorker() error {
 		switch pkt := pkt.(type) {
 		case *sshFxpOpenPacket:
 			readonly = pkt.readonly()
+		case *sshFxpExtendedPacket:
+			readonly = pkt.SpecificPacket.readonly()
 		}
 
 		// If server is operating read-only and a write operation is requested,

--- a/server_standalone/main.go
+++ b/server_standalone/main.go
@@ -17,10 +17,12 @@ func main() {
 	var (
 		readOnly    bool
 		debugStderr bool
+		debugLevel  string
 	)
 
 	flag.BoolVar(&readOnly, "R", false, "read-only server")
 	flag.BoolVar(&debugStderr, "e", false, "debug to stderr")
+	flag.StringVar(&debugLevel, "l", "none", "debug level (ignored)")
 	flag.Parse()
 
 	debugStream := ioutil.Discard

--- a/server_statvfs_darwin.go
+++ b/server_statvfs_darwin.go
@@ -1,0 +1,21 @@
+package sftp
+
+import (
+	"syscall"
+)
+
+func statvfsFromStatfst(stat *syscall.Statfs_t) (*StatVFS, error) {
+	return &StatVFS{
+		Bsize:   uint64(stat.Bsize),
+		Frsize:  uint64(stat.Bsize), // fragment size is a linux thing; use block size here
+		Blocks:  stat.Blocks,
+		Bfree:   stat.Bfree,
+		Bavail:  stat.Bavail,
+		Files:   stat.Files,
+		Ffree:   stat.Ffree,
+		Favail:  stat.Ffree,                                                      // not sure how to calculate Favail
+		Fsid:    uint64(uint64(stat.Fsid.Val[1])<<32 | uint64(stat.Fsid.Val[0])), // endianness?
+		Flag:    uint64(stat.Flags),                                              // assuming POSIX?
+		Namemax: 1024,                                                            // man 2 statfs shows: #define MAXPATHLEN      1024
+	}, nil
+}

--- a/server_statvfs_impl.go
+++ b/server_statvfs_impl.go
@@ -1,0 +1,25 @@
+// +build darwin linux
+
+// fill in statvfs structure with OS specific values
+// Statfs_t is different per-kernel, and only exists on some unixes (not Solaris for instance)
+
+package sftp
+
+import (
+	"syscall"
+)
+
+func (p sshFxpExtendedPacketStatVFS) respond(svr *Server) error {
+	stat := &syscall.Statfs_t{}
+	if err := syscall.Statfs(p.Path, stat); err != nil {
+		return svr.sendPacket(statusFromError(p.ID, err))
+	}
+
+	retPkt, err := statvfsFromStatfst(stat)
+	if err != nil {
+		return svr.sendPacket(statusFromError(p.ID, err))
+	}
+	retPkt.ID = p.ID
+
+	return svr.sendPacket(retPkt)
+}

--- a/server_statvfs_linux.go
+++ b/server_statvfs_linux.go
@@ -1,0 +1,21 @@
+package sftp
+
+import (
+	"syscall"
+)
+
+func statvfsFromStatfst(stat *syscall.Statfs_t) (*StatVFS, error) {
+	return &StatVFS{
+		Bsize:   uint64(stat.Bsize),
+		Frsize:  uint64(stat.Frsize),
+		Blocks:  stat.Blocks,
+		Bfree:   stat.Bfree,
+		Bavail:  stat.Bavail,
+		Files:   stat.Files,
+		Ffree:   stat.Ffree,
+		Favail:  stat.Ffree,                                                            // not sure how to calculate Favail
+		Fsid:    uint64(uint64(stat.Fsid.X__val[1])<<32 | uint64(stat.Fsid.X__val[0])), // endianness?
+		Flag:    uint64(stat.Flags),                                                    // assuming POSIX?
+		Namemax: uint64(stat.Namelen),
+	}, nil
+}

--- a/server_statvfs_stubs.go
+++ b/server_statvfs_stubs.go
@@ -1,0 +1,11 @@
+// +build !darwin,!linux
+
+package sftp
+
+import (
+	"syscall"
+)
+
+func (p sshFxpExtendedPacketStatVFS) respond(svr *Server) error {
+	return syscall.ENOTSUP
+}

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,60 @@
+package sftp
+
+import (
+	"errors"
+	"testing"
+)
+
+var errClientRecvFinished = errors.New("client recv finished")
+
+func clientServerPair(t *testing.T) (*Client, *Server) {
+	c, s := netPipe(t)
+	server, err := NewServer(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go server.Serve()
+	client, err := NewClientPipe(c, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client, server
+}
+
+type sshFxpTestBadExtendedPacket struct {
+	ID        uint32
+	Extension string
+	Data      string
+}
+
+func (p sshFxpTestBadExtendedPacket) id() uint32 { return p.ID }
+
+func (p sshFxpTestBadExtendedPacket) MarshalBinary() ([]byte, error) {
+	l := 1 + 4 + 4 + // type(byte) + uint32 + uint32
+		len(p.Extension) +
+		len(p.Data)
+
+	b := make([]byte, 0, l)
+	b = append(b, ssh_FXP_EXTENDED)
+	b = marshalUint32(b, p.ID)
+	b = marshalString(b, p.Extension)
+	b = marshalString(b, p.Data)
+	return b, nil
+}
+
+// test that errors are sent back when we request an invalid extended packet operation
+func TestInvalidExtendedPacket(t *testing.T) {
+	client, _ := clientServerPair(t)
+	defer client.Close()
+	badPacket := sshFxpTestBadExtendedPacket{client.nextID(), "thisDoesn'tExist", "foobar"}
+	_, _, err := client.sendRequest(badPacket)
+	if err != nil {
+		t.Log(err)
+	} else {
+		t.Fatal("expected error from bad packet")
+	}
+
+	// try to stat a file; the client should have shut down.
+	filePath := "/etc/passwd"
+	_, err = client.Stat(filePath)
+}


### PR DESCRIPTION
Also have the client return errors if methods are invoked after the server recv loop dies; currently client functions hang if called after the server dies. This can cause problems in multithreaded clients.