### PR TITLE
General server cleanups

### DIFF
--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -99,11 +99,12 @@ func testClientGoSvr(t testing.TB, readonly bool, delay time.Duration) (*Client,
 		options = append(options, ReadOnly())
 	}
 
-	server, err := NewServer(
-		txPipeRd,
-		rxPipeWr,
-		options...,
-	)
+	rwc := struct {
+		io.Reader
+		io.WriteCloser
+	}{txPipeRd, rxPipeWr}
+
+	server, err := NewServer(rwc, options...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/sftp-server/main.go
+++ b/examples/sftp-server/main.go
@@ -120,7 +120,6 @@ func main() {
 
 		server, err := sftp.NewServer(
 			channel,
-			channel,
 			sftp.WithDebug(debugStream),
 			sftp.ReadOnly(),
 		)

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -296,7 +296,6 @@ func (chsvr *sshSessionChannelServer) handleSubsystem(req *ssh.Request) error {
 
 	sftpServer, err := NewServer(
 		chsvr.ch,
-		chsvr.ch,
 		WithDebug(sftpServerDebugStream),
 	)
 	if err != nil {

--- a/server_standalone/main.go
+++ b/server_standalone/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 
@@ -28,8 +29,12 @@ func main() {
 	}
 
 	svr, _ := sftp.NewServer(
-		os.Stdin,
-		os.Stdout,
+		struct {
+			io.Reader
+			io.WriteCloser
+		}{os.Stdin,
+			os.Stdout,
+		},
 		sftp.WithDebug(debugStream),
 		sftp.ReadOnly(),
 	)


### PR DESCRIPTION
- no need to initalise mutexes, their zero value is valid
- make NewServer simpler, 90% of use cases already had an
  io.ReadWriteCloser, in the single case that it it is easy to provide a
  simple wrapper.