### PR TITLE
Responder interface prototype

### DIFF
--- a/attrs.go
+++ b/attrs.go
@@ -1,6 +1,6 @@
 package sftp
 
-// ssh_FXP_ATTRS support
+// SSH_FXP_ATTRS support
 // see http://tools.ietf.org/html/draft-ietf-secsh-filexfer-02#section-5
 
 import (

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -405,8 +405,8 @@ func TestClientCreateFailed(t *testing.T) {
 	defer os.Remove(f.Name())
 
 	f2, err := sftp.Create(f.Name())
-	if err1, ok := err.(*StatusError); !ok || err1.Code != ssh_FX_PERMISSION_DENIED {
-		t.Fatalf("Create: want: %v, got %#v", ssh_FX_PERMISSION_DENIED, err)
+	if err1, ok := err.(*StatusError); !ok || err1.Code != SSH_FX_PERMISSION_DENIED {
+		t.Fatalf("Create: want: %v, got %#v", SSH_FX_PERMISSION_DENIED, err)
 	}
 	if err == nil {
 		f2.Close()

--- a/client_test.go
+++ b/client_test.go
@@ -17,10 +17,10 @@ var _ io.ReadWriteCloser = new(File)
 
 func TestNormaliseError(t *testing.T) {
 	var (
-		ok         = &StatusError{Code: ssh_FX_OK}
-		eof        = &StatusError{Code: ssh_FX_EOF}
-		fail       = &StatusError{Code: ssh_FX_FAILURE}
-		noSuchFile = &StatusError{Code: ssh_FX_NO_SUCH_FILE}
+		ok         = &StatusError{Code: SSH_FX_OK}
+		eof        = &StatusError{Code: SSH_FX_EOF}
+		fail       = &StatusError{Code: SSH_FX_FAILURE}
+		noSuchFile = &StatusError{Code: SSH_FX_NO_SUCH_FILE}
 		foo        = errors.New("foo")
 	)
 
@@ -38,21 +38,21 @@ func TestNormaliseError(t *testing.T) {
 			want: foo,
 		},
 		{
-			desc: "*StatusError with ssh_FX_EOF",
+			desc: "*StatusError with SSH_FX_EOF",
 			err:  eof,
 			want: io.EOF,
 		},
 		{
-			desc: "*StatusError with ssh_FX_NO_SUCH_FILE",
+			desc: "*StatusError with SSH_FX_NO_SUCH_FILE",
 			err:  noSuchFile,
 			want: os.ErrNotExist,
 		},
 		{
-			desc: "*StatusError with ssh_FX_OK",
+			desc: "*StatusError with SSH_FX_OK",
 			err:  ok,
 		},
 		{
-			desc: "*StatusError with ssh_FX_FAILURE",
+			desc: "*StatusError with SSH_FX_FAILURE",
 			err:  fail,
 			want: fail,
 		},
@@ -71,11 +71,11 @@ var flagsTests = []struct {
 	flags int
 	want  uint32
 }{
-	{os.O_RDONLY, ssh_FXF_READ},
-	{os.O_WRONLY, ssh_FXF_WRITE},
-	{os.O_RDWR, ssh_FXF_READ | ssh_FXF_WRITE},
-	{os.O_RDWR | os.O_CREATE | os.O_TRUNC, ssh_FXF_READ | ssh_FXF_WRITE | ssh_FXF_CREAT | ssh_FXF_TRUNC},
-	{os.O_WRONLY | os.O_APPEND, ssh_FXF_WRITE | ssh_FXF_APPEND},
+	{os.O_RDONLY, SSH_FXF_READ},
+	{os.O_WRONLY, SSH_FXF_WRITE},
+	{os.O_RDWR, SSH_FXF_READ | SSH_FXF_WRITE},
+	{os.O_RDWR | os.O_CREATE | os.O_TRUNC, SSH_FXF_READ | SSH_FXF_WRITE | SSH_FXF_CREAT | SSH_FXF_TRUNC},
+	{os.O_WRONLY | os.O_APPEND, SSH_FXF_WRITE | SSH_FXF_APPEND},
 }
 
 func TestFlags(t *testing.T) {

--- a/filesystem_responders.go
+++ b/filesystem_responders.go
@@ -1,0 +1,50 @@
+package sftp
+
+import "fmt"
+
+func FilesystemResponder(pktType Fxpkt) (ServerRespondablePacket, error) {
+	var pkt ServerRespondablePacket
+	switch pktType {
+	case SSH_FXP_INIT:
+		pkt = &SshFxInitPacket{}
+	case SSH_FXP_LSTAT:
+		pkt = &SshFxpLstatPacket{}
+	case SSH_FXP_OPEN:
+		pkt = &SshFxpOpenPacket{}
+	case SSH_FXP_CLOSE:
+		pkt = &SshFxpClosePacket{}
+	case SSH_FXP_READ:
+		pkt = &SshFxpReadPacket{}
+	case SSH_FXP_WRITE:
+		pkt = &SshFxpWritePacket{}
+	case SSH_FXP_FSTAT:
+		pkt = &SshFxpFstatPacket{}
+	case SSH_FXP_SETSTAT:
+		pkt = &SshFxpSetstatPacket{}
+	case SSH_FXP_FSETSTAT:
+		pkt = &SshFxpFsetstatPacket{}
+	case SSH_FXP_OPENDIR:
+		pkt = &SshFxpOpendirPacket{}
+	case SSH_FXP_READDIR:
+		pkt = &SshFxpReaddirPacket{}
+	case SSH_FXP_REMOVE:
+		pkt = &SshFxpRemovePacket{}
+	case SSH_FXP_MKDIR:
+		pkt = &SshFxpMkdirPacket{}
+	case SSH_FXP_RMDIR:
+		pkt = &SshFxpRmdirPacket{}
+	case SSH_FXP_REALPATH:
+		pkt = &SshFxpRealpathPacket{}
+	case SSH_FXP_STAT:
+		pkt = &SshFxpStatPacket{}
+	case SSH_FXP_RENAME:
+		pkt = &SshFxpRenamePacket{}
+	case SSH_FXP_READLINK:
+		pkt = &SshFxpReadlinkPacket{}
+	case SSH_FXP_SYMLINK:
+		pkt = &SshFxpSymlinkPacket{}
+	default:
+		return nil, fmt.Errorf("unhandled packet type: %s", pktType)
+	}
+	return pkt, nil
+}

--- a/packet_test.go
+++ b/packet_test.go
@@ -142,20 +142,20 @@ var sendPacketTests = []struct {
 	p    encoding.BinaryMarshaler
 	want []byte
 }{
-	{sshFxInitPacket{
+	{SshFxInitPacket{
 		Version: 3,
 		Extensions: []extensionPair{
 			{"posix-rename@openssh.com", "1"},
 		},
 	}, []byte{0x0, 0x0, 0x0, 0x26, 0x1, 0x0, 0x0, 0x0, 0x3, 0x0, 0x0, 0x0, 0x18, 0x70, 0x6f, 0x73, 0x69, 0x78, 0x2d, 0x72, 0x65, 0x6e, 0x61, 0x6d, 0x65, 0x40, 0x6f, 0x70, 0x65, 0x6e, 0x73, 0x73, 0x68, 0x2e, 0x63, 0x6f, 0x6d, 0x0, 0x0, 0x0, 0x1, 0x31}},
 
-	{sshFxpOpenPacket{
+	{SshFxpOpenPacket{
 		ID:     1,
 		Path:   "/foo",
 		Pflags: flags(os.O_RDONLY),
 	}, []byte{0x0, 0x0, 0x0, 0x15, 0x3, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x4, 0x2f, 0x66, 0x6f, 0x6f, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0}},
 
-	{sshFxpWritePacket{
+	{SshFxpWritePacket{
 		ID:     124,
 		Handle: "foo",
 		Offset: 13,
@@ -163,7 +163,7 @@ var sendPacketTests = []struct {
 		Data:   []byte("bar"),
 	}, []byte{0x0, 0x0, 0x0, 0x1b, 0x6, 0x0, 0x0, 0x0, 0x7c, 0x0, 0x0, 0x0, 0x3, 0x66, 0x6f, 0x6f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xd, 0x0, 0x0, 0x0, 0x3, 0x62, 0x61, 0x72}},
 
-	{sshFxpSetstatPacket{
+	{SshFxpSetstatPacket{
 		ID:    31,
 		Path:  "/bar",
 		Flags: flags(os.O_WRONLY),
@@ -195,12 +195,12 @@ var recvPacketTests = []struct {
 	want uint8
 	rest []byte
 }{
-	{sp(sshFxInitPacket{
+	{sp(SshFxInitPacket{
 		Version: 3,
 		Extensions: []extensionPair{
 			{"posix-rename@openssh.com", "1"},
 		},
-	}), ssh_FXP_INIT, []byte{0x0, 0x0, 0x0, 0x3, 0x0, 0x0, 0x0, 0x18, 0x70, 0x6f, 0x73, 0x69, 0x78, 0x2d, 0x72, 0x65, 0x6e, 0x61, 0x6d, 0x65, 0x40, 0x6f, 0x70, 0x65, 0x6e, 0x73, 0x73, 0x68, 0x2e, 0x63, 0x6f, 0x6d, 0x0, 0x0, 0x0, 0x1, 0x31}},
+	}), SSH_FXP_INIT, []byte{0x0, 0x0, 0x0, 0x3, 0x0, 0x0, 0x0, 0x18, 0x70, 0x6f, 0x73, 0x69, 0x78, 0x2d, 0x72, 0x65, 0x6e, 0x61, 0x6d, 0x65, 0x40, 0x6f, 0x70, 0x65, 0x6e, 0x73, 0x73, 0x68, 0x2e, 0x63, 0x6f, 0x6d, 0x0, 0x0, 0x0, 0x1, 0x31}},
 }
 
 func TestRecvPacket(t *testing.T) {
@@ -219,21 +219,21 @@ func TestSSHFxpOpenPacketreadonly(t *testing.T) {
 		ok     bool
 	}{
 		{
-			pflags: ssh_FXF_READ,
+			pflags: SSH_FXF_READ,
 			ok:     true,
 		},
 		{
-			pflags: ssh_FXF_WRITE,
+			pflags: SSH_FXF_WRITE,
 			ok:     false,
 		},
 		{
-			pflags: ssh_FXF_READ | ssh_FXF_WRITE,
+			pflags: SSH_FXF_READ | SSH_FXF_WRITE,
 			ok:     false,
 		},
 	}
 
 	for _, tt := range tests {
-		p := &sshFxpOpenPacket{
+		p := &SshFxpOpenPacket{
 			Pflags: tt.pflags,
 		}
 
@@ -253,32 +253,32 @@ func TestSSHFxpOpenPackethasPflags(t *testing.T) {
 	}{
 		{
 			desc:      "have read, test against write",
-			haveFlags: ssh_FXF_READ,
-			testFlags: []uint32{ssh_FXF_WRITE},
+			haveFlags: SSH_FXF_READ,
+			testFlags: []uint32{SSH_FXF_WRITE},
 			ok:        false,
 		},
 		{
 			desc:      "have write, test against read",
-			haveFlags: ssh_FXF_WRITE,
-			testFlags: []uint32{ssh_FXF_READ},
+			haveFlags: SSH_FXF_WRITE,
+			testFlags: []uint32{SSH_FXF_READ},
 			ok:        false,
 		},
 		{
 			desc:      "have read+write, test against read",
-			haveFlags: ssh_FXF_READ | ssh_FXF_WRITE,
-			testFlags: []uint32{ssh_FXF_READ},
+			haveFlags: SSH_FXF_READ | SSH_FXF_WRITE,
+			testFlags: []uint32{SSH_FXF_READ},
 			ok:        true,
 		},
 		{
 			desc:      "have read+write, test against write",
-			haveFlags: ssh_FXF_READ | ssh_FXF_WRITE,
-			testFlags: []uint32{ssh_FXF_WRITE},
+			haveFlags: SSH_FXF_READ | SSH_FXF_WRITE,
+			testFlags: []uint32{SSH_FXF_WRITE},
 			ok:        true,
 		},
 		{
 			desc:      "have read+write, test against read+write",
-			haveFlags: ssh_FXF_READ | ssh_FXF_WRITE,
-			testFlags: []uint32{ssh_FXF_READ, ssh_FXF_WRITE},
+			haveFlags: SSH_FXF_READ | SSH_FXF_WRITE,
+			testFlags: []uint32{SSH_FXF_READ, SSH_FXF_WRITE},
 			ok:        true,
 		},
 	}
@@ -286,7 +286,7 @@ func TestSSHFxpOpenPackethasPflags(t *testing.T) {
 	for _, tt := range tests {
 		t.Log(tt.desc)
 
-		p := &sshFxpOpenPacket{
+		p := &SshFxpOpenPacket{
 			Pflags: tt.haveFlags,
 		}
 
@@ -299,7 +299,7 @@ func TestSSHFxpOpenPackethasPflags(t *testing.T) {
 
 func BenchmarkMarshalInit(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		sp(sshFxInitPacket{
+		sp(SshFxInitPacket{
 			Version: 3,
 			Extensions: []extensionPair{
 				{"posix-rename@openssh.com", "1"},
@@ -310,7 +310,7 @@ func BenchmarkMarshalInit(b *testing.B) {
 
 func BenchmarkMarshalOpen(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		sp(sshFxpOpenPacket{
+		sp(SshFxpOpenPacket{
 			ID:     1,
 			Path:   "/home/test/some/random/path",
 			Pflags: flags(os.O_RDONLY),
@@ -321,7 +321,7 @@ func BenchmarkMarshalOpen(b *testing.B) {
 func BenchmarkMarshalWriteWorstCase(b *testing.B) {
 	data := make([]byte, 32*1024)
 	for i := 0; i < b.N; i++ {
-		sp(sshFxpWritePacket{
+		sp(SshFxpWritePacket{
 			ID:     1,
 			Handle: "someopaquehandle",
 			Offset: 0,
@@ -334,7 +334,7 @@ func BenchmarkMarshalWriteWorstCase(b *testing.B) {
 func BenchmarkMarshalWrite1k(b *testing.B) {
 	data := make([]byte, 1024)
 	for i := 0; i < b.N; i++ {
-		sp(sshFxpWritePacket{
+		sp(SshFxpWritePacket{
 			ID:     1,
 			Handle: "someopaquehandle",
 			Offset: 0,

--- a/sftp.go
+++ b/sftp.go
@@ -7,139 +7,139 @@ import (
 )
 
 const (
-	ssh_FXP_INIT           = 1
-	ssh_FXP_VERSION        = 2
-	ssh_FXP_OPEN           = 3
-	ssh_FXP_CLOSE          = 4
-	ssh_FXP_READ           = 5
-	ssh_FXP_WRITE          = 6
-	ssh_FXP_LSTAT          = 7
-	ssh_FXP_FSTAT          = 8
-	ssh_FXP_SETSTAT        = 9
-	ssh_FXP_FSETSTAT       = 10
-	ssh_FXP_OPENDIR        = 11
-	ssh_FXP_READDIR        = 12
-	ssh_FXP_REMOVE         = 13
-	ssh_FXP_MKDIR          = 14
-	ssh_FXP_RMDIR          = 15
-	ssh_FXP_REALPATH       = 16
-	ssh_FXP_STAT           = 17
-	ssh_FXP_RENAME         = 18
-	ssh_FXP_READLINK       = 19
-	ssh_FXP_SYMLINK        = 20
-	ssh_FXP_STATUS         = 101
-	ssh_FXP_HANDLE         = 102
-	ssh_FXP_DATA           = 103
-	ssh_FXP_NAME           = 104
-	ssh_FXP_ATTRS          = 105
-	ssh_FXP_EXTENDED       = 200
-	ssh_FXP_EXTENDED_REPLY = 201
+	SSH_FXP_INIT           = 1
+	SSH_FXP_VERSION        = 2
+	SSH_FXP_OPEN           = 3
+	SSH_FXP_CLOSE          = 4
+	SSH_FXP_READ           = 5
+	SSH_FXP_WRITE          = 6
+	SSH_FXP_LSTAT          = 7
+	SSH_FXP_FSTAT          = 8
+	SSH_FXP_SETSTAT        = 9
+	SSH_FXP_FSETSTAT       = 10
+	SSH_FXP_OPENDIR        = 11
+	SSH_FXP_READDIR        = 12
+	SSH_FXP_REMOVE         = 13
+	SSH_FXP_MKDIR          = 14
+	SSH_FXP_RMDIR          = 15
+	SSH_FXP_REALPATH       = 16
+	SSH_FXP_STAT           = 17
+	SSH_FXP_RENAME         = 18
+	SSH_FXP_READLINK       = 19
+	SSH_FXP_SYMLINK        = 20
+	SSH_FXP_STATUS         = 101
+	SSH_FXP_HANDLE         = 102
+	SSH_FXP_DATA           = 103
+	SSH_FXP_NAME           = 104
+	SSH_FXP_ATTRS          = 105
+	SSH_FXP_EXTENDED       = 200
+	SSH_FXP_EXTENDED_REPLY = 201
 )
 
 const (
-	ssh_FX_OK                = 0
-	ssh_FX_EOF               = 1
-	ssh_FX_NO_SUCH_FILE      = 2
-	ssh_FX_PERMISSION_DENIED = 3
-	ssh_FX_FAILURE           = 4
-	ssh_FX_BAD_MESSAGE       = 5
-	ssh_FX_NO_CONNECTION     = 6
-	ssh_FX_CONNECTION_LOST   = 7
-	ssh_FX_OP_UNSUPPORTED    = 8
+	SSH_FX_OK                = 0
+	SSH_FX_EOF               = 1
+	SSH_FX_NO_SUCH_FILE      = 2
+	SSH_FX_PERMISSION_DENIED = 3
+	SSH_FX_FAILURE           = 4
+	SSH_FX_BAD_MESSAGE       = 5
+	SSH_FX_NO_CONNECTION     = 6
+	SSH_FX_CONNECTION_LOST   = 7
+	SSH_FX_OP_UNSUPPORTED    = 8
 
 	// see draft-ietf-secsh-filexfer-13
 	// https://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-9.1
-	ssh_FX_INVALID_HANDLE              = 9
-	ssh_FX_NO_SUCH_PATH                = 10
-	ssh_FX_FILE_ALREADY_EXISTS         = 11
-	ssh_FX_WRITE_PROTECT               = 12
-	ssh_FX_NO_MEDIA                    = 13
-	ssh_FX_NO_SPACE_ON_FILESYSTEM      = 14
-	ssh_FX_QUOTA_EXCEEDED              = 15
-	ssh_FX_UNKNOWN_PRINCIPAL           = 16
-	ssh_FX_LOCK_CONFLICT               = 17
-	ssh_FX_DIR_NOT_EMPTY               = 18
-	ssh_FX_NOT_A_DIRECTORY             = 19
-	ssh_FX_INVALID_FILENAME            = 20
-	ssh_FX_LINK_LOOP                   = 21
-	ssh_FX_CANNOT_DELETE               = 22
-	ssh_FX_INVALID_PARAMETER           = 23
-	ssh_FX_FILE_IS_A_DIRECTORY         = 24
-	ssh_FX_BYTE_RANGE_LOCK_CONFLICT    = 25
-	ssh_FX_BYTE_RANGE_LOCK_REFUSED     = 26
-	ssh_FX_DELETE_PENDING              = 27
-	ssh_FX_FILE_CORRUPT                = 28
-	ssh_FX_OWNER_INVALID               = 29
-	ssh_FX_GROUP_INVALID               = 30
-	ssh_FX_NO_MATCHING_BYTE_RANGE_LOCK = 31
+	SSH_FX_INVALID_HANDLE              = 9
+	SSH_FX_NO_SUCH_PATH                = 10
+	SSH_FX_FILE_ALREADY_EXISTS         = 11
+	SSH_FX_WRITE_PROTECT               = 12
+	SSH_FX_NO_MEDIA                    = 13
+	SSH_FX_NO_SPACE_ON_FILESYSTEM      = 14
+	SSH_FX_QUOTA_EXCEEDED              = 15
+	SSH_FX_UNKNOWN_PRINCIPAL           = 16
+	SSH_FX_LOCK_CONFLICT               = 17
+	SSH_FX_DIR_NOT_EMPTY               = 18
+	SSH_FX_NOT_A_DIRECTORY             = 19
+	SSH_FX_INVALID_FILENAME            = 20
+	SSH_FX_LINK_LOOP                   = 21
+	SSH_FX_CANNOT_DELETE               = 22
+	SSH_FX_INVALID_PARAMETER           = 23
+	SSH_FX_FILE_IS_A_DIRECTORY         = 24
+	SSH_FX_BYTE_RANGE_LOCK_CONFLICT    = 25
+	SSH_FX_BYTE_RANGE_LOCK_REFUSED     = 26
+	SSH_FX_DELETE_PENDING              = 27
+	SSH_FX_FILE_CORRUPT                = 28
+	SSH_FX_OWNER_INVALID               = 29
+	SSH_FX_GROUP_INVALID               = 30
+	SSH_FX_NO_MATCHING_BYTE_RANGE_LOCK = 31
 )
 
 const (
-	ssh_FXF_READ   = 0x00000001
-	ssh_FXF_WRITE  = 0x00000002
-	ssh_FXF_APPEND = 0x00000004
-	ssh_FXF_CREAT  = 0x00000008
-	ssh_FXF_TRUNC  = 0x00000010
-	ssh_FXF_EXCL   = 0x00000020
+	SSH_FXF_READ   = 0x00000001
+	SSH_FXF_WRITE  = 0x00000002
+	SSH_FXF_APPEND = 0x00000004
+	SSH_FXF_CREAT  = 0x00000008
+	SSH_FXF_TRUNC  = 0x00000010
+	SSH_FXF_EXCL   = 0x00000020
 )
 
-type fxp uint8
+type Fxpkt uint8
 
-func (f fxp) String() string {
+func (f Fxpkt) String() string {
 	switch f {
-	case ssh_FXP_INIT:
+	case SSH_FXP_INIT:
 		return "SSH_FXP_INIT"
-	case ssh_FXP_VERSION:
+	case SSH_FXP_VERSION:
 		return "SSH_FXP_VERSION"
-	case ssh_FXP_OPEN:
+	case SSH_FXP_OPEN:
 		return "SSH_FXP_OPEN"
-	case ssh_FXP_CLOSE:
+	case SSH_FXP_CLOSE:
 		return "SSH_FXP_CLOSE"
-	case ssh_FXP_READ:
+	case SSH_FXP_READ:
 		return "SSH_FXP_READ"
-	case ssh_FXP_WRITE:
+	case SSH_FXP_WRITE:
 		return "SSH_FXP_WRITE"
-	case ssh_FXP_LSTAT:
+	case SSH_FXP_LSTAT:
 		return "SSH_FXP_LSTAT"
-	case ssh_FXP_FSTAT:
+	case SSH_FXP_FSTAT:
 		return "SSH_FXP_FSTAT"
-	case ssh_FXP_SETSTAT:
+	case SSH_FXP_SETSTAT:
 		return "SSH_FXP_SETSTAT"
-	case ssh_FXP_FSETSTAT:
+	case SSH_FXP_FSETSTAT:
 		return "SSH_FXP_FSETSTAT"
-	case ssh_FXP_OPENDIR:
+	case SSH_FXP_OPENDIR:
 		return "SSH_FXP_OPENDIR"
-	case ssh_FXP_READDIR:
+	case SSH_FXP_READDIR:
 		return "SSH_FXP_READDIR"
-	case ssh_FXP_REMOVE:
+	case SSH_FXP_REMOVE:
 		return "SSH_FXP_REMOVE"
-	case ssh_FXP_MKDIR:
+	case SSH_FXP_MKDIR:
 		return "SSH_FXP_MKDIR"
-	case ssh_FXP_RMDIR:
+	case SSH_FXP_RMDIR:
 		return "SSH_FXP_RMDIR"
-	case ssh_FXP_REALPATH:
+	case SSH_FXP_REALPATH:
 		return "SSH_FXP_REALPATH"
-	case ssh_FXP_STAT:
+	case SSH_FXP_STAT:
 		return "SSH_FXP_STAT"
-	case ssh_FXP_RENAME:
+	case SSH_FXP_RENAME:
 		return "SSH_FXP_RENAME"
-	case ssh_FXP_READLINK:
+	case SSH_FXP_READLINK:
 		return "SSH_FXP_READLINK"
-	case ssh_FXP_SYMLINK:
+	case SSH_FXP_SYMLINK:
 		return "SSH_FXP_SYMLINK"
-	case ssh_FXP_STATUS:
+	case SSH_FXP_STATUS:
 		return "SSH_FXP_STATUS"
-	case ssh_FXP_HANDLE:
+	case SSH_FXP_HANDLE:
 		return "SSH_FXP_HANDLE"
-	case ssh_FXP_DATA:
+	case SSH_FXP_DATA:
 		return "SSH_FXP_DATA"
-	case ssh_FXP_NAME:
+	case SSH_FXP_NAME:
 		return "SSH_FXP_NAME"
-	case ssh_FXP_ATTRS:
+	case SSH_FXP_ATTRS:
 		return "SSH_FXP_ATTRS"
-	case ssh_FXP_EXTENDED:
+	case SSH_FXP_EXTENDED:
 		return "SSH_FXP_EXTENDED"
-	case ssh_FXP_EXTENDED_REPLY:
+	case SSH_FXP_EXTENDED_REPLY:
 		return "SSH_FXP_EXTENDED_REPLY"
 	default:
 		return "unknown"
@@ -150,23 +150,23 @@ type fx uint8
 
 func (f fx) String() string {
 	switch f {
-	case ssh_FX_OK:
+	case SSH_FX_OK:
 		return "SSH_FX_OK"
-	case ssh_FX_EOF:
+	case SSH_FX_EOF:
 		return "SSH_FX_EOF"
-	case ssh_FX_NO_SUCH_FILE:
+	case SSH_FX_NO_SUCH_FILE:
 		return "SSH_FX_NO_SUCH_FILE"
-	case ssh_FX_PERMISSION_DENIED:
+	case SSH_FX_PERMISSION_DENIED:
 		return "SSH_FX_PERMISSION_DENIED"
-	case ssh_FX_FAILURE:
+	case SSH_FX_FAILURE:
 		return "SSH_FX_FAILURE"
-	case ssh_FX_BAD_MESSAGE:
+	case SSH_FX_BAD_MESSAGE:
 		return "SSH_FX_BAD_MESSAGE"
-	case ssh_FX_NO_CONNECTION:
+	case SSH_FX_NO_CONNECTION:
 		return "SSH_FX_NO_CONNECTION"
-	case ssh_FX_CONNECTION_LOST:
+	case SSH_FX_CONNECTION_LOST:
 		return "SSH_FX_CONNECTION_LOST"
-	case ssh_FX_OP_UNSUPPORTED:
+	case SSH_FX_OP_UNSUPPORTED:
 		return "SSH_FX_OP_UNSUPPORTED"
 	default:
 		return "unknown"
@@ -178,11 +178,11 @@ type unexpectedPacketErr struct {
 }
 
 func (u *unexpectedPacketErr) Error() string {
-	return fmt.Sprintf("sftp: unexpected packet: want %v, got %v", fxp(u.want), fxp(u.got))
+	return fmt.Sprintf("sftp: unexpected packet: want %v, got %v", Fxpkt(u.want), Fxpkt(u.got))
 }
 
 func unimplementedPacketErr(u uint8) error {
-	return fmt.Errorf("sftp: unimplemented packet type: got %v", fxp(u))
+	return fmt.Errorf("sftp: unimplemented packet type: got %v", Fxpkt(u))
 }
 
 type unexpectedIDErr struct{ want, got uint32 }


### PR DESCRIPTION
This pull request builds on pull request #96, first commit here is same as that. Second commit is the important part.

I left most of the filesystem handling code alone so that the changes required for the Responder interface are clear. In the final version it probably makes sense to migrate the filesystem handling into the filesystem_responders.go along with a struct for the openFiles, nextHandle, etc. Though it really doesn't affect the ability to use different backends, so it isn't necessary.