### PR TITLE
Always close client conn when clientConn.recv exits

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -35,9 +35,8 @@ type clientConn struct {
 
 // Close closes the SFTP session.
 func (c *clientConn) Close() error {
-	err := c.conn.Close()
-	c.wg.Wait()
-	return err
+	defer c.wg.Wait()
+	return c.conn.Close()
 }
 
 func (c *clientConn) loop() {
@@ -51,6 +50,7 @@ func (c *clientConn) loop() {
 // recv continuously reads from the server and forwards responses to the
 // appropriate channel.
 func (c *clientConn) recv() error {
+	defer c.conn.Close()
 	for {
 		typ, data, err := c.recvPacket()
 		if err != nil {

--- a/packet.go
+++ b/packet.go
@@ -118,7 +118,7 @@ func unmarshalStringSafe(b []byte) (string, []byte, error) {
 func sendPacket(w io.Writer, m encoding.BinaryMarshaler) error {
 	bb, err := m.MarshalBinary()
 	if err != nil {
-		return errors.Wrap(err, "binary marshaller failed")
+		return errors.Errorf("binary marshaller failed: %v", err)
 	}
 	if debugDumpTxPacketBytes {
 		debug("send packet: %s %d bytes %x", fxp(bb[0]), len(bb), bb[1:])
@@ -129,10 +129,13 @@ func sendPacket(w io.Writer, m encoding.BinaryMarshaler) error {
 	hdr := []byte{byte(l >> 24), byte(l >> 16), byte(l >> 8), byte(l)}
 	_, err = w.Write(hdr)
 	if err != nil {
-		return err
+		return errors.Errorf("failed to send packet header: %v", err)
 	}
 	_, err = w.Write(bb)
-	return err
+	if err != nil {
+		return errors.Errorf("failed to send packet body: %v", err)
+	}
+	return nil
 }
 
 func recvPacket(r io.Reader) (uint8, []byte, error) {

--- a/server.go
+++ b/server.go
@@ -220,9 +220,9 @@ func (svr *Server) Serve() error {
 	}
 
 	var err error
+	var pktType uint8
+	var pktBytes []byte
 	for {
-		var pktType uint8
-		var pktBytes []byte
 		pktType, pktBytes, err = svr.recvPacket()
 		if err != nil {
 			break


### PR DESCRIPTION
If recv has exited then nobody will retrive the response, so
make sure we cannot send anything by shutting down the Write side of the
connection.