### PR TITLE
Introduce sftp.conn type to handle common send/recv behaviour

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,0 +1,25 @@
+package sftp
+
+import (
+	"encoding"
+	"io"
+	"sync"
+)
+
+// conn implements a bidirectional channel on which client and server
+// connections are multiplexed
+
+type conn struct {
+	io.ReadWriteCloser
+	sync.Mutex // used to serialise writes to sendPacket
+}
+
+func (c *conn) recvPacket() (uint8, []byte, error) {
+	return recvPacket(c)
+}
+
+func (c *conn) sendPacket(m encoding.BinaryMarshaler) error {
+	c.Lock()
+	defer c.Unlock()
+	return sendPacket(c, m)
+}


### PR DESCRIPTION
Introduce sftp.conn type to bind packet send/recv to a io.ReadWriteCloser.