### PR TITLE
Fix build directive to properly compile under gccgo in Linux

### DIFF
--- a/server_statvfs_impl.go
+++ b/server_statvfs_impl.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin linux,!gccgo
 
 // fill in statvfs structure with OS specific values
 // Statfs_t is different per-kernel, and only exists on some unixes (not Solaris for instance)


### PR DESCRIPTION
Before this fix:

eric@workstation:~/go/src/github.com/pkg/sftp$ /opt/gccgo/bin/go test
client.go:12:2: cannot find package "github.com/kr/fs" in any of:
        /opt/gccgo/src/github.com/kr/fs (from $GOROOT)
        ($GOPATH not set)
client.go:13:2: cannot find package "github.com/pkg/errors" in any of:
        /opt/gccgo/src/github.com/pkg/errors (from $GOROOT)
        ($GOPATH not set)
client.go:14:2: cannot find package "golang.org/x/crypto/ssh" in any of:
        /opt/gccgo/src/golang.org/x/crypto/ssh (from $GOROOT)
        ($GOPATH not set)
eric@workstation:~/go/src/github.com/pkg/sftp$ export GOPATH=/home/eric/go
eric@workstation:~/go/src/github.com/pkg/sftp$ /opt/gccgo/bin/go test
./server_statvfs_stubs.go:9:1: error: redefinition of ‘respond’
 func (p sshFxpExtendedPacketStatVFS) respond(svr *Server) error {
 ^
./server_statvfs_impl.go:12:1: note: previous definition of ‘respond’ was here
 func (p sshFxpExtendedPacketStatVFS) respond(svr *Server) error {
 ^
./server_statvfs_impl.go:18:17: error: reference to undefined name ‘statvfsFromStatfst’
  retPkt, err := statvfsFromStatfst(stat)
                 ^
go1: internal compiler error: in do_get_backend, at go/gofrontend/statements.cc:476
0x67d1b3 Temporary_statement::do_get_backend(Translate_context*)
        ../../gccgo/gcc/go/gofrontend/statements.cc:476
0x64b9d0 Block::get_backend(Translate_context*)
        ../../gccgo/gcc/go/gofrontend/gogo.cc:5816
0x67a4cc Block_statement::do_get_backend(Translate_context*)
        ../../gccgo/gcc/go/gofrontend/statements.cc:1836
0x64b9d0 Block::get_backend(Translate_context*)
        ../../gccgo/gcc/go/gofrontend/gogo.cc:5816
0x67a556 If_statement::do_get_backend(Translate_context*)
        ../../gccgo/gcc/go/gofrontend/statements.cc:3213
0x64b9d0 Block::get_backend(Translate_context*)
        ../../gccgo/gcc/go/gofrontend/gogo.cc:5816
0x67a4cc Block_statement::do_get_backend(Translate_context*)
        ../../gccgo/gcc/go/gofrontend/statements.cc:1836
0x64b9d0 Block::get_backend(Translate_context*)
        ../../gccgo/gcc/go/gofrontend/gogo.cc:5816
0x64c3cb Function::build(Gogo*, Named_object*)
        ../../gccgo/gcc/go/gofrontend/gogo.cc:5422
0x64ca17 Named_object::get_backend(Gogo*, std::vector<Bexpression*, std::allocator<Bexpression*> >&, std::vector<Btype*, std::allocator<Btype*> >&, std::vector<Bfunction*, std::allocator<Bfunction*> >&)
        ../../gccgo/gcc/go/gofrontend/gogo.cc:7140
0x655ac9 Gogo::write_globals()
        ../../gccgo/gcc/go/gofrontend/gogo.cc:1262
Please submit a full bug report,
with preprocessed source if appropriate.
Please include the complete backtrace with any bug report.
See <http://gcc.gnu.org/bugs.html> for instructions.
FAIL    github.com/pkg/sftp [build failed]

After this fix:

eric@workstation:~/go/src/github.com/pkg/sftp$ /opt/gccgo/bin/go test
PASS
ok      github.com/pkg/sftp     0.093s

and, under gc Go:

eric@workstation:~/go/src/github.com/pkg/sftp$ /home/eric/src/go/bin/go test
PASS
ok      github.com/pkg/sftp     0.005s

Fixes #121