### PR TITLE
make example server respect readOnly flag

### DIFF
--- a/examples/sftp-server/main.go
+++ b/examples/sftp-server/main.go
@@ -118,10 +118,20 @@ func main() {
 			}
 		}(requests)
 
+		serverOptions := []sftp.ServerOption{
+			sftp.WithDebug(debugStream),
+		}
+
+		if readOnly {
+			serverOptions = append(serverOptions, sftp.ReadOnly())
+			fmt.Fprintf(debugStream, "Read-only server\n")
+		} else {
+			fmt.Fprintf(debugStream, "Read write server\n")
+		}
+
 		server, err := sftp.NewServer(
 			channel,
-			sftp.WithDebug(debugStream),
-			sftp.ReadOnly(),
+			serverOptions...,
 		)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Currently the example server has a flag `-R` that should toggle `sftp.ReadOnly`.

`sftp.ReadOnly` is hard-coded in `sftp.NewServer` so this flag is ineffective.

This PR changes that and provides an example of way to send an arbitrary number of `sftp.ServerOption`'s to `sftp.NewServer`