### PR TITLE
conn: seperate io.Reader and io.WriteCloser

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,10 +54,8 @@ func NewClientPipe(rd io.Reader, wr io.WriteCloser, opts ...func(*Client) error)
 	sftp := &Client{
 		clientConn: clientConn{
 			conn: conn{
-				ReadWriteCloser: struct {
-					io.Reader
-					io.WriteCloser
-				}{rd, wr},
+				Reader:      rd,
+				WriteCloser: wr,
 			},
 			inflight: make(map[uint32]chan<- result),
 		},

--- a/conn.go
+++ b/conn.go
@@ -11,7 +11,8 @@ import (
 // conn implements a bidirectional channel on which client and server
 // connections are multiplexed.
 type conn struct {
-	io.ReadWriteCloser
+	io.Reader
+	io.WriteCloser
 	sync.Mutex // used to serialise writes to sendPacket
 }
 

--- a/server.go
+++ b/server.go
@@ -77,7 +77,8 @@ type serverRespondablePacket interface {
 func NewServer(rwc io.ReadWriteCloser, options ...ServerOption) (*Server, error) {
 	s := &Server{
 		conn: conn{
-			ReadWriteCloser: rwc,
+			Reader:      rwc,
+			WriteCloser: rwc,
 		},
 		debugStream: ioutil.Discard,
 		pktChan:     make(chan rxPacket, sftpServerWorkerCount),


### PR DESCRIPTION
Reading and Writing are less coupled in the sftp client and server than
they may be over a traditional ReadWriter. This mirrors the full duplex
/ half close nature of a TCP connection.

In essence conn.Reader cannot be closed locally, it can only close in
response to the remote side using conn.WriteCloser.Close(), or a network
error, which is effectively the same thing.

Make this behaviour super clear by no longer smooshing the type into a
ReadWriteCloser.