### PR TITLE
Make SSH_FXP_STATUS "message" field optional.

### DIFF
--- a/client.go
+++ b/client.go
@@ -1085,10 +1085,7 @@ func unmarshalStatus(id uint32, data []byte) error {
 		return &unexpectedIDErr{id, sid}
 	}
 	code, data := unmarshalUint32(data)
-	msg, data, err := unmarshalStringSafe(data)
-	if err != nil {
-		return err
-	}
+	msg, data, _ := unmarshalStringSafe(data)
 	lang, _, _ := unmarshalStringSafe(data)
 	return &StatusError{
 		Code: code,

--- a/client_test.go
+++ b/client_test.go
@@ -116,7 +116,9 @@ func TestUnmarshalStatus(t *testing.T) {
 			desc:   "missing error message and language tag",
 			reqID:  1,
 			status: idCode,
-			want:   errShortPacket,
+			want: &StatusError{
+				Code: ssh_FX_FAILURE,
+			},
 		},
 		{
 			desc:   "missing language tag",


### PR DESCRIPTION
Follow-up to issue #110 and PR #109. I can read directories with the last commit, but reading files is now a problem...

Cisco SSH 2.0 server doesn't fill out the "message" field,
even though it returns valid status codes. This makes
File.Read method error out without actually reading the
file due to unmarshalStatus returning a "packet too short"
error.
