### PR TITLE
Skip statvfs impl on linux if using gccgo

### DIFF
--- a/server_statvfs_linux.go
+++ b/server_statvfs_linux.go
@@ -1,3 +1,5 @@
+// +build !gccgo,linux
+
 package sftp
 
 import (

--- a/server_statvfs_stubs.go
+++ b/server_statvfs_stubs.go
@@ -1,4 +1,4 @@
-// +build !darwin,!linux
+// +build !darwin,!linux gccgo
 
 package sftp
 


### PR DESCRIPTION
gccgo is missing some fields in the linux version of the
syscall.Statfs_t type, so use the stub impl instead.

Fixes #121