### PR TITLE
Request

### DIFF
--- a/examples/request-server/main.go
+++ b/examples/request-server/main.go
@@ -28,7 +28,9 @@ func main() {
 	flag.Parse()
 
 	debugStream := ioutil.Discard
-	if debugStderr { debugStream = os.Stderr }
+	if debugStderr {
+		debugStream = os.Stderr
+	}
 
 	// An SSH server is represented by a ServerConfig, which holds
 	// certificate details and handles authentication of ServerConns.
@@ -45,17 +47,23 @@ func main() {
 	}
 
 	privateBytes, err := ioutil.ReadFile("id_rsa")
-	if err != nil { log.Fatal("Failed to load private key", err) }
+	if err != nil {
+		log.Fatal("Failed to load private key", err)
+	}
 
 	private, err := ssh.ParsePrivateKey(privateBytes)
-	if err != nil { log.Fatal("Failed to parse private key", err) }
+	if err != nil {
+		log.Fatal("Failed to parse private key", err)
+	}
 
 	config.AddHostKey(private)
 
 	// Once a ServerConfig has been configured, connections can be
 	// accepted.
 	listener, err := net.Listen("tcp", "0.0.0.0:2022")
-	if err != nil { log.Fatal("failed to listen for connection", err) }
+	if err != nil {
+		log.Fatal("failed to listen for connection", err)
+	}
 	fmt.Printf("Listening on %v\n", listener.Addr())
 
 	nConn, err := listener.Accept()
@@ -66,7 +74,9 @@ func main() {
 	// Before use, a handshake must be performed on the incoming
 	// net.Conn.
 	_, chans, reqs, err := ssh.NewServerConn(nConn, config)
-	if err != nil { log.Fatal("failed to handshake", err) }
+	if err != nil {
+		log.Fatal("failed to handshake", err)
+	}
 	fmt.Fprintf(debugStream, "SSH server established\n")
 
 	// The incoming Request channel must be serviced.
@@ -84,7 +94,9 @@ func main() {
 			continue
 		}
 		channel, requests, err := newChannel.Accept()
-		if err != nil { log.Fatal("could not accept channel.", err) }
+		if err != nil {
+			log.Fatal("could not accept channel.", err)
+		}
 		fmt.Fprintf(debugStream, "Channel accepted\n")
 
 		// Sessions have out-of-band requests such as "shell",
@@ -108,7 +120,9 @@ func main() {
 
 		root := sftp.InMemHandler()
 		server, err := sftp.NewRequestServer(channel, root)
-		if err != nil { log.Fatal(err) }
+		if err != nil {
+			log.Fatal(err)
+		}
 		if err := server.Serve(); err != nil {
 			log.Fatal("sftp server completed with error:", err)
 		}

--- a/examples/request-server/main.go
+++ b/examples/request-server/main.go
@@ -1,0 +1,116 @@
+// An example SFTP server implementation using the golang SSH package.
+// Serves the whole filesystem visible to the user, and has a hard-coded username and password,
+// so not for real use!
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+
+	"github.com/eikenb/sftp"
+	"golang.org/x/crypto/ssh"
+)
+
+// Based on example server code from golang.org/x/crypto/ssh and server_standalone
+func main() {
+
+	var (
+		readOnly    bool
+		debugStderr bool
+	)
+
+	flag.BoolVar(&readOnly, "R", false, "read-only server")
+	flag.BoolVar(&debugStderr, "e", false, "debug to stderr")
+	flag.Parse()
+
+	debugStream := ioutil.Discard
+	if debugStderr { debugStream = os.Stderr }
+
+	// An SSH server is represented by a ServerConfig, which holds
+	// certificate details and handles authentication of ServerConns.
+	config := &ssh.ServerConfig{
+		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+			// Should use constant-time compare (or better, salt+hash) in
+			// a production setting.
+			fmt.Fprintf(debugStream, "Login: %s\n", c.User())
+			if c.User() == "testuser" && string(pass) == "" {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("password rejected for %q", c.User())
+		},
+	}
+
+	privateBytes, err := ioutil.ReadFile("id_rsa")
+	if err != nil { log.Fatal("Failed to load private key", err) }
+
+	private, err := ssh.ParsePrivateKey(privateBytes)
+	if err != nil { log.Fatal("Failed to parse private key", err) }
+
+	config.AddHostKey(private)
+
+	// Once a ServerConfig has been configured, connections can be
+	// accepted.
+	listener, err := net.Listen("tcp", "0.0.0.0:2022")
+	if err != nil { log.Fatal("failed to listen for connection", err) }
+	fmt.Printf("Listening on %v\n", listener.Addr())
+
+	nConn, err := listener.Accept()
+	if err != nil {
+		log.Fatal("failed to accept incoming connection", err)
+	}
+
+	// Before use, a handshake must be performed on the incoming
+	// net.Conn.
+	_, chans, reqs, err := ssh.NewServerConn(nConn, config)
+	if err != nil { log.Fatal("failed to handshake", err) }
+	fmt.Fprintf(debugStream, "SSH server established\n")
+
+	// The incoming Request channel must be serviced.
+	go ssh.DiscardRequests(reqs)
+
+	// Service the incoming Channel channel.
+	for newChannel := range chans {
+		// Channels have a type, depending on the application level
+		// protocol intended. In the case of an SFTP session, this is "subsystem"
+		// with a payload string of "<length=4>sftp"
+		fmt.Fprintf(debugStream, "Incoming channel: %s\n", newChannel.ChannelType())
+		if newChannel.ChannelType() != "session" {
+			newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
+			fmt.Fprintf(debugStream, "Unknown channel type: %s\n", newChannel.ChannelType())
+			continue
+		}
+		channel, requests, err := newChannel.Accept()
+		if err != nil { log.Fatal("could not accept channel.", err) }
+		fmt.Fprintf(debugStream, "Channel accepted\n")
+
+		// Sessions have out-of-band requests such as "shell",
+		// "pty-req" and "env".  Here we handle only the
+		// "subsystem" request.
+		go func(in <-chan *ssh.Request) {
+			for req := range in {
+				fmt.Fprintf(debugStream, "Request: %v\n", req.Type)
+				ok := false
+				switch req.Type {
+				case "subsystem":
+					fmt.Fprintf(debugStream, "Subsystem: %s\n", req.Payload[4:])
+					if string(req.Payload[4:]) == "sftp" {
+						ok = true
+					}
+				}
+				fmt.Fprintf(debugStream, " - accepted: %v\n", ok)
+				req.Reply(ok, nil)
+			}
+		}(requests)
+
+		root := sftp.InMemHandler()
+		server, err := sftp.NewRequestServer(channel, root)
+		if err != nil { log.Fatal(err) }
+		if err := server.Serve(); err != nil {
+			log.Fatal("sftp server completed with error:", err)
+		}
+	}
+}

--- a/examples/request-server/main.go
+++ b/examples/request-server/main.go
@@ -119,10 +119,7 @@ func main() {
 		}(requests)
 
 		root := sftp.InMemHandler()
-		server, err := sftp.NewRequestServer(channel, root)
-		if err != nil {
-			log.Fatal(err)
-		}
+		server := sftp.NewRequestServer(channel, root)
 		if err := server.Serve(); err != nil {
 			log.Fatal("sftp server completed with error:", err)
 		}

--- a/examples/request-server/main.go
+++ b/examples/request-server/main.go
@@ -11,7 +11,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/eikenb/sftp"
+	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 )
 

--- a/request-example.go
+++ b/request-example.go
@@ -65,6 +65,10 @@ func (fs *root) Filecmd(r *Request) error {
 		if err != nil {
 			return err
 		}
+		if _, ok := fs.files[r.Target]; ok {
+			return &os.LinkError{"rename", r.Filepath, r.Target,
+				fmt.Errorf("dest file exists")}
+		}
 		fs.files[r.Target] = file
 		delete(fs.files, r.Filepath)
 	case "Rmdir", "Remove":

--- a/request-example.go
+++ b/request-example.go
@@ -165,6 +165,9 @@ func (f *memFile) Mode() os.FileMode {
 	if f.isdir {
 		ret = os.FileMode(0755) | os.ModeDir
 	}
+	if f.symlink != "" {
+		ret = os.FileMode(0777) | os.ModeSymlink
+	}
 	return ret
 }
 func (f *memFile) ModTime() time.Time { return time.Now() }

--- a/request-example.go
+++ b/request-example.go
@@ -6,17 +6,143 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
+	"syscall"
 	"time"
 )
 
 var _ = fmt.Println
 
+func InMemHandler() Handlers {
+	root := &root{
+		files: make(map[string]*memFile),
+	}
+	root.memFile = newMemFile("/", true)
+	return Handlers{root, root, root, root}
+}
+
+//
+type root struct {
+	*memFile
+	files map[string]*memFile
+}
+
+func (r *root) fetch(path string) (*memFile, error) {
+	fmt.Println("fetch", r.files)
+	if path == "/" {
+		return r.memFile, nil
+	}
+	if file, ok := r.files[path]; ok {
+		return file, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+// Handlers
+func (fs *root) Fileread(r *Request) (io.Reader, error) {
+	file, err := fs.fetch(r.Filepath)
+	if err != nil {
+		return nil, err
+	}
+	if file.symlink != "" {
+		file, err = fs.fetch(file.symlink)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return file.Reader()
+}
+
+func (fs *root) Filewrite(r *Request) (io.Writer, error) {
+	file, err := fs.fetch(r.Filepath)
+	if err == os.ErrNotExist {
+		dir, err := fs.fetch(filepath.Dir(r.Filepath))
+		if err != nil {
+			return nil, err
+		}
+		if !dir.isdir {
+			return nil, os.ErrInvalid
+		}
+		file = newMemFile(r.Filepath, false)
+		fs.files[r.Filepath] = file
+	}
+	return file.Writer()
+}
+
+func (fs *root) Filecmd(r *Request) error {
+	switch r.Method {
+	case "SetStat":
+		return nil
+	case "Rename":
+		file, err := fs.fetch(r.Filepath)
+		if err != nil {
+			return err
+		}
+		fs.files[r.Target] = file
+		delete(fs.files, r.Filepath)
+	case "Rmdir", "Remove":
+		_, err := fs.fetch(filepath.Dir(r.Filepath))
+		if err != nil {
+			return err
+		}
+		delete(fs.files, r.Filepath)
+	case "Mkdir":
+		_, err := fs.fetch(filepath.Dir(r.Filepath))
+		if err != nil {
+			return err
+		}
+		fs.files[r.Filepath] = newMemFile(r.Filepath, true)
+	case "Symlink":
+		fmt.Println("ln -s", r.Filepath, r.Target)
+		_, err := fs.fetch(r.Filepath)
+		if err != nil {
+			return err
+		}
+		link := newMemFile(r.Target, false)
+		link.symlink = r.Filepath
+		fs.files[r.Target] = link
+	}
+	return nil
+}
+
+func (fs *root) Fileinfo(r *Request) ([]os.FileInfo, error) {
+	switch r.Method {
+	case "List":
+		list := []os.FileInfo{}
+		fmt.Println("ls", r.Filepath)
+		for fn, fi := range fs.files {
+			if filepath.Dir(fn) == r.Filepath {
+				fmt.Println(fn, fi.Name())
+				list = append(list, fi)
+			}
+		}
+		return list, nil
+	case "Stat":
+		file, err := fs.fetch(r.Filepath)
+		if err != nil {
+			return nil, err
+		}
+		return []os.FileInfo{file}, nil
+	case "Readlink":
+		file, err := fs.fetch(r.Filepath)
+		if err != nil {
+			return nil, err
+		}
+		if file.symlink != "" {
+			file, err = fs.fetch(file.symlink)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return []os.FileInfo{file}, nil
+	}
+	return nil, nil
+}
+
+// Implements os.FileInfo interface
 type memFile struct {
 	name    string
 	content []byte
 	modtime time.Time
-	files   map[string]*memFile
 	symlink string
 	isdir   bool
 }
@@ -25,29 +151,27 @@ func newMemFile(name string, isdir bool) *memFile {
 	return &memFile{
 		name:    name,
 		modtime: time.Now(),
-		files:   make(map[string]*memFile),
 		isdir:   isdir,
 	}
 }
 
-func InMemHandler() Handlers {
-	root := newMemFile("/", true)
-	return Handlers{root, root, root, root}
-}
-
 // Have memFile fulfill os.FileInfo interface
-func (f *memFile) Name() string { return f.name }
-func (f *memFile) Size() int64  { return int64(len(f.content)) }
+func (f *memFile) Name() string {
+	return filepath.Base(f.name)
+}
+func (f *memFile) Size() int64 { return int64(len(f.content)) }
 func (f *memFile) Mode() os.FileMode {
-	ret := os.ModePerm
+	ret := os.FileMode(0644)
 	if f.isdir {
-		ret = ret | os.ModeDir
+		ret = os.FileMode(0755) | os.ModeDir
 	}
 	return ret
 }
 func (f *memFile) ModTime() time.Time { return time.Now() }
 func (f *memFile) IsDir() bool        { return f.isdir }
-func (f *memFile) Sys() interface{}   { return nil }
+func (f *memFile) Sys() interface{} {
+	return syscall.Stat_t{Uid: 65534, Gid: 65534}
+}
 
 // Read/Write
 func (f *memFile) Reader() (io.Reader, error) {
@@ -66,140 +190,4 @@ func (f *memFile) Writer() (io.Writer, error) {
 func (f *memFile) Write(p []byte) (int, error) {
 	f.content = append(f.content, p...)
 	return len(p), nil
-}
-
-// Filesystemy things
-func (f *memFile) fetch(path string) (*memFile, error) {
-	var file *memFile = f
-	for _, name := range strings.Split(path, "/") {
-		fmt.Print(name, " - ")
-		var ok bool
-		switch name {
-		case "/":
-		default:
-			fmt.Println(file.files)
-			if file, ok = file.files[name]; !ok {
-				return nil, os.ErrNotExist
-			}
-		}
-	}
-	return file, nil
-}
-
-// Handlers
-func (f *memFile) Fileread(r *Request) (io.Reader, error) {
-	file, err := f.fetch(r.Filepath)
-	if err != nil {
-		return nil, err
-	}
-	if file.symlink != "" {
-		file, err = f.fetch(file.symlink)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return file.Reader()
-}
-
-func (f *memFile) Filewrite(r *Request) (io.Writer, error) {
-	file, err := f.fetch(r.Filepath)
-	if err == os.ErrNotExist {
-		dir, err := f.fetch(filepath.Dir(r.Filepath))
-		if !dir.isdir {
-			return nil, os.ErrInvalid
-		}
-		if err != nil {
-			return nil, err
-		}
-		name := filepath.Base(r.Filepath)
-		file = newMemFile(name, false)
-		dir.files[name] = file
-	}
-	return file.Writer()
-}
-
-func (f *memFile) Filecmd(r *Request) error {
-	switch r.Method {
-	case "SetStat":
-		return nil
-	case "Rename":
-		filename := filepath.Base(r.Filepath)
-		orig_dir, err := f.fetch(filepath.Dir(r.Filepath))
-		if err != nil {
-			return err
-		}
-		dest, err := f.fetch(r.Target)
-		if err != nil {
-			return err
-		}
-		if !dest.isdir {
-			return os.ErrInvalid
-		}
-		dest.files[filename] = orig_dir.files[filename]
-		delete(orig_dir.files, filename)
-	case "Rmdir", "Remove":
-		parent, err := f.fetch(filepath.Dir(r.Filepath))
-		if err != nil {
-			return err
-		}
-		delete(parent.files, filepath.Base(r.Filepath))
-	case "Mkdir":
-		parent, err := f.fetch(filepath.Dir(r.Filepath))
-		if err != nil {
-			return err
-		}
-		name := filepath.Base(r.Filepath)
-		file := newMemFile(name, true)
-		parent.files[name] = file
-	case "Symlink":
-		fmt.Println("ln -s", r.Filepath, r.Target)
-		parent, err := f.fetch(filepath.Dir(r.Filepath))
-		if err != nil {
-			return err
-		}
-		name := filepath.Base(r.Target)
-		file := newMemFile(name, false)
-		file.symlink = r.Filepath
-		parent.files[name] = file
-	}
-	return nil
-}
-
-func (f *memFile) Fileinfo(r *Request) ([]os.FileInfo, error) {
-	switch r.Method {
-	case "List":
-		file, err := f.fetch(r.Filepath)
-		if err != nil {
-			return nil, err
-		}
-		if file.isdir {
-			list := make([]os.FileInfo, 0, len(file.files))
-			for _, val := range file.files {
-				fmt.Println(val)
-				list = append(list, val)
-			}
-			return list, nil
-		} else {
-			return []os.FileInfo{file}, nil
-		}
-	case "Stat":
-		file, err := f.fetch(r.Filepath)
-		if err != nil {
-			return nil, err
-		}
-		return []os.FileInfo{file}, nil
-	case "Readlink":
-		file, err := f.fetch(r.Filepath)
-		if err != nil {
-			return nil, err
-		}
-		if len(file.symlink) > 0 {
-			file, err = f.fetch(file.symlink)
-			if err != nil {
-				return nil, err
-			}
-		}
-		return []os.FileInfo{file}, nil
-	}
-	return nil, nil
 }

--- a/request-example.go
+++ b/request-example.go
@@ -100,6 +100,7 @@ func (fs *root) Fileinfo(r *Request) ([]os.FileInfo, error) {
 	switch r.Method {
 	case "List":
 		list := []os.FileInfo{}
+		fmt.Println("ls", r.Filepath)
 		for fn, fi := range fs.files {
 			if filepath.Dir(fn) == r.Filepath {
 				fmt.Println(fn, fi.Name())
@@ -110,8 +111,7 @@ func (fs *root) Fileinfo(r *Request) ([]os.FileInfo, error) {
 	case "Stat":
 		file, err := fs.fetch(r.Filepath)
 		if err != nil {
-			// mimic os.Stat() return error
-			return nil, &os.PathError{"stat", r.Filepath, syscall.ENOENT}
+			return nil, err
 		}
 		return []os.FileInfo{file}, nil
 	case "Readlink":

--- a/request-example.go
+++ b/request-example.go
@@ -64,8 +64,8 @@ func (fs *root) Filecmd(r *Request) error {
 			return err
 		}
 		if _, ok := fs.files[r.Target]; ok {
-			return &os.LinkError{"rename", r.Filepath, r.Target,
-				fmt.Errorf("dest file exists")}
+			return &os.LinkError{Op: "rename", Old: r.Filepath, New: r.Target,
+				Err: fmt.Errorf("dest file exists")}
 		}
 		fs.files[r.Target] = file
 		delete(fs.files, r.Filepath)

--- a/request-example.go
+++ b/request-example.go
@@ -96,7 +96,6 @@ func (fs *root) Fileinfo(r *Request) ([]os.FileInfo, error) {
 	switch r.Method {
 	case "List":
 		list := []os.FileInfo{}
-		fmt.Println("ls", r.Filepath)
 		for fn, fi := range fs.files {
 			if filepath.Dir(fn) == r.Filepath {
 				fmt.Println(fn, fi.Name())
@@ -107,7 +106,8 @@ func (fs *root) Fileinfo(r *Request) ([]os.FileInfo, error) {
 	case "Stat":
 		file, err := fs.fetch(r.Filepath)
 		if err != nil {
-			return nil, err
+			// mimic os.Stat() return error
+			return nil, &os.PathError{"stat", r.Filepath, syscall.ENOENT}
 		}
 		return []os.FileInfo{file}, nil
 	case "Readlink":

--- a/request-example.go
+++ b/request-example.go
@@ -170,7 +170,7 @@ func (f *memFile) Mode() os.FileMode {
 func (f *memFile) ModTime() time.Time { return time.Now() }
 func (f *memFile) IsDir() bool        { return f.isdir }
 func (f *memFile) Sys() interface{} {
-	return syscall.Stat_t{Uid: 65534, Gid: 65534}
+	return &syscall.Stat_t{Uid: 65534, Gid: 65534}
 }
 
 // Read/Write

--- a/request-example.go
+++ b/request-example.go
@@ -14,8 +14,6 @@ import (
 	"time"
 )
 
-var _ = fmt.Println
-
 // Returns a Hanlders object with the test handlers
 func InMemHandler() Handlers {
 	root := &root{
@@ -84,7 +82,6 @@ func (fs *root) Filecmd(r *Request) error {
 		}
 		fs.files[r.Filepath] = newMemFile(r.Filepath, true)
 	case "Symlink":
-		fmt.Println("ln -s", r.Filepath, r.Target)
 		_, err := fs.fetch(r.Filepath)
 		if err != nil {
 			return err
@@ -100,10 +97,8 @@ func (fs *root) Fileinfo(r *Request) ([]os.FileInfo, error) {
 	switch r.Method {
 	case "List":
 		list := []os.FileInfo{}
-		fmt.Println("ls", r.Filepath)
 		for fn, fi := range fs.files {
 			if filepath.Dir(fn) == r.Filepath {
-				fmt.Println(fn, fi.Name())
 				list = append(list, fi)
 			}
 		}

--- a/request-example.go
+++ b/request-example.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-// Returns a Hanlders object with the test handlers
+// InMemHandler returns a Hanlders object with the test handlers
 func InMemHandler() Handlers {
 	root := &root{
 		files: make(map[string]*memFile),
@@ -131,11 +131,11 @@ type root struct {
 	files map[string]*memFile
 }
 
-func (r *root) fetch(path string) (*memFile, error) {
+func (fs *root) fetch(path string) (*memFile, error) {
 	if path == "/" {
-		return r.memFile, nil
+		return fs.memFile, nil
 	}
-	if file, ok := r.files[path]; ok {
+	if file, ok := fs.files[path]; ok {
 		return file, nil
 	}
 	return nil, os.ErrNotExist

--- a/request-example.go
+++ b/request-example.go
@@ -1,0 +1,205 @@
+package sftp
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var _ = fmt.Println
+
+type memFile struct {
+	name    string
+	content []byte
+	modtime time.Time
+	files   map[string]*memFile
+	symlink string
+	isdir   bool
+}
+
+func newMemFile(name string, isdir bool) *memFile {
+	return &memFile{
+		name:    name,
+		modtime: time.Now(),
+		files:   make(map[string]*memFile),
+		isdir:   isdir,
+	}
+}
+
+func InMemHandler() Handlers {
+	root := newMemFile("/", true)
+	return Handlers{root, root, root, root}
+}
+
+// Have memFile fulfill os.FileInfo interface
+func (f *memFile) Name() string { return f.name }
+func (f *memFile) Size() int64  { return int64(len(f.content)) }
+func (f *memFile) Mode() os.FileMode {
+	ret := os.ModePerm
+	if f.isdir {
+		ret = ret | os.ModeDir
+	}
+	return ret
+}
+func (f *memFile) ModTime() time.Time { return time.Now() }
+func (f *memFile) IsDir() bool        { return f.isdir }
+func (f *memFile) Sys() interface{}   { return nil }
+
+// Read/Write
+func (f *memFile) Reader() (io.Reader, error) {
+	if f.isdir {
+		return nil, os.ErrInvalid
+	}
+	return bytes.NewReader(f.content), nil
+}
+
+func (f *memFile) Writer() (io.Writer, error) {
+	if f.isdir {
+		return nil, os.ErrInvalid
+	}
+	return f, nil
+}
+func (f *memFile) Write(p []byte) (int, error) {
+	f.content = append(f.content, p...)
+	return len(p), nil
+}
+
+// Filesystemy things
+func (f *memFile) fetch(path string) (*memFile, error) {
+	var file *memFile = f
+	for _, name := range strings.Split(path, "/") {
+		fmt.Print(name, " - ")
+		var ok bool
+		switch name {
+		case "/":
+		default:
+			fmt.Println(file.files)
+			if file, ok = file.files[name]; !ok {
+				return nil, os.ErrNotExist
+			}
+		}
+	}
+	return file, nil
+}
+
+// Handlers
+func (f *memFile) Fileread(r *Request) (io.Reader, error) {
+	file, err := f.fetch(r.Filepath)
+	if err != nil {
+		return nil, err
+	}
+	if file.symlink != "" {
+		file, err = f.fetch(file.symlink)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return file.Reader()
+}
+
+func (f *memFile) Filewrite(r *Request) (io.Writer, error) {
+	file, err := f.fetch(r.Filepath)
+	if err == os.ErrNotExist {
+		dir, err := f.fetch(filepath.Dir(r.Filepath))
+		if !dir.isdir {
+			return nil, os.ErrInvalid
+		}
+		if err != nil {
+			return nil, err
+		}
+		name := filepath.Base(r.Filepath)
+		file = newMemFile(name, false)
+		dir.files[name] = file
+	}
+	return file.Writer()
+}
+
+func (f *memFile) Filecmd(r *Request) error {
+	switch r.Method {
+	case "SetStat":
+		return nil
+	case "Rename":
+		filename := filepath.Base(r.Filepath)
+		orig_dir, err := f.fetch(filepath.Dir(r.Filepath))
+		if err != nil {
+			return err
+		}
+		dest, err := f.fetch(r.Target)
+		if err != nil {
+			return err
+		}
+		if !dest.isdir {
+			return os.ErrInvalid
+		}
+		dest.files[filename] = orig_dir.files[filename]
+		delete(orig_dir.files, filename)
+	case "Rmdir", "Remove":
+		parent, err := f.fetch(filepath.Dir(r.Filepath))
+		if err != nil {
+			return err
+		}
+		delete(parent.files, filepath.Base(r.Filepath))
+	case "Mkdir":
+		parent, err := f.fetch(filepath.Dir(r.Filepath))
+		if err != nil {
+			return err
+		}
+		name := filepath.Base(r.Filepath)
+		file := newMemFile(name, true)
+		parent.files[name] = file
+	case "Symlink":
+		fmt.Println("ln -s", r.Filepath, r.Target)
+		parent, err := f.fetch(filepath.Dir(r.Filepath))
+		if err != nil {
+			return err
+		}
+		name := filepath.Base(r.Target)
+		file := newMemFile(name, false)
+		file.symlink = r.Filepath
+		parent.files[name] = file
+	}
+	return nil
+}
+
+func (f *memFile) Fileinfo(r *Request) ([]os.FileInfo, error) {
+	switch r.Method {
+	case "List":
+		file, err := f.fetch(r.Filepath)
+		if err != nil {
+			return nil, err
+		}
+		if file.isdir {
+			list := make([]os.FileInfo, 0, len(file.files))
+			for _, val := range file.files {
+				fmt.Println(val)
+				list = append(list, val)
+			}
+			return list, nil
+		} else {
+			return []os.FileInfo{file}, nil
+		}
+	case "Stat":
+		file, err := f.fetch(r.Filepath)
+		if err != nil {
+			return nil, err
+		}
+		return []os.FileInfo{file}, nil
+	case "Readlink":
+		file, err := f.fetch(r.Filepath)
+		if err != nil {
+			return nil, err
+		}
+		if len(file.symlink) > 0 {
+			file, err = f.fetch(file.symlink)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return []os.FileInfo{file}, nil
+	}
+	return nil, nil
+}

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -10,21 +10,21 @@ import (
 
 // should return an io.Reader for the filepath
 type FileReader interface {
-	Fileread(Request) io.Reader
+	Filereader(*Request) (io.Reader, error)
 }
 
 // should return an io.Writer for the filepath
 type FileWriter interface {
-	Filewrite(Request) io.Writer
+	Filewriter(*Request) (io.Writer, error)
 }
 
 // should return an error (rename, remove, setstate, etc.)
 type FileCmder interface {
-	Filecmd(Request) error
+	Filecmd(*Request) error
 }
 
 // should return file listing info and errors (readdir, stat)
 // note stat requests would return a list of 1
 type FileInfoer interface {
-	Fileinfo(Request) ([]os.FileInfo, error)
+	Fileinfo(*Request) ([]os.FileInfo, error)
 }

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -1,0 +1,5 @@
+package sftp
+
+type FileActor interface{}
+type Renamer interface{}
+type ReadDirer interface{}

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -8,22 +8,22 @@ import (
 // Interfaces are differentiated based on required returned values.
 // All input arguments are to be pulled from Request (the only arg).
 
-// should return an io.Reader for the filepath
+// FileReader should return an io.Reader for the filepath
 type FileReader interface {
 	Fileread(*Request) (io.Reader, error)
 }
 
-// should return an io.Writer for the filepath
+// FileWriter should return an io.Writer for the filepath
 type FileWriter interface {
 	Filewrite(*Request) (io.Writer, error)
 }
 
-// should return an error (rename, remove, setstate, etc.)
+// FileCmder should return an error (rename, remove, setstate, etc.)
 type FileCmder interface {
 	Filecmd(*Request) error
 }
 
-// should return file listing info and errors (readdir, stat)
+// FileInfoer should return file listing info and errors (readdir, stat)
 // note stat requests would return a list of 1
 type FileInfoer interface {
 	Fileinfo(*Request) ([]os.FileInfo, error)

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -10,12 +10,12 @@ import (
 
 // should return an io.Reader for the filepath
 type FileReader interface {
-	Filereader(*Request) (io.Reader, error)
+	Fileread(*Request) (io.Reader, error)
 }
 
 // should return an io.Writer for the filepath
 type FileWriter interface {
-	Filewriter(*Request) (io.Writer, error)
+	Filewrite(*Request) (io.Writer, error)
 }
 
 // should return an error (rename, remove, setstate, etc.)

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -1,9 +1,30 @@
 package sftp
 
-type FileActor interface{}
-type Renamer interface{}
-type ReadDirer interface{}
+import (
+	"io"
+	"os"
+)
 
-type FileCmder interface{}
-type Stater interface{}
-type SetStater interface{}
+// Interfaces are differentiated based on required returned values.
+// All input arguments are to be pulled from Request (the only arg).
+
+// should return an io.Reader for the filepath
+type FileReader interface {
+	Fileread(Request) io.Reader
+}
+
+// should return an io.Writer for the filepath
+type FileWriter interface {
+	Filewrite(Request) io.Writer
+}
+
+// should return an error (rename, remove, setstate, etc.)
+type FileCmder interface {
+	Filecmd(Request) error
+}
+
+// should return file listing info and errors (readdir, stat)
+// note stat requests would return a list of 1
+type FileInfoer interface {
+	Fileinfo(Request) ([]os.FileInfo, error)
+}

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -3,3 +3,7 @@ package sftp
 type FileActor interface{}
 type Renamer interface{}
 type ReadDirer interface{}
+
+type FileCmder interface{}
+type Stater interface{}
+type SetStater interface{}

--- a/request-packet.go
+++ b/request-packet.go
@@ -40,7 +40,6 @@ func (p sshFxpRemovePacket) getPath() string   { return p.Filename }
 func (p sshFxpRenamePacket) getPath() string   { return p.Oldpath }
 func (p sshFxpSymlinkPacket) getPath() string  { return p.Targetpath }
 
-// have path but not handled the same... keep?
 func (p sshFxpOpendirPacket) getPath() string { return p.Path }
 func (p sshFxpOpenPacket) getPath() string    { return p.Path }
 

--- a/request-packet.go
+++ b/request-packet.go
@@ -1,6 +1,18 @@
 package sftp
 
-// Type the packets using interfaces in a couple ways
+import (
+	"encoding"
+
+	"github.com/pkg/errors"
+)
+
+// all incoming packets
+type packet interface {
+	encoding.BinaryUnmarshaler
+	id() uint32
+}
+
+// interfaces to group types
 type hasPath interface {
 	getPath() string
 }
@@ -26,9 +38,64 @@ func (p sshFxpRenamePacket) getPath() string   { return p.Oldpath }
 func (p sshFxpSymlinkPacket) getPath() string  { return p.Targetpath }
 
 // hasHandle
-func (p sshFxpReaddirPacket) getHandle() string  { return p.Handle }
 func (p sshFxpFstatPacket) getHandle() string    { return p.Handle }
-func (p sshFxpClosePacket) getHandle() string    { return p.Handle }
+func (p sshFxpFsetstatPacket) getHandle() string { return p.Handle }
 func (p sshFxpReadPacket) getHandle() string     { return p.Handle }
 func (p sshFxpWritePacket) getHandle() string    { return p.Handle }
-func (p sshFxpFsetstatPacket) getHandle() string { return p.Handle }
+func (p sshFxpReaddirPacket) getHandle() string  { return p.Handle }
+
+// this has a handle, but is only used for close
+func (p sshFxpClosePacket) getHandle() string { return p.Handle }
+
+// take raw incoming packet data and build packet objects
+func makePacket(p rxPacket) (packet, error) {
+	var pkt packet
+	switch p.pktType {
+	case ssh_FXP_INIT:
+		pkt = &sshFxInitPacket{}
+	case ssh_FXP_LSTAT:
+		pkt = &sshFxpLstatPacket{}
+	case ssh_FXP_OPEN:
+		pkt = &sshFxpOpenPacket{}
+	case ssh_FXP_CLOSE:
+		pkt = &sshFxpClosePacket{}
+	case ssh_FXP_READ:
+		pkt = &sshFxpReadPacket{}
+	case ssh_FXP_WRITE:
+		pkt = &sshFxpWritePacket{}
+	case ssh_FXP_FSTAT:
+		pkt = &sshFxpFstatPacket{}
+	case ssh_FXP_SETSTAT:
+		pkt = &sshFxpSetstatPacket{}
+	case ssh_FXP_FSETSTAT:
+		pkt = &sshFxpFsetstatPacket{}
+	case ssh_FXP_OPENDIR:
+		pkt = &sshFxpOpendirPacket{}
+	case ssh_FXP_READDIR:
+		pkt = &sshFxpReaddirPacket{}
+	case ssh_FXP_REMOVE:
+		pkt = &sshFxpRemovePacket{}
+	case ssh_FXP_MKDIR:
+		pkt = &sshFxpMkdirPacket{}
+	case ssh_FXP_RMDIR:
+		pkt = &sshFxpRmdirPacket{}
+	case ssh_FXP_REALPATH:
+		pkt = &sshFxpRealpathPacket{}
+	case ssh_FXP_STAT:
+		pkt = &sshFxpStatPacket{}
+	case ssh_FXP_RENAME:
+		pkt = &sshFxpRenamePacket{}
+	case ssh_FXP_READLINK:
+		pkt = &sshFxpReadlinkPacket{}
+	case ssh_FXP_SYMLINK:
+		pkt = &sshFxpSymlinkPacket{}
+	case ssh_FXP_EXTENDED:
+		pkt = &sshFxpExtendedPacket{}
+	default:
+		return nil, errors.Errorf("unhandled packet type: %s", p.pktType)
+	}
+	if err := pkt.UnmarshalBinary(p.pktBytes); err != nil {
+		return nil, err
+	}
+	return pkt, nil
+}

--- a/request-packet.go
+++ b/request-packet.go
@@ -25,6 +25,11 @@ type hasHandle interface {
 	getHandle() string
 }
 
+type isOpener interface {
+	hasPath
+	isOpener()
+}
+
 //// define types by adding methods
 // hasPath
 func (p sshFxpLstatPacket) getPath() string    { return p.Path }
@@ -39,8 +44,11 @@ func (p sshFxpRemovePacket) getPath() string   { return p.Filename }
 func (p sshFxpRenamePacket) getPath() string   { return p.Oldpath }
 func (p sshFxpSymlinkPacket) getPath() string  { return p.Targetpath }
 
+// Openers implement hasPath and isOpener
 func (p sshFxpOpendirPacket) getPath() string { return p.Path }
+func (p sshFxpOpendirPacket) isOpener()       {}
 func (p sshFxpOpenPacket) getPath() string    { return p.Path }
+func (p sshFxpOpenPacket) isOpener()          {}
 
 // hasHandle
 func (p sshFxpFstatPacket) getHandle() string    { return p.Handle }

--- a/request-packet.go
+++ b/request-packet.go
@@ -28,19 +28,21 @@ type hasHandle interface {
 
 //// define types by adding methods
 // hasPath
-func (p sshFxpOpendirPacket) getPath() string  { return p.Path }
 func (p sshFxpLstatPacket) getPath() string    { return p.Path }
 func (p sshFxpStatPacket) getPath() string     { return p.Path }
 func (p sshFxpRmdirPacket) getPath() string    { return p.Path }
 func (p sshFxpReadlinkPacket) getPath() string { return p.Path }
 func (p sshFxpRealpathPacket) getPath() string { return p.Path }
-func (p sshFxpOpenPacket) getPath() string     { return p.Path }
 func (p sshFxpMkdirPacket) getPath() string    { return p.Path }
 func (p sshFxpSetstatPacket) getPath() string  { return p.Path }
 func (p sshFxpStatvfsPacket) getPath() string  { return p.Path }
 func (p sshFxpRemovePacket) getPath() string   { return p.Filename }
 func (p sshFxpRenamePacket) getPath() string   { return p.Oldpath }
 func (p sshFxpSymlinkPacket) getPath() string  { return p.Targetpath }
+
+// have path but not handled the same... keep?
+func (p sshFxpOpendirPacket) getPath() string { return p.Path }
+func (p sshFxpOpenPacket) getPath() string    { return p.Path }
 
 // hasHandle
 func (p sshFxpFstatPacket) getHandle() string    { return p.Handle }

--- a/request-packet.go
+++ b/request-packet.go
@@ -8,9 +8,13 @@ import (
 
 // all incoming packets
 type packet interface {
-	encoding.BinaryMarshaler
 	encoding.BinaryUnmarshaler
 	id() uint32
+}
+
+type resp_packet interface {
+	id() uint32
+	encoding.BinaryMarshaler
 }
 
 // interfaces to group types
@@ -48,10 +52,11 @@ func (p sshFxpReaddirPacket) getHandle() string  { return p.Handle }
 // this has a handle, but is only used for close
 func (p sshFxpClosePacket) getHandle() string { return p.Handle }
 
-// for packet struct uniformity, so they all implement packet interface
-func (s *sshFxpExtendedPacket) MarshalBinary() ([]byte, error) {
-	return []byte{}, nil
-}
+// some packets with ID are missing id()
+func (p sshFxpDataPacket) id() uint32   { return p.ID }
+func (p sshFxpStatusPacket) id() uint32 { return p.ID }
+func (p sshFxpStatResponse) id() uint32 { return p.ID }
+func (p sshFxpNamePacket) id() uint32   { return p.ID }
 
 // take raw incoming packet data and build packet objects
 func makePacket(p rxPacket) (packet, error) {

--- a/request-packet.go
+++ b/request-packet.go
@@ -12,7 +12,7 @@ type packet interface {
 	id() uint32
 }
 
-type resp_packet interface {
+type responsePacket interface {
 	encoding.BinaryMarshaler
 }
 

--- a/request-packet.go
+++ b/request-packet.go
@@ -8,6 +8,7 @@ import (
 
 // all incoming packets
 type packet interface {
+	encoding.BinaryMarshaler
 	encoding.BinaryUnmarshaler
 	id() uint32
 }
@@ -46,6 +47,11 @@ func (p sshFxpReaddirPacket) getHandle() string  { return p.Handle }
 
 // this has a handle, but is only used for close
 func (p sshFxpClosePacket) getHandle() string { return p.Handle }
+
+// for packet struct uniformity, so they all implement packet interface
+func (s *sshFxpExtendedPacket) MarshalBinary() ([]byte, error) {
+	return []byte{}, nil
+}
 
 // take raw incoming packet data and build packet objects
 func makePacket(p rxPacket) (packet, error) {

--- a/request-packet.go
+++ b/request-packet.go
@@ -12,7 +12,9 @@ type packet interface {
 	id() uint32
 }
 
-type resp_packet interface { encoding.BinaryMarshaler }
+type resp_packet interface {
+	encoding.BinaryMarshaler
+}
 
 // interfaces to group types
 type hasPath interface {

--- a/request-packet.go
+++ b/request-packet.go
@@ -12,17 +12,16 @@ type packet interface {
 	id() uint32
 }
 
-type resp_packet interface {
-	id() uint32
-	encoding.BinaryMarshaler
-}
+type resp_packet interface { encoding.BinaryMarshaler }
 
 // interfaces to group types
 type hasPath interface {
+	packet
 	getPath() string
 }
 
 type hasHandle interface {
+	packet
 	getHandle() string
 }
 

--- a/request-packet.go
+++ b/request-packet.go
@@ -1,0 +1,34 @@
+package sftp
+
+// Type the packets using interfaces in a couple ways
+type hasPath interface {
+	getPath() string
+}
+
+type hasHandle interface {
+	getHandle() string
+}
+
+//// define types by adding methods
+// hasPath
+func (p sshFxpOpendirPacket) getPath() string  { return p.Path }
+func (p sshFxpLstatPacket) getPath() string    { return p.Path }
+func (p sshFxpStatPacket) getPath() string     { return p.Path }
+func (p sshFxpRmdirPacket) getPath() string    { return p.Path }
+func (p sshFxpReadlinkPacket) getPath() string { return p.Path }
+func (p sshFxpRealpathPacket) getPath() string { return p.Path }
+func (p sshFxpOpenPacket) getPath() string     { return p.Path }
+func (p sshFxpMkdirPacket) getPath() string    { return p.Path }
+func (p sshFxpSetstatPacket) getPath() string  { return p.Path }
+func (p sshFxpStatvfsPacket) getPath() string  { return p.Path }
+func (p sshFxpRemovePacket) getPath() string   { return p.Filename }
+func (p sshFxpRenamePacket) getPath() string   { return p.Oldpath }
+func (p sshFxpSymlinkPacket) getPath() string  { return p.Targetpath }
+
+// hasHandle
+func (p sshFxpReaddirPacket) getHandle() string  { return p.Handle }
+func (p sshFxpFstatPacket) getHandle() string    { return p.Handle }
+func (p sshFxpClosePacket) getHandle() string    { return p.Handle }
+func (p sshFxpReadPacket) getHandle() string     { return p.Handle }
+func (p sshFxpWritePacket) getHandle() string    { return p.Handle }
+func (p sshFxpFsetstatPacket) getHandle() string { return p.Handle }

--- a/request-readme.md
+++ b/request-readme.md
@@ -1,0 +1,39 @@
+
+The request based API allows for custom backends in a way similar to the http
+package. In order to create a backend you need to implement 4 handler
+interfaces; one for reading, one for writing, one for misc commands and one for
+listing files. Each has 1 required method and in each case those methods take
+the Request as the only parameter and they each return something different.
+These 4 interfaces are enough to handle all the SFTP traffic in a simplified
+manner.
+
+The Request structure has 5 public fields which you will deal with.
+
+- Method (string) - string name of incoming call
+- Filepath (string) - path of file to act on
+- Attrs ([]byte) - byte string of file attribute data
+- Target (string) - target path for renames and sym-links
+
+Below are the methods and a brief description of what they need to do.
+
+## Fileread(*Request) (io.Reader, error)
+
+Handler for "Get" method and returns an io.Reader for the file which the server
+then sends to the client.
+
+    Filewrite(*Request) (io.Writer, error)
+
+Handler for "Put" method and returns an io.Writer for the file which the server
+then writes the uploaded file to.
+
+    Filecmd(*Request) error
+
+Handles "SetStat", "Rename", "Rmdir", "Mkdir"  and "Symlink" methods. Makes the
+appropriate changes and returns nil for success or an filesystem like error
+(eg. os.ErrNotExist).
+
+    Fileinfo(*Request) ([]os.FileInfo, error)
+
+Handles "List", "Stat", "Readlink" methods. Gathers/creates FileInfo structs
+with the data on the files and returns in a list (list of 1 for Stat and
+Readlink).

--- a/request-readme.md
+++ b/request-readme.md
@@ -42,6 +42,7 @@ Readlink).
 
 ## TODO
 
-- Add support for SFTP file append only mode.
 - Add support for API users to see trace/debugging info of what is going on
 inside SFTP server.
+- Consider adding support for SFTP file append only mode.
+

--- a/request-readme.md
+++ b/request-readme.md
@@ -1,3 +1,4 @@
+# Request Based SFTP API
 
 The request based API allows for custom backends in a way similar to the http
 package. In order to create a backend you need to implement 4 handler
@@ -16,24 +17,31 @@ The Request structure has 5 public fields which you will deal with.
 
 Below are the methods and a brief description of what they need to do.
 
-## Fileread(*Request) (io.Reader, error)
+### Fileread(*Request) (io.Reader, error)
 
 Handler for "Get" method and returns an io.Reader for the file which the server
 then sends to the client.
 
-    Filewrite(*Request) (io.Writer, error)
+### Filewrite(*Request) (io.Writer, error)
 
 Handler for "Put" method and returns an io.Writer for the file which the server
 then writes the uploaded file to.
 
-    Filecmd(*Request) error
+###    Filecmd(*Request) error
 
 Handles "SetStat", "Rename", "Rmdir", "Mkdir"  and "Symlink" methods. Makes the
 appropriate changes and returns nil for success or an filesystem like error
 (eg. os.ErrNotExist).
 
-    Fileinfo(*Request) ([]os.FileInfo, error)
+### Fileinfo(*Request) ([]os.FileInfo, error)
 
 Handles "List", "Stat", "Readlink" methods. Gathers/creates FileInfo structs
 with the data on the files and returns in a list (list of 1 for Stat and
 Readlink).
+
+
+## TODO
+
+- Add support for SFTP file append only mode.
+- Add support for API users to see trace/debugging info of what is going on
+inside SFTP server.

--- a/request-server.go
+++ b/request-server.go
@@ -140,7 +140,7 @@ func (rs *RequestServer) packetWorker() error {
 			if err != nil { return err }
 			continue
 		case hasPath:
-			handle = rs.nextRequest(NewRequest(pkt.getPath()))
+			handle = rs.nextRequest(newRequest(pkt.getPath(), rs))
 		case hasHandle:
 			handle = pkt.getHandle()
 		}

--- a/request-server.go
+++ b/request-server.go
@@ -137,7 +137,11 @@ func (rs *RequestServer) packetWorker() error {
 }
 
 func cleanPath(pkt *sshFxpRealpathPacket) resp_packet {
-	cleaned_path := filepath.Clean(pkt.getPath())
+	path := pkt.getPath()
+	if !filepath.IsAbs(path) {
+		path = "/" + path // all paths are absolute
+	}
+	cleaned_path := filepath.Clean(path)
 	return &sshFxpNamePacket{
 		ID: pkt.id(),
 		NameAttrs: []sshFxpNameAttr{{

--- a/request-server.go
+++ b/request-server.go
@@ -126,16 +126,13 @@ func (rs *RequestServer) packetWorker() error {
 		switch pkt := pkt.(type) {
 		case *sshFxInitPacket:
 			rpkt = sshFxVersionPacket{sftpProtocolVersion, nil}
-		case *sshFxpOpenPacket:
-			handle = rs.nextRequest(newRequest(pkt.getPath()))
-			rpkt = sshFxpHandlePacket{pkt.id(), handle}
-		case *sshFxpOpendirPacket:
-			handle = rs.nextRequest(newRequest(pkt.getPath()))
-			rpkt = sshFxpHandlePacket{pkt.id(), handle}
 		case *sshFxpClosePacket:
 			handle = pkt.getHandle()
 			rs.closeRequest(handle)
 			rpkt = statusFromError(pkt, nil)
+		case isOpener:
+			handle = rs.nextRequest(newRequest(pkt.getPath()))
+			rpkt = sshFxpHandlePacket{pkt.id(), handle}
 		case hasPath:
 			handle = rs.nextRequest(newRequest(pkt.getPath()))
 			rpkt = rs.request(handle, pkt)

--- a/request-server.go
+++ b/request-server.go
@@ -1,0 +1,281 @@
+package sftp
+
+import (
+	"encoding"
+	"io"
+	"io/ioutil"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// Server takes the dataHandler and openHandler as arguments
+// starts up packet handlers
+// packet handlers convert packets to datas
+// call dataHandler with data
+// is done with packet/data
+//
+// dataHandler should call Handler() on data to process data and
+// reply to client
+//
+// tricky bit about reading/writing spinning up workers to handle all packets
+
+// datas using Id for switch
+// + only 1 type + const
+// - duplicates sftp prot Id
+
+// datas using data-type for switch
+// + types as types
+// + type.Handle could enforce type of arg
+// - requires dummy interface only for typing
+
+type Request struct {
+	Method   string
+	Filepath string
+	Pflags   uint32
+	Attrs    uint32
+	Target   string // for renames and sym-links
+	packet   interface{}
+}
+
+// callback method for handling requests
+type requestHandler func(Request) (interface{}, error)
+
+type handleHandler func(string) (string, error)
+
+// Server that abstracts the sftp protocol for a http request-like protocol
+type RequestServer struct {
+	// new
+	requestHandler requestHandler
+	getHandle      handleHandler
+	getPath        handleHandler
+	// same
+	serverConn
+	debugStream io.Writer
+	pktChan     chan rxPacket
+	maxTxPacket uint32
+	// handles are just file paths
+	openHandles map[string]string
+	handleCount int
+}
+
+var handles map[string]string
+
+func getHandle(path string) (string, error) {
+	handles[path] = path
+	return path, nil
+}
+
+func getPath(handle string) (string, error) {
+	if path, ok := handles[handle]; ok { return path, nil }
+	return "", errors.New("Missing handle")
+}
+
+// simple factory function
+// one server per user-session
+func NewRequestServer(handler requestHandler,
+	rwc io.ReadWriteCloser) (*RequestServer, error) {
+
+	s := &RequestServer{
+		requestHandler: handler,
+		getHandle:      getHandle,
+		getPath:        getPath,
+		serverConn: serverConn{
+			conn: conn{
+				Reader:      rwc,
+				WriteCloser: rwc,
+			},
+		},
+		debugStream: ioutil.Discard,
+		pktChan:     make(chan rxPacket, sftpServerWorkerCount),
+		openHandles: make(map[string]string),
+		maxTxPacket: 1 << 15,
+	}
+
+	return s, nil
+}
+
+// start serving requests from user session
+func (svr *RequestServer) Serve() error {
+	var wg sync.WaitGroup
+	wg.Add(sftpServerWorkerCount)
+	for i := 0; i < sftpServerWorkerCount; i++ {
+		go func() {
+			defer wg.Done()
+			if err := requestWorker(svr); err != nil {
+				svr.conn.Close() // shuts down recvPacket
+			}
+		}()
+	}
+
+	var err error
+	var pktType uint8
+	var pktBytes []byte
+	for {
+		pktType, pktBytes, err = svr.recvPacket()
+		if err != nil { break }
+		svr.pktChan <- rxPacket{fxp(pktType), pktBytes}
+	}
+
+	close(svr.pktChan) // shuts down sftpServerWorkers
+	wg.Wait()          // wait for all workers to exit
+	return err
+}
+
+// make packet
+// handle special cases
+// convert to request
+// call RequestHandler
+// send feedback
+func requestWorker(svr *RequestServer) error {
+	for p := range svr.pktChan {
+		pkt, err := makePacket(p)
+		if err != nil { return err }
+
+		var path string
+		switch pkt := pkt.(type) {
+		case *sshFxInitPacket:
+			return svr.sendPacket(sshFxVersionPacket{sftpProtocolVersion, nil})
+		case hasPath:
+			path = pkt.getPath()
+			svr.getHandle(path)
+		case hasHandle:
+			svr.getPath(pkt.getHandle())
+		}
+		request := makeRequest(pkt, path)
+		handler, err := svr.requestHandler(request)
+		if err != nil { return err }
+
+		runHandler(svr, p, handler)
+	}
+	return nil
+}
+
+func runHandler(svr *RequestServer, p, handler interface{}) error {
+	switch handler := handler.(type) {
+	case io.Reader:
+		data := make([]byte, svr.maxTxPacket)
+		n, err := handler.Read(data)
+		if err != nil && (err != io.EOF || n == 0) {
+			return svr.sendError(p.(id), err)
+		}
+	case io.Writer:
+	case FileActor:
+	case Renamer:
+	case ReadDirer:
+	}
+	return svr.sendError(p.(id), errors.New("undefined"))
+}
+
+func makeRequest(p interface{}, path string) Request {
+	request := Request{Filepath: path}
+	switch p.(type) {
+	case *sshFxpReadPacket:
+		request.Method = "Get"
+	case *sshFxpWritePacket:
+		request.Method = "Put"
+	case *sshFxpReaddirPacket:
+		request.Method = "List"
+	case *sshFxpStatPacket, *sshFxpLstatPacket, *sshFxpFstatPacket,
+		*sshFxpRealpathPacket, *sshFxpRemovePacket:
+		request.Method = "Stat"
+	case *sshFxpSetstatPacket, *sshFxpFsetstatPacket:
+		request.Method = "Setstat"
+	case *sshFxpMkdirPacket:
+		request.Method = "Mkdir"
+	case *sshFxpRmdirPacket:
+		request.Method = "Rmdir"
+	case *sshFxpRenamePacket:
+		request.Method = "Rename"
+	case *sshFxpSymlinkPacket:
+		request.Method = "Symlink"
+	case *sshFxpReadlinkPacket:
+		request.Method = "Readlink"
+	}
+	return request
+}
+
+func deadcode(p interface{}) error {
+	switch p := p.(type) {
+	// these have no point of being here
+	// but they need responding to
+	case *sshFxpClosePacket:
+	case *sshFxInitPacket:
+	case *sshFxpExtendedPacket:
+	// these need request
+	case *sshFxpStatPacket, *sshFxpLstatPacket, *sshFxpFstatPacket,
+		*sshFxpRealpathPacket, *sshFxpRemovePacket:
+	case *sshFxpMkdirPacket:
+	case *sshFxpRmdirPacket:
+	case *sshFxpRenamePacket:
+	case *sshFxpSymlinkPacket:
+	case *sshFxpReadlinkPacket:
+	case *sshFxpOpendirPacket:
+	case *sshFxpReadPacket:
+	case *sshFxpWritePacket:
+	// this is a catch all interface
+	case serverRespondablePacket:
+	default:
+		return errors.Errorf("unexpected packet type %T", p)
+	}
+	return nil
+}
+
+// all incoming packets
+type packet interface {
+	encoding.BinaryUnmarshaler
+	id() uint32
+}
+
+// take raw incoming packet data and build packet objects
+func makePacket(p rxPacket) (packet, error) {
+	var pkt packet
+	switch p.pktType {
+	case ssh_FXP_INIT:
+		pkt = &sshFxInitPacket{}
+	case ssh_FXP_LSTAT:
+		pkt = &sshFxpLstatPacket{}
+	case ssh_FXP_OPEN:
+		pkt = &sshFxpOpenPacket{}
+	case ssh_FXP_CLOSE:
+		pkt = &sshFxpClosePacket{}
+	case ssh_FXP_READ:
+		pkt = &sshFxpReadPacket{}
+	case ssh_FXP_WRITE:
+		pkt = &sshFxpWritePacket{}
+	case ssh_FXP_FSTAT:
+		pkt = &sshFxpFstatPacket{}
+	case ssh_FXP_SETSTAT:
+		pkt = &sshFxpSetstatPacket{}
+	case ssh_FXP_FSETSTAT:
+		pkt = &sshFxpFsetstatPacket{}
+	case ssh_FXP_OPENDIR:
+		pkt = &sshFxpOpendirPacket{}
+	case ssh_FXP_READDIR:
+		pkt = &sshFxpReaddirPacket{}
+	case ssh_FXP_REMOVE:
+		pkt = &sshFxpRemovePacket{}
+	case ssh_FXP_MKDIR:
+		pkt = &sshFxpMkdirPacket{}
+	case ssh_FXP_RMDIR:
+		pkt = &sshFxpRmdirPacket{}
+	case ssh_FXP_REALPATH:
+		pkt = &sshFxpRealpathPacket{}
+	case ssh_FXP_STAT:
+		pkt = &sshFxpStatPacket{}
+	case ssh_FXP_RENAME:
+		pkt = &sshFxpRenamePacket{}
+	case ssh_FXP_READLINK:
+		pkt = &sshFxpReadlinkPacket{}
+	case ssh_FXP_SYMLINK:
+		pkt = &sshFxpSymlinkPacket{}
+	case ssh_FXP_EXTENDED:
+		pkt = &sshFxpExtendedPacket{}
+	default:
+		return nil, errors.Errorf("unhandled packet type: %s", p.pktType)
+	}
+	if err := pkt.UnmarshalBinary(p.pktBytes); err != nil {
+		return nil, err
+	}
+	return pkt, nil
+}

--- a/request-server.go
+++ b/request-server.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"syscall"
 )
@@ -27,6 +28,7 @@ type RequestServer struct {
 	pktChan         chan packet
 	openRequests    map[string]*Request
 	openRequestLock sync.RWMutex
+	handleCount     int
 }
 
 // NewRequestServer creates/allocates/returns new RequestServer.
@@ -48,8 +50,10 @@ func NewRequestServer(rwc io.ReadWriteCloser, h Handlers) *RequestServer {
 func (rs *RequestServer) nextRequest(r *Request) string {
 	rs.openRequestLock.Lock()
 	defer rs.openRequestLock.Unlock()
-	rs.openRequests[r.Filepath] = r
-	return r.Filepath
+	rs.handleCount++
+	handle := strconv.Itoa(rs.handleCount)
+	rs.openRequests[handle] = r
+	return handle
 }
 
 func (rs *RequestServer) getRequest(handle string) (*Request, bool) {

--- a/request-server.go
+++ b/request-server.go
@@ -151,7 +151,8 @@ func (rs *RequestServer) packetWorker() error {
 		request, ok := rs.getRequest(handle)
 		if !ok { return rs.sendError(pkt, syscall.EBADF) }
 
-		resp := request.handleRequest(rs.Handlers, pkt)
+		request.populate(pkt)
+		resp := request.handleRequest(rs.Handlers)
 		if resp.err != nil { rs.sendError(resp.pkt, resp.err) }
 		rs.sendPacket(resp.pkt)
 	}

--- a/request-server.go
+++ b/request-server.go
@@ -69,6 +69,11 @@ func (rs *RequestServer) closeRequest(handle string) {
 	}
 }
 
+// close the read/write/closer to trigger exiting the main server loop
+func (rs *RequestServer) Close() error {
+	return rs.conn.Close()
+}
+
 // start serving requests from user session
 func (rs *RequestServer) Serve() error {
 	var wg sync.WaitGroup

--- a/request-server.go
+++ b/request-server.go
@@ -107,7 +107,7 @@ func (rs *RequestServer) packetWorker() error {
 	for pkt := range rs.pktChan {
 		// fmt.Println("Incoming Packet: ", pkt, reflect.TypeOf(pkt))
 		var handle string
-		var rpkt resp_packet
+		var rpkt responsePacket
 		var err error
 		switch pkt := pkt.(type) {
 		case *sshFxInitPacket:
@@ -138,7 +138,7 @@ func (rs *RequestServer) packetWorker() error {
 	return nil
 }
 
-func cleanPath(pkt *sshFxpRealpathPacket) resp_packet {
+func cleanPath(pkt *sshFxpRealpathPacket) responsePacket {
 	path := pkt.getPath()
 	if !filepath.IsAbs(path) {
 		path = "/" + path
@@ -155,8 +155,8 @@ func cleanPath(pkt *sshFxpRealpathPacket) resp_packet {
 	}
 }
 
-func (rs *RequestServer) request(handle string, pkt packet) resp_packet {
-	var rpkt resp_packet
+func (rs *RequestServer) request(handle string, pkt packet) responsePacket {
+	var rpkt responsePacket
 	var err error
 	if request, ok := rs.getRequest(handle); ok {
 		// called here to keep packet handling out of request for testing

--- a/request-server.go
+++ b/request-server.go
@@ -40,8 +40,8 @@ type Handlers struct {
 
 // Server that abstracts the sftp protocol for a http request-like protocol
 type RequestServer struct {
+	Handlers        *Handlers
 	serverConn
-	handlers        Handlers
 	debugStream     io.Writer
 	pktChan         chan rxPacket
 	openRequests    map[string]*Request

--- a/request-server.go
+++ b/request-server.go
@@ -70,9 +70,7 @@ func (rs *RequestServer) closeRequest(handle string) {
 }
 
 // close the read/write/closer to trigger exiting the main server loop
-func (rs *RequestServer) Close() error {
-	return rs.conn.Close()
-}
+func (rs *RequestServer) Close() error { return rs.conn.Close() }
 
 // start serving requests from user session
 func (rs *RequestServer) Serve() error {
@@ -145,8 +143,9 @@ func (rs *RequestServer) packetWorker() error {
 func cleanPath(pkt *sshFxpRealpathPacket) resp_packet {
 	path := pkt.getPath()
 	if !filepath.IsAbs(path) {
-		path = "/" + path // all paths are absolute
-	}
+		path = "/" + path
+	} // all paths are absolute
+
 	cleaned_path := filepath.Clean(path)
 	return &sshFxpNamePacket{
 		ID: pkt.id(),

--- a/request-server.go
+++ b/request-server.go
@@ -139,10 +139,20 @@ func (rs *RequestServer) packetWorker() error {
 			err := rs.sendError(pkt, nil)
 			if err != nil { return err }
 			continue
-		case hasPath:
+		case *sshFxpOpenPacket:
 			handle = rs.nextRequest(newRequest(pkt.getPath(), *rs.Handlers))
+			err := rs.sendPacket(sshFxpHandlePacket{pkt.id(), handle})
+			if err != nil { return err }
+			continue
+		case *sshFxpOpendirPacket:
+			handle = rs.nextRequest(newRequest(pkt.getPath(), *rs.Handlers))
+			err := rs.sendPacket(sshFxpHandlePacket{pkt.id(), handle})
+			if err != nil { return err }
+			continue
 		case hasHandle:
 			handle = pkt.getHandle()
+		case hasPath:
+			handle = rs.nextRequest(newRequest(pkt.getPath(), *rs.Handlers))
 		}
 		request, ok := rs.getRequest(handle)
 		if !ok { return rs.sendError(pkt, syscall.EBADF) }

--- a/request-server.go
+++ b/request-server.go
@@ -86,9 +86,13 @@ func (rs *RequestServer) Serve() error {
 	var pktBytes []byte
 	for {
 		pktType, pktBytes, err = rs.recvPacket()
-		if err != nil { break }
+		if err != nil {
+			break
+		}
 		pkt, err := makePacket(rxPacket{fxp(pktType), pktBytes})
-		if err != nil { break }
+		if err != nil {
+			break
+		}
 		rs.pktChan <- pkt
 	}
 
@@ -125,7 +129,9 @@ func (rs *RequestServer) packetWorker() error {
 
 		fmt.Println("Reply Packet: ", rpkt, reflect.TypeOf(rpkt))
 		err = rs.sendPacket(rpkt)
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -150,7 +156,11 @@ func (rs *RequestServer) request(handle string, pkt packet) resp_packet {
 		request.populate(pkt)
 		fmt.Println("Request Method: ", request.Method)
 		rpkt, err = request.handle(rs.Handlers)
-		if err != nil { rpkt = statusFromError(pkt, err) }
-	} else { rpkt = statusFromError(pkt, syscall.EBADF) }
+		if err != nil {
+			rpkt = statusFromError(pkt, err)
+		}
+	} else {
+		rpkt = statusFromError(pkt, syscall.EBADF)
+	}
 	return rpkt
 }

--- a/request-server.go
+++ b/request-server.go
@@ -151,8 +151,9 @@ func (rs *RequestServer) request(handle string, pkt packet) resp_packet {
 	var rpkt resp_packet
 	var err error
 	if request, ok := rs.getRequest(handle); ok {
+		// called here to keep packet handling out of request for testing
 		request.populate(pkt)
-		rpkt, err = request.handleRequest(rs.Handlers)
+		rpkt, err = request.handle(rs.Handlers)
 		if err != nil { rpkt = statusFromError(pkt, err) }
 	} else { rpkt = statusFromError(pkt, syscall.EBADF) }
 	return rpkt

--- a/request-server.go
+++ b/request-server.go
@@ -1,11 +1,9 @@
 package sftp
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sync"
 	"syscall"
 )
@@ -108,7 +106,7 @@ func (rs *RequestServer) Serve() error {
 
 func (rs *RequestServer) packetWorker() error {
 	for pkt := range rs.pktChan {
-		fmt.Println("Incoming Packet: ", pkt, reflect.TypeOf(pkt))
+		// fmt.Println("Incoming Packet: ", pkt, reflect.TypeOf(pkt))
 		var handle string
 		var rpkt resp_packet
 		var err error
@@ -132,7 +130,7 @@ func (rs *RequestServer) packetWorker() error {
 			rpkt = rs.request(handle, pkt)
 		}
 
-		fmt.Println("Reply Packet: ", rpkt, reflect.TypeOf(rpkt))
+		// fmt.Println("Reply Packet: ", rpkt, reflect.TypeOf(rpkt))
 		err = rs.sendPacket(rpkt)
 		if err != nil {
 			return err
@@ -164,7 +162,7 @@ func (rs *RequestServer) request(handle string, pkt packet) resp_packet {
 	if request, ok := rs.getRequest(handle); ok {
 		// called here to keep packet handling out of request for testing
 		request.populate(pkt)
-		fmt.Println("Request Method: ", request.Method)
+		// fmt.Println("Request Method: ", request.Method)
 		rpkt, err = request.handle(rs.Handlers)
 		if err != nil {
 			err = errorAdapter(err)

--- a/request-server.go
+++ b/request-server.go
@@ -31,7 +31,7 @@ type RequestServer struct {
 
 // simple factory function
 // one server per user-session
-func NewRequestServer(rwc io.ReadWriteCloser) (*RequestServer, error) {
+func NewRequestServer(rwc io.ReadWriteCloser, h Handlers) (*RequestServer, error) {
 	s := &RequestServer{
 		serverConn: serverConn{
 			conn: conn{
@@ -39,6 +39,7 @@ func NewRequestServer(rwc io.ReadWriteCloser) (*RequestServer, error) {
 				WriteCloser: rwc,
 			},
 		},
+		Handlers:     h,
 		pktChan:      make(chan packet, sftpServerWorkerCount),
 		openRequests: make(map[string]*Request),
 	}

--- a/request-server.go
+++ b/request-server.go
@@ -31,18 +31,12 @@ var maxTxPacket uint32 = 1 << 15
 
 type handleHandler func(string) string
 
-// XXX this or request.Handle???
 type Handlers struct {
-	Get     io.Reader
-	Put     io.Writer
-	FileCmd FileCmder
-	Rename  Renamer
-	ReadDir ReadDirer
-	Stat    Stater
-	SetStat SetStater
+	FileGet  FileReader
+	FilePut  FileWriter
+	FileCmd  FileCmder
+	FileInfo FileInfoer
 }
-
-/// XXX plus handlers in server struct below
 
 // Server that abstracts the sftp protocol for a http request-like protocol
 type RequestServer struct {

--- a/request-server.go
+++ b/request-server.go
@@ -50,7 +50,7 @@ type RequestServer struct {
 
 // simple factory function
 // one server per user-session
-func NewPacketServer(rwc io.ReadWriteCloser) (*RequestServer, error) {
+func NewRequestServer(rwc io.ReadWriteCloser) (*RequestServer, error) {
 	s := &RequestServer{
 		serverConn: serverConn{
 			conn: conn{
@@ -146,13 +146,6 @@ func (rs *RequestServer) packetWorker() error {
 		}
 		request, ok := rs.getRequest(handle)
 		if !ok { return rs.sendError(pkt, syscall.EBADF) }
-		// XXX need to process request + additional packets
-		// each request should have a worker to handle incoming packets
-		// worker takes packet, derives method, ..
-		// XXX then calls whatever is needed to get interface{} XXX ???
-		// takes interface, matches on it, gets output, ..
-		// converts output to packet level and sends back to client
-
 		request.pktChan <- pkt
 	}
 	return nil

--- a/request-server.go
+++ b/request-server.go
@@ -1,12 +1,10 @@
 package sftp
 
 import (
-	"encoding"
 	"io"
 	"io/ioutil"
 	"sync"
-
-	"github.com/pkg/errors"
+	"syscall"
 )
 
 // Server takes the dataHandler and openHandler as arguments
@@ -29,81 +27,83 @@ import (
 // + type.Handle could enforce type of arg
 // - requires dummy interface only for typing
 
-type Request struct {
-	Method   string
-	Filepath string
-	Pflags   uint32
-	Attrs    uint32
-	Target   string // for renames and sym-links
-	packet   interface{}
+var maxTxPacket uint32 = 1 << 15
+
+type handleHandler func(string) string
+
+// XXX this or request.Handle???
+type Handlers struct {
+	Get     io.Reader
+	Put     io.Writer
+	FileCmd FileCmder
+	Rename  Renamer
+	ReadDir ReadDirer
+	Stat    Stater
+	SetStat SetStater
 }
 
-// callback method for handling requests
-type requestHandler func(Request) (interface{}, error)
-
-type handleHandler func(string) (string, error)
+/// XXX plus handlers in server struct below
 
 // Server that abstracts the sftp protocol for a http request-like protocol
 type RequestServer struct {
-	// new
-	requestHandler requestHandler
-	getHandle      handleHandler
-	getPath        handleHandler
-	// same
 	serverConn
-	debugStream io.Writer
-	pktChan     chan rxPacket
-	maxTxPacket uint32
-	// handles are just file paths
-	openHandles map[string]string
-	handleCount int
-}
-
-var handles map[string]string
-
-func getHandle(path string) (string, error) {
-	handles[path] = path
-	return path, nil
-}
-
-func getPath(handle string) (string, error) {
-	if path, ok := handles[handle]; ok { return path, nil }
-	return "", errors.New("Missing handle")
+	handlers        Handlers
+	debugStream     io.Writer
+	pktChan         chan rxPacket
+	openRequests    map[string]*Request
+	openRequestLock sync.RWMutex
 }
 
 // simple factory function
 // one server per user-session
-func NewRequestServer(handler requestHandler,
-	rwc io.ReadWriteCloser) (*RequestServer, error) {
-
+func NewPacketServer(rwc io.ReadWriteCloser) (*RequestServer, error) {
 	s := &RequestServer{
-		requestHandler: handler,
-		getHandle:      getHandle,
-		getPath:        getPath,
 		serverConn: serverConn{
 			conn: conn{
 				Reader:      rwc,
 				WriteCloser: rwc,
 			},
 		},
-		debugStream: ioutil.Discard,
-		pktChan:     make(chan rxPacket, sftpServerWorkerCount),
-		openHandles: make(map[string]string),
-		maxTxPacket: 1 << 15,
+		debugStream:  ioutil.Discard,
+		pktChan:      make(chan rxPacket, sftpServerWorkerCount),
+		openRequests: make(map[string]*Request),
 	}
 
 	return s, nil
 }
 
+func (rs *RequestServer) nextRequest(r *Request) string {
+	rs.openRequestLock.Lock()
+	defer rs.openRequestLock.Unlock()
+	rs.openRequests[r.Filepath] = r
+	return r.Filepath
+}
+
+func (rs *RequestServer) getRequest(handle string) (*Request, bool) {
+	rs.openRequestLock.Lock()
+	defer rs.openRequestLock.Unlock()
+	r, ok := rs.openRequests[handle]
+	return r, ok
+}
+
+func (rs *RequestServer) closeRequest(handle string) {
+	rs.openRequestLock.Lock()
+	defer rs.openRequestLock.Unlock()
+	if _, ok := rs.openRequests[handle]; ok {
+		delete(rs.openRequests, handle)
+		// Do Requests need cleanup?
+	}
+}
+
 // start serving requests from user session
-func (svr *RequestServer) Serve() error {
+func (rs *RequestServer) Serve() error {
 	var wg sync.WaitGroup
 	wg.Add(sftpServerWorkerCount)
 	for i := 0; i < sftpServerWorkerCount; i++ {
 		go func() {
 			defer wg.Done()
-			if err := requestWorker(svr); err != nil {
-				svr.conn.Close() // shuts down recvPacket
+			if err := rs.packetWorker(); err != nil {
+				rs.conn.Close() // shuts down recvPacket
 			}
 		}()
 	}
@@ -112,13 +112,13 @@ func (svr *RequestServer) Serve() error {
 	var pktType uint8
 	var pktBytes []byte
 	for {
-		pktType, pktBytes, err = svr.recvPacket()
+		pktType, pktBytes, err = rs.recvPacket()
 		if err != nil { break }
-		svr.pktChan <- rxPacket{fxp(pktType), pktBytes}
+		rs.pktChan <- rxPacket{fxp(pktType), pktBytes}
 	}
 
-	close(svr.pktChan) // shuts down sftpServerWorkers
-	wg.Wait()          // wait for all workers to exit
+	close(rs.pktChan) // shuts down sftpServerWorkers
+	wg.Wait()         // wait for all workers to exit
 	return err
 }
 
@@ -127,155 +127,39 @@ func (svr *RequestServer) Serve() error {
 // convert to request
 // call RequestHandler
 // send feedback
-func requestWorker(svr *RequestServer) error {
-	for p := range svr.pktChan {
+func (rs *RequestServer) packetWorker() error {
+	for p := range rs.pktChan {
 		pkt, err := makePacket(p)
 		if err != nil { return err }
 
-		var path string
+		// handle packet specific pre-processing
+		var handle string
 		switch pkt := pkt.(type) {
 		case *sshFxInitPacket:
-			return svr.sendPacket(sshFxVersionPacket{sftpProtocolVersion, nil})
+			err := rs.sendPacket(sshFxVersionPacket{sftpProtocolVersion, nil})
+			if err != nil { return err }
+			continue
+		case *sshFxpClosePacket:
+			handle = pkt.getHandle()
+			rs.closeRequest(handle)
+			err := rs.sendError(pkt, nil)
+			if err != nil { return err }
+			continue
 		case hasPath:
-			path = pkt.getPath()
-			svr.getHandle(path)
+			handle = rs.nextRequest(NewRequest(pkt.getPath()))
 		case hasHandle:
-			svr.getPath(pkt.getHandle())
+			handle = pkt.getHandle()
 		}
-		request := makeRequest(pkt, path)
-		handler, err := svr.requestHandler(request)
-		if err != nil { return err }
+		request, ok := rs.getRequest(handle)
+		if !ok { return rs.sendError(pkt, syscall.EBADF) }
+		// XXX need to process request + additional packets
+		// each request should have a worker to handle incoming packets
+		// worker takes packet, derives method, ..
+		// XXX then calls whatever is needed to get interface{} XXX ???
+		// takes interface, matches on it, gets output, ..
+		// converts output to packet level and sends back to client
 
-		runHandler(svr, p, handler)
+		request.pktChan <- pkt
 	}
 	return nil
-}
-
-func runHandler(svr *RequestServer, p, handler interface{}) error {
-	switch handler := handler.(type) {
-	case io.Reader:
-		data := make([]byte, svr.maxTxPacket)
-		n, err := handler.Read(data)
-		if err != nil && (err != io.EOF || n == 0) {
-			return svr.sendError(p.(id), err)
-		}
-	case io.Writer:
-	case FileActor:
-	case Renamer:
-	case ReadDirer:
-	}
-	return svr.sendError(p.(id), errors.New("undefined"))
-}
-
-func makeRequest(p interface{}, path string) Request {
-	request := Request{Filepath: path}
-	switch p.(type) {
-	case *sshFxpReadPacket:
-		request.Method = "Get"
-	case *sshFxpWritePacket:
-		request.Method = "Put"
-	case *sshFxpReaddirPacket:
-		request.Method = "List"
-	case *sshFxpStatPacket, *sshFxpLstatPacket, *sshFxpFstatPacket,
-		*sshFxpRealpathPacket, *sshFxpRemovePacket:
-		request.Method = "Stat"
-	case *sshFxpSetstatPacket, *sshFxpFsetstatPacket:
-		request.Method = "Setstat"
-	case *sshFxpMkdirPacket:
-		request.Method = "Mkdir"
-	case *sshFxpRmdirPacket:
-		request.Method = "Rmdir"
-	case *sshFxpRenamePacket:
-		request.Method = "Rename"
-	case *sshFxpSymlinkPacket:
-		request.Method = "Symlink"
-	case *sshFxpReadlinkPacket:
-		request.Method = "Readlink"
-	}
-	return request
-}
-
-func deadcode(p interface{}) error {
-	switch p := p.(type) {
-	// these have no point of being here
-	// but they need responding to
-	case *sshFxpClosePacket:
-	case *sshFxInitPacket:
-	case *sshFxpExtendedPacket:
-	// these need request
-	case *sshFxpStatPacket, *sshFxpLstatPacket, *sshFxpFstatPacket,
-		*sshFxpRealpathPacket, *sshFxpRemovePacket:
-	case *sshFxpMkdirPacket:
-	case *sshFxpRmdirPacket:
-	case *sshFxpRenamePacket:
-	case *sshFxpSymlinkPacket:
-	case *sshFxpReadlinkPacket:
-	case *sshFxpOpendirPacket:
-	case *sshFxpReadPacket:
-	case *sshFxpWritePacket:
-	// this is a catch all interface
-	case serverRespondablePacket:
-	default:
-		return errors.Errorf("unexpected packet type %T", p)
-	}
-	return nil
-}
-
-// all incoming packets
-type packet interface {
-	encoding.BinaryUnmarshaler
-	id() uint32
-}
-
-// take raw incoming packet data and build packet objects
-func makePacket(p rxPacket) (packet, error) {
-	var pkt packet
-	switch p.pktType {
-	case ssh_FXP_INIT:
-		pkt = &sshFxInitPacket{}
-	case ssh_FXP_LSTAT:
-		pkt = &sshFxpLstatPacket{}
-	case ssh_FXP_OPEN:
-		pkt = &sshFxpOpenPacket{}
-	case ssh_FXP_CLOSE:
-		pkt = &sshFxpClosePacket{}
-	case ssh_FXP_READ:
-		pkt = &sshFxpReadPacket{}
-	case ssh_FXP_WRITE:
-		pkt = &sshFxpWritePacket{}
-	case ssh_FXP_FSTAT:
-		pkt = &sshFxpFstatPacket{}
-	case ssh_FXP_SETSTAT:
-		pkt = &sshFxpSetstatPacket{}
-	case ssh_FXP_FSETSTAT:
-		pkt = &sshFxpFsetstatPacket{}
-	case ssh_FXP_OPENDIR:
-		pkt = &sshFxpOpendirPacket{}
-	case ssh_FXP_READDIR:
-		pkt = &sshFxpReaddirPacket{}
-	case ssh_FXP_REMOVE:
-		pkt = &sshFxpRemovePacket{}
-	case ssh_FXP_MKDIR:
-		pkt = &sshFxpMkdirPacket{}
-	case ssh_FXP_RMDIR:
-		pkt = &sshFxpRmdirPacket{}
-	case ssh_FXP_REALPATH:
-		pkt = &sshFxpRealpathPacket{}
-	case ssh_FXP_STAT:
-		pkt = &sshFxpStatPacket{}
-	case ssh_FXP_RENAME:
-		pkt = &sshFxpRenamePacket{}
-	case ssh_FXP_READLINK:
-		pkt = &sshFxpReadlinkPacket{}
-	case ssh_FXP_SYMLINK:
-		pkt = &sshFxpSymlinkPacket{}
-	case ssh_FXP_EXTENDED:
-		pkt = &sshFxpExtendedPacket{}
-	default:
-		return nil, errors.Errorf("unhandled packet type: %s", p.pktType)
-	}
-	if err := pkt.UnmarshalBinary(p.pktBytes); err != nil {
-		return nil, err
-	}
-	return pkt, nil
 }

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -1,9 +1,10 @@
 package sftp
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func clientRequestServerPair(t *testing.T) (*Client, *RequestServer) {
@@ -12,15 +13,19 @@ func clientRequestServerPair(t *testing.T) (*Client, *RequestServer) {
 	server, err := NewRequestServer(struct {
 		io.Reader
 		io.WriteCloser
-	}{sr, sw})
-	if err != nil { t.Fatal(err) }
+	}{sr, sw}, Handlers{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	go server.Serve()
 	client, err := NewClientPipe(cr, cw)
-	if err != nil { t.Fatalf("%+v\n", err) }
+	if err != nil {
+		t.Fatalf("%+v\n", err)
+	}
 	return client, server
 }
 
-func TestPsRequestCache(t *testing.T) {
+func TestRequestCache(t *testing.T) {
 	_, rs := clientRequestServerPair(t)
 	foo := &Request{Filepath: "foo"}
 	bar := &Request{Filepath: "bar"}

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 )
 
-func clientPacketserverPair(t *testing.T) (*Client, *packetServer) {
+func clientRequestServerPair(t *testing.T) (*Client, *RequestServer) {
 	cr, sw := io.Pipe()
 	sr, cw := io.Pipe()
-	server, err := NewPacketServer(struct {
+	server, err := NewRequestServer(struct {
 		io.Reader
 		io.WriteCloser
 	}{sr, sw})
@@ -21,7 +21,7 @@ func clientPacketserverPair(t *testing.T) (*Client, *packetServer) {
 }
 
 func TestPsRequestCache(t *testing.T) {
-	_, ps := clientPacketserverPair(t)
+	_, ps := clientRequestServerPair(t)
 	foo := &Request{Filepath: "foo"}
 	bar := &Request{Filepath: "bar"}
 	ps.nextRequest(foo)

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -1,11 +1,16 @@
 package sftp
 
 import (
+	"fmt"
 	"io"
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+var _ = fmt.Print
 
 type csPair struct {
 	cli *Client
@@ -16,6 +21,10 @@ type csPair struct {
 func (cs csPair) Close() {
 	cs.svr.Close()
 	cs.cli.Close()
+}
+
+func (cs csPair) testHandler() *root {
+	return cs.svr.Handlers.FileGet.(*root)
 }
 
 func clientRequestServerPair(t *testing.T) *csPair {
@@ -60,14 +69,33 @@ func putTestFile(cli *Client, path, content string) (int, error) {
 	return 0, err
 }
 
+// needs fail check
 func TestRequestWrite(t *testing.T) {
 	p := clientRequestServerPair(t)
 	defer p.Close()
 	n, err := putTestFile(p.cli, "/foo", "hello")
-	if err != nil { t.Fatal(err) }
+	assert.Nil(t, err)
 	assert.Equal(t, 5, n)
+	r := p.testHandler()
+	f, err := r.fetch("/foo")
+	assert.Nil(t, err)
+	assert.False(t, f.isdir)
+	assert.Equal(t, f.content, []byte("hello"))
 }
 
+// needs fail check
+func TestRequestFilename(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	_, err := putTestFile(p.cli, "/foo", "hello")
+	assert.Nil(t, err)
+	r := p.testHandler()
+	f, err := r.fetch("/foo")
+	assert.Nil(t, err)
+	assert.Equal(t, f.Name(), "foo")
+}
+
+// needs fail check
 func TestRequestRead(t *testing.T) {
 	p := clientRequestServerPair(t)
 	defer p.Close()
@@ -76,10 +104,92 @@ func TestRequestRead(t *testing.T) {
 	rf, err := p.cli.Open("/foo")
 	assert.Nil(t, err)
 	defer rf.Close()
-	// defer rf.Close()
 	contents := make([]byte, 5)
 	n, err := rf.Read(contents)
 	if err != nil && err != io.EOF { t.Fatalf("err: %v", err) }
 	assert.Equal(t, 5, n)
 	assert.Equal(t, "hello", string(contents[0:5]))
+}
+
+// needs fail check
+func TestRequestOpen(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	fh, err := p.cli.Open("foo")
+	assert.Nil(t, err)
+	err = fh.Close()
+	assert.Nil(t, err)
+}
+
+// needs fail check
+func TestRequestMkdir(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	err := p.cli.Mkdir("/foo")
+	assert.Nil(t, err)
+	r := p.testHandler()
+	f, err := r.fetch("/foo")
+	assert.Nil(t, err)
+	assert.True(t, f.isdir)
+}
+
+// needs fail check
+func TestRequestRemove(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	_, err := putTestFile(p.cli, "/foo", "hello")
+	assert.Nil(t, err)
+	r := p.testHandler()
+	_, err = r.fetch("/foo")
+	assert.Nil(t, err)
+	err = p.cli.Remove("/foo")
+	assert.Nil(t, err)
+	_, err = r.fetch("/foo")
+	assert.Equal(t, err, os.ErrNotExist)
+}
+
+// needs fail check
+func TestRequestRename(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	_, err := putTestFile(p.cli, "/foo", "hello")
+	assert.Nil(t, err)
+	r := p.testHandler()
+	_, err = r.fetch("/foo")
+	assert.Nil(t, err)
+	err = p.cli.Rename("/foo", "/bar")
+	assert.Nil(t, err)
+	_, err = r.fetch("/bar")
+	assert.Nil(t, err)
+	_, err = r.fetch("/foo")
+	assert.Equal(t, err, os.ErrNotExist)
+}
+
+func TestRequestStat(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	_, err := putTestFile(p.cli, "/foo", "hello")
+	assert.Nil(t, err)
+	fi, err := p.cli.Stat("/foo")
+	assert.Equal(t, fi.Name(), "foo")
+	assert.Equal(t, fi.Size(), int64(5))
+	assert.Equal(t, fi.Mode(), os.FileMode(0644))
+	fstat := fi.Sys().(*FileStat)
+	assert.Equal(t, fstat.UID, uint32(65534))
+	assert.Equal(t, fstat.GID, uint32(65534))
+}
+
+func TestRequestStatFail(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	fi, err := p.cli.Stat("/foo")
+	assert.Nil(t, fi)
+	fmt.Println(err, reflect.TypeOf(err))
+	assert.True(t, os.IsNotExist(err))
+}
+
+// {sym,read}link and readdir left
+func TestRequest(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
 }

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -7,37 +7,79 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func clientRequestServerPair(t *testing.T) (*Client, *RequestServer) {
+type csPair struct {
+	cli *Client
+	svr *RequestServer
+}
+
+// these must be closed in order, else client.Close will hang
+func (cs csPair) Close() {
+	cs.svr.Close()
+	cs.cli.Close()
+}
+
+func clientRequestServerPair(t *testing.T) *csPair {
 	cr, sw := io.Pipe()
 	sr, cw := io.Pipe()
+	handlers := InMemHandler()
 	server, err := NewRequestServer(struct {
 		io.Reader
 		io.WriteCloser
-	}{sr, sw}, Handlers{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	}{sr, sw}, handlers)
+	if err != nil { t.Fatal(err) }
 	go server.Serve()
 	client, err := NewClientPipe(cr, cw)
-	if err != nil {
-		t.Fatalf("%+v\n", err)
-	}
-	return client, server
+	if err != nil { t.Fatalf("%+v\n", err) }
+	return &csPair{client, server}
 }
 
 func TestRequestCache(t *testing.T) {
-	_, rs := clientRequestServerPair(t)
+	p := clientRequestServerPair(t)
+	defer p.Close()
 	foo := &Request{Filepath: "foo"}
 	bar := &Request{Filepath: "bar"}
-	rs.nextRequest(foo)
-	rs.nextRequest(bar)
-	assert.Len(t, rs.openRequests, 2)
-	_foo, ok := rs.getRequest("foo")
+	p.svr.nextRequest(foo)
+	p.svr.nextRequest(bar)
+	assert.Len(t, p.svr.openRequests, 2)
+	_foo, ok := p.svr.getRequest("foo")
 	assert.Equal(t, foo, _foo)
 	assert.True(t, ok)
-	_, ok = rs.getRequest("zed")
+	_, ok = p.svr.getRequest("zed")
 	assert.False(t, ok)
-	rs.closeRequest("foo")
-	rs.closeRequest("bar")
-	assert.Len(t, rs.openRequests, 0)
+	p.svr.closeRequest("foo")
+	p.svr.closeRequest("bar")
+	assert.Len(t, p.svr.openRequests, 0)
+}
+
+func putTestFile(cli *Client, path, content string) (int, error) {
+	w, err := cli.Create(path)
+	if err == nil {
+		defer w.Close()
+		return w.Write([]byte(content))
+	}
+	return 0, err
+}
+
+func TestRequestWrite(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	n, err := putTestFile(p.cli, "/foo", "hello")
+	if err != nil { t.Fatal(err) }
+	assert.Equal(t, 5, n)
+}
+
+func TestRequestRead(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	_, err := putTestFile(p.cli, "/foo", "hello")
+	assert.Nil(t, err)
+	rf, err := p.cli.Open("/foo")
+	assert.Nil(t, err)
+	defer rf.Close()
+	// defer rf.Close()
+	contents := make([]byte, 5)
+	n, err := rf.Read(contents)
+	if err != nil && err != io.EOF { t.Fatalf("err: %v", err) }
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "hello", string(contents[0:5]))
 }

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -247,6 +248,7 @@ func TestRequestReaddir(t *testing.T) {
 	di, err := p.cli.ReadDir("/")
 	assert.Nil(t, err)
 	assert.Len(t, di, 2)
-	assert.Equal(t, di[0].Name(), "foo")
-	assert.Equal(t, di[1].Name(), "bar")
+	names := []string{di[0].Name(), di[1].Name()}
+	sort.Strings(names)
+	assert.Equal(t, []string{"bar", "foo"}, names)
 }

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -47,16 +47,16 @@ func TestRequestCache(t *testing.T) {
 	defer p.Close()
 	foo := &Request{Filepath: "foo"}
 	bar := &Request{Filepath: "bar"}
-	p.svr.nextRequest(foo)
-	p.svr.nextRequest(bar)
+	fh := p.svr.nextRequest(foo)
+	bh := p.svr.nextRequest(bar)
 	assert.Len(t, p.svr.openRequests, 2)
-	_foo, ok := p.svr.getRequest("foo")
+	_foo, ok := p.svr.getRequest(fh)
 	assert.Equal(t, foo, _foo)
 	assert.True(t, ok)
 	_, ok = p.svr.getRequest("zed")
 	assert.False(t, ok)
-	p.svr.closeRequest("foo")
-	p.svr.closeRequest("bar")
+	p.svr.closeRequest(fh)
+	p.svr.closeRequest(bh)
 	assert.Len(t, p.svr.openRequests, 0)
 }
 

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -30,13 +30,10 @@ func clientRequestServerPair(t *testing.T) *csPair {
 	cr, sw := io.Pipe()
 	sr, cw := io.Pipe()
 	handlers := InMemHandler()
-	server, err := NewRequestServer(struct {
+	server := NewRequestServer(struct {
 		io.Reader
 		io.WriteCloser
 	}{sr, sw}, handlers)
-	if err != nil {
-		t.Fatal(err)
-	}
 	go server.Serve()
 	client, err := NewClientPipe(cr, cw)
 	if err != nil {

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -1,0 +1,38 @@
+package sftp
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io"
+	"testing"
+)
+
+func clientPacketserverPair(t *testing.T) (*Client, *packetServer) {
+	cr, sw := io.Pipe()
+	sr, cw := io.Pipe()
+	server, err := NewPacketServer(struct {
+		io.Reader
+		io.WriteCloser
+	}{sr, sw})
+	if err != nil { t.Fatal(err) }
+	go server.Serve()
+	client, err := NewClientPipe(cr, cw)
+	if err != nil { t.Fatalf("%+v\n", err) }
+	return client, server
+}
+
+func TestPsRequestCache(t *testing.T) {
+	_, ps := clientPacketserverPair(t)
+	foo := &Request{Filepath: "foo"}
+	bar := &Request{Filepath: "bar"}
+	ps.nextRequest(foo)
+	ps.nextRequest(bar)
+	assert.Len(t, ps.openRequests, 2)
+	_foo, ok := ps.getRequest("foo")
+	assert.Equal(t, foo, _foo)
+	assert.True(t, ok)
+	_, ok = ps.getRequest("zed")
+	assert.False(t, ok)
+	ps.closeRequest("foo")
+	ps.closeRequest("bar")
+	assert.Len(t, ps.openRequests, 0)
+}

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -21,18 +21,18 @@ func clientRequestServerPair(t *testing.T) (*Client, *RequestServer) {
 }
 
 func TestPsRequestCache(t *testing.T) {
-	_, ps := clientRequestServerPair(t)
+	_, rs := clientRequestServerPair(t)
 	foo := &Request{Filepath: "foo"}
 	bar := &Request{Filepath: "bar"}
-	ps.nextRequest(foo)
-	ps.nextRequest(bar)
-	assert.Len(t, ps.openRequests, 2)
-	_foo, ok := ps.getRequest("foo")
+	rs.nextRequest(foo)
+	rs.nextRequest(bar)
+	assert.Len(t, rs.openRequests, 2)
+	_foo, ok := rs.getRequest("foo")
 	assert.Equal(t, foo, _foo)
 	assert.True(t, ok)
-	_, ok = ps.getRequest("zed")
+	_, ok = rs.getRequest("zed")
 	assert.False(t, ok)
-	ps.closeRequest("foo")
-	ps.closeRequest("bar")
-	assert.Len(t, ps.openRequests, 0)
+	rs.closeRequest("foo")
+	rs.closeRequest("bar")
+	assert.Len(t, rs.openRequests, 0)
 }

--- a/request.go
+++ b/request.go
@@ -33,9 +33,9 @@ func newRequest(path string) *Request {
 }
 
 // called from worker to handle packet/request
-func (r *Request) handle(handlers Handlers) (resp_packet, error) {
+func (r *Request) handle(handlers Handlers) (responsePacket, error) {
 	var err error
-	var rpkt resp_packet
+	var rpkt responsePacket
 	switch r.Method {
 	case "Get":
 		rpkt, err = fileget(handlers.FileGet, r)
@@ -50,7 +50,7 @@ func (r *Request) handle(handlers Handlers) (resp_packet, error) {
 }
 
 // wrap FileReader handler
-func fileget(h FileReader, r *Request) (resp_packet, error) {
+func fileget(h FileReader, r *Request) (responsePacket, error) {
 	if r.get_reader == nil {
 		reader, err := h.Fileread(r)
 		if err != nil {
@@ -72,7 +72,7 @@ func fileget(h FileReader, r *Request) (resp_packet, error) {
 }
 
 // wrap FileWriter handler
-func fileput(h FileWriter, r *Request) (resp_packet, error) {
+func fileput(h FileWriter, r *Request) (responsePacket, error) {
 	if r.put_writer == nil {
 		writer, err := h.Filewrite(r)
 		if err != nil {
@@ -94,7 +94,7 @@ func fileput(h FileWriter, r *Request) (resp_packet, error) {
 }
 
 // wrap FileCmder handler
-func filecmd(h FileCmder, r *Request) (resp_packet, error) {
+func filecmd(h FileCmder, r *Request) (responsePacket, error) {
 	err := h.Filecmd(r)
 	if err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func filecmd(h FileCmder, r *Request) (resp_packet, error) {
 }
 
 // wrap FileInfoer handler
-func fileinfo(h FileInfoer, r *Request) (resp_packet, error) {
+func fileinfo(h FileInfoer, r *Request) (responsePacket, error) {
 	if r.eof {
 		return nil, io.EOF
 	}

--- a/request.go
+++ b/request.go
@@ -7,12 +7,6 @@ import (
 	"syscall"
 )
 
-// response passed back to packet handling code
-type response struct {
-	pkt resp_packet
-	err error
-}
-
 type Request struct {
 	// Get, Put, SetStat, Rename, Rmdir, Mkdir, Symlink, List, Stat, Readlink
 	Method   string
@@ -36,7 +30,7 @@ func newRequest(path string) *Request {
 }
 
 // called from worker to handle packet/request
-func (r *Request) handleRequest(handlers Handlers) response {
+func (r *Request) handleRequest(handlers Handlers) (resp_packet, error) {
 	var err error
 	var rpkt resp_packet
 	switch r.Method {
@@ -49,8 +43,7 @@ func (r *Request) handleRequest(handlers Handlers) response {
 	case "List", "Stat", "Readlink":
 		rpkt, err = fileinfo(handlers.FileInfo, r)
 	}
-	if err != nil { return response{nil, err} }
-	return response{rpkt, nil}
+	return rpkt, err
 }
 
 // wrap FileReader handler

--- a/request.go
+++ b/request.go
@@ -1,0 +1,71 @@
+package sftp
+
+type Request struct {
+	Method   string
+	Filepath string
+	Pflags   uint32
+	Attrs    []byte // convert to sub-struct
+	Target   string // for renames and sym-links
+	pktChan  chan packet
+	cur_pkt  packet
+	svr      RequestServer
+}
+
+func NewRequest(path string) *Request {
+	request := &Request{Filepath: path}
+	go request.requestWorker()
+	return request
+}
+
+func (r *Request) sendError(err error) error {
+	return r.svr.sendError(r.cur_pkt, err)
+}
+
+func (r *Request) close() { close(r.pktChan) }
+
+func (r *Request) requestWorker() error {
+	for p := range r.pktChan {
+		r.populate(p)
+		r.cur_pkt = p
+	}
+	return nil
+}
+
+func (r *Request) populate(p interface{}) {
+	switch p := p.(type) {
+	case *sshFxpSetstatPacket:
+		r.Method = "Setstat"
+		r.Pflags = p.Flags
+		r.Attrs = p.Attrs.([]byte)
+	case *sshFxpFsetstatPacket:
+		r.Method = "Setstat"
+		r.Pflags = p.Flags
+		r.Attrs = p.Attrs.([]byte)
+	case *sshFxpRenamePacket:
+		r.Method = "Rename"
+		r.Target = p.Newpath
+	case *sshFxpSymlinkPacket:
+		r.Method = "Symlink"
+		r.Target = p.Linkpath
+	// below here method and path are all the data
+	case *sshFxpReaddirPacket:
+		r.Method = "List"
+	case *sshFxpStatPacket, *sshFxpLstatPacket, *sshFxpFstatPacket,
+		*sshFxpRealpathPacket, *sshFxpRemovePacket:
+		r.Method = "Stat"
+	case *sshFxpRmdirPacket:
+		r.Method = "Rmdir"
+	case *sshFxpReadlinkPacket:
+		r.Method = "Readlink"
+	// special cases
+	case *sshFxpReadPacket:
+		r.Method = "Get"
+		// data processed elsewhere
+	case *sshFxpWritePacket:
+		r.Method = "Put"
+		// data processed elsewhere
+	case *sshFxpMkdirPacket:
+		r.Method = "Mkdir"
+		// attributes are ignored in packet
+	}
+}

--- a/request.go
+++ b/request.go
@@ -36,7 +36,7 @@ func (r *Request) requestWorker() error {
 	for p := range r.pktChan {
 		r.populate(p)
 		r.cur_pkt = p
-		handlers := r.svr.handlers
+		handlers := r.svr.Handlers
 		switch r.Method {
 		case "Get":
 			return fileget(handlers.FileGet, r)

--- a/request.go
+++ b/request.go
@@ -129,7 +129,7 @@ func fileinfo(h FileInfoer, r *Request) (resp_packet, error) {
 			err = &os.PathError{"readlink", r.Filepath, syscall.ENOENT}
 			return nil, err
 		}
-		filename := filepath.Clean(r.Filepath)
+		filename := finfo[0].Name()
 		return &sshFxpNamePacket{
 			ID: r.pkt_id,
 			NameAttrs: []sshFxpNameAttr{{

--- a/request.go
+++ b/request.go
@@ -8,7 +8,8 @@ import (
 )
 
 type Request struct {
-	// Get, Put, SetStat, Rename, Rmdir, Mkdir, Symlink, List, Stat, Readlink
+	// Get, Put, SetStat, Stat, Rename, Remove
+	// Rmdir, Mkdir, List, Readlink, Symlink
 	Method   string
 	Filepath string
 	Pflags   uint32
@@ -38,7 +39,7 @@ func (r *Request) handle(handlers Handlers) (resp_packet, error) {
 		rpkt, err = fileget(handlers.FileGet, r)
 	case "Put":
 		rpkt, err = fileput(handlers.FilePut, r)
-	case "SetStat", "Rename", "Rmdir", "Mkdir", "Symlink":
+	case "SetStat", "Rename", "Rmdir", "Mkdir", "Symlink", "Remove":
 		rpkt, err = filecmd(handlers.FileCmd, r)
 	case "List", "Stat", "Readlink":
 		rpkt, err = fileinfo(handlers.FileInfo, r)

--- a/request.go
+++ b/request.go
@@ -52,7 +52,7 @@ func (r *Request) requestWorker() error {
 }
 
 func fileget(h FileReader, r *Request) error {
-	reader, err := h.Filereader(r)
+	reader, err := h.Fileread(r)
 	if err != nil { return r.sendError(syscall.EBADF) }
 	pkt, ok := r.cur_pkt.(*sshFxpReadPacket)
 	if !ok { return r.sendError(syscall.EBADF) }
@@ -68,7 +68,7 @@ func fileget(h FileReader, r *Request) error {
 	})
 }
 func fileput(h FileWriter, r *Request) error {
-	writer, err := h.Filewriter(r)
+	writer, err := h.Filewrite(r)
 	if err != nil { return r.sendError(syscall.EBADF) }
 	pkt, ok := r.cur_pkt.(*sshFxpWritePacket)
 	if !ok { return r.sendError(syscall.EBADF) }

--- a/request.go
+++ b/request.go
@@ -28,7 +28,7 @@ type Request struct {
 
 // Here mainly to specify that Filepath is required
 func newRequest(path string) *Request {
-	request := &Request{Filepath: path}
+	request := &Request{Filepath: filepath.Clean(path)}
 	return request
 }
 
@@ -158,11 +158,11 @@ func (r *Request) populate(p interface{}) {
 		r.pkt_id = p.id()
 	case *sshFxpRenamePacket:
 		r.Method = "Rename"
-		r.Target = p.Newpath
+		r.Target = filepath.Clean(p.Newpath)
 		r.pkt_id = p.id()
 	case *sshFxpSymlinkPacket:
 		r.Method = "Symlink"
-		r.Target = p.Linkpath
+		r.Target = filepath.Clean(p.Linkpath)
 		r.pkt_id = p.id()
 	case *sshFxpReadPacket:
 		r.Method = "Get"

--- a/request.go
+++ b/request.go
@@ -36,8 +36,7 @@ func newRequest(path string) *Request {
 }
 
 // called from worker to handle packet/request
-func (r *Request) handleRequest(handlers Handlers, pkt packet) response {
-	r.populate(pkt)
+func (r *Request) handleRequest(handlers Handlers) response {
 	var err error
 	var rpkt resp_packet
 	switch r.Method {

--- a/request.go
+++ b/request.go
@@ -46,6 +46,7 @@ func (r *Request) requestWorker() error {
 			return filecmd(handlers.FileCmd, r)
 		case "List", "Stat", "Readlink":
 			return fileinfo(handlers.FileInfo, r)
+		case "Open": // no-op
 		}
 	}
 	return nil
@@ -124,6 +125,7 @@ func fileinfo(h FileInfoer, r *Request) error {
 }
 
 func (r *Request) populate(p interface{}) {
+	// r.Filepath set in newRequest()
 	switch p := p.(type) {
 	case *sshFxpSetstatPacket:
 		r.Method = "Setstat"
@@ -149,6 +151,8 @@ func (r *Request) populate(p interface{}) {
 		r.Method = "Rmdir"
 	case *sshFxpReadlinkPacket:
 		r.Method = "Readlink"
+	case *sshFxpOpenPacket:
+		r.Method = "Open"
 	// special cases
 	case *sshFxpReadPacket:
 		r.Method = "Get"

--- a/request.go
+++ b/request.go
@@ -53,7 +53,6 @@ func (r *Request) requestWorker() {
 			rpkt, err = filecmd(handlers.FileCmd, r, pkt.id())
 		case "List", "Stat", "Readlink":
 			rpkt, err = fileinfo(handlers.FileInfo, r, pkt.id())
-		case "Open": // no-op
 		}
 		if err != nil { r.rspChan <- response{nil, err} }
 		r.rspChan <- response{rpkt, nil}
@@ -150,6 +149,13 @@ func (r *Request) populate(p interface{}) {
 	case *sshFxpSymlinkPacket:
 		r.Method = "Symlink"
 		r.Target = p.Linkpath
+	case *sshFxpReadPacket:
+		r.Method = "Get"
+		r.length = p.Len
+	case *sshFxpWritePacket:
+		r.Method = "Put"
+		r.data = p.Data
+		r.length = p.Length
 	// below here method and path are all the data
 	case *sshFxpReaddirPacket:
 		r.Method = "List"
@@ -160,15 +166,7 @@ func (r *Request) populate(p interface{}) {
 		r.Method = "Rmdir"
 	case *sshFxpReadlinkPacket:
 		r.Method = "Readlink"
-	case *sshFxpOpenPacket:
-		r.Method = "Open"
 	// special cases
-	case *sshFxpReadPacket:
-		r.Method = "Get"
-		// data processed elsewhere
-	case *sshFxpWritePacket:
-		r.Method = "Put"
-		// data processed elsewhere
 	case *sshFxpMkdirPacket:
 		r.Method = "Mkdir"
 		//r.Attrs are ignored in ./packet.go

--- a/request.go
+++ b/request.go
@@ -13,7 +13,6 @@ type Request struct {
 	// Rmdir, Mkdir, List, Readlink, Symlink
 	Method   string
 	Filepath string
-	Pflags   uint32
 	Attrs    []byte // convert to sub-struct
 	Target   string // for renames and sym-links
 	// packet data
@@ -39,7 +38,7 @@ func (r *Request) handle(handlers Handlers) (resp_packet, error) {
 	switch r.Method {
 	case "Get":
 		rpkt, err = fileget(handlers.FileGet, r)
-	case "Put":
+	case "Put": // add "Append" to this to handle append only file writes
 		rpkt, err = fileput(handlers.FilePut, r)
 	case "SetStat", "Rename", "Rmdir", "Mkdir", "Symlink", "Remove":
 		rpkt, err = filecmd(handlers.FileCmd, r)
@@ -148,12 +147,10 @@ func (r *Request) populate(p interface{}) {
 	switch p := p.(type) {
 	case *sshFxpSetstatPacket:
 		r.Method = "Setstat"
-		r.Pflags = p.Flags
 		r.Attrs = p.Attrs.([]byte)
 		r.pkt_id = p.id()
 	case *sshFxpFsetstatPacket:
 		r.Method = "Setstat"
-		r.Pflags = p.Flags
 		r.Attrs = p.Attrs.([]byte)
 		r.pkt_id = p.id()
 	case *sshFxpRenamePacket:

--- a/request.go
+++ b/request.go
@@ -22,6 +22,7 @@ type Request struct {
 	// reader/writer from handlers
 	put_writer io.Writer
 	get_reader io.Reader
+	eof        bool // hack for readdir to keep eof state
 }
 
 // Here mainly to specify that Filepath is required
@@ -96,6 +97,7 @@ func filecmd(h FileCmder, r *Request) (resp_packet, error) {
 
 // wrap FileInfoer handler
 func fileinfo(h FileInfoer, r *Request) (resp_packet, error) {
+	if r.eof { return nil, io.EOF }
 	finfo, err := h.Fileinfo(r)
 	if err != nil { return nil, err }
 
@@ -110,6 +112,7 @@ func fileinfo(h FileInfoer, r *Request) (resp_packet, error) {
 				Attrs:    []interface{}{fi},
 			})
 		}
+		r.eof = true
 		return ret, nil
 	case "Stat":
 		if len(finfo) == 0 {

--- a/request.go
+++ b/request.go
@@ -30,7 +30,7 @@ func newRequest(path string) *Request {
 }
 
 // called from worker to handle packet/request
-func (r *Request) handleRequest(handlers Handlers) (resp_packet, error) {
+func (r *Request) handle(handlers Handlers) (resp_packet, error) {
 	var err error
 	var rpkt resp_packet
 	switch r.Method {

--- a/request.go
+++ b/request.go
@@ -29,11 +29,13 @@ type Request struct {
 	get_reader io.Reader
 }
 
+// Here mainly to specify that Filepath is required
 func newRequest(path string) *Request {
 	request := &Request{Filepath: path}
 	return request
 }
 
+// called from worker to handle packet/request
 func (r *Request) handleRequest(handlers Handlers, pkt packet) response {
 	r.populate(pkt)
 	var err error
@@ -52,6 +54,7 @@ func (r *Request) handleRequest(handlers Handlers, pkt packet) response {
 	return response{rpkt, nil}
 }
 
+// wrap FileReader handler
 func fileget(h FileReader, r *Request) (resp_packet, error) {
 	if r.get_reader == nil {
 		reader, err := h.Fileread(r)
@@ -68,6 +71,8 @@ func fileget(h FileReader, r *Request) (resp_packet, error) {
 		Data:   r.data[:n],
 	}, nil
 }
+
+// wrap FileWriter handler
 func fileput(h FileWriter, r *Request) (resp_packet, error) {
 	if r.put_writer == nil {
 		writer, err := h.Filewrite(r)
@@ -84,6 +89,8 @@ func fileput(h FileWriter, r *Request) (resp_packet, error) {
 			Code: ssh_FX_OK,
 		}}, nil
 }
+
+// wrap FileCmder handler
 func filecmd(h FileCmder, r *Request) (resp_packet, error) {
 	err := h.Filecmd(r)
 	if err != nil { return nil, err }
@@ -93,6 +100,8 @@ func filecmd(h FileCmder, r *Request) (resp_packet, error) {
 			Code: ssh_FX_OK,
 		}}, nil
 }
+
+// wrap FileInfoer handler
 func fileinfo(h FileInfoer, r *Request) (resp_packet, error) {
 	finfo, err := h.Fileinfo(r)
 	if err != nil { return nil, err }
@@ -134,8 +143,9 @@ func fileinfo(h FileInfoer, r *Request) (resp_packet, error) {
 	return nil, err
 }
 
+// populate attributes of request object from packet data
 func (r *Request) populate(p interface{}) {
-	// r.Filepath set in newRequest()
+	// r.Filepath should be set in newRequest()
 	switch p := p.(type) {
 	case *sshFxpSetstatPacket:
 		r.Method = "Setstat"

--- a/request.go
+++ b/request.go
@@ -13,9 +13,8 @@ type response struct {
 	err error
 }
 
-// Valid Method values:
-// Get, Put, SetStat, Rename, Rmdir, Mkdir, Symlink, List, Stat, Readlink
 type Request struct {
+	// Get, Put, SetStat, Rename, Rmdir, Mkdir, Symlink, List, Stat, Readlink
 	Method   string
 	Filepath string
 	Pflags   uint32
@@ -25,11 +24,11 @@ type Request struct {
 	length   uint32
 	pktChan  chan packet
 	rspChan  chan response
-	svr      *RequestServer
+	handlers Handlers
 }
 
-func newRequest(path string, svr *RequestServer) *Request {
-	request := &Request{Filepath: path, svr: svr}
+func newRequest(path string, handlers Handlers) *Request {
+	request := &Request{Filepath: path, handlers: handlers}
 	go request.requestWorker()
 	return request
 }
@@ -42,7 +41,7 @@ func (r *Request) close() {
 func (r *Request) requestWorker() {
 	for pkt := range r.pktChan {
 		r.populate(pkt)
-		handlers := r.svr.Handlers
+		handlers := r.handlers
 		var err error
 		var rpkt resp_packet
 		switch r.Method {

--- a/request.go
+++ b/request.go
@@ -1,5 +1,14 @@
 package sftp
 
+import (
+	"io"
+	"os"
+	"path"
+	"syscall"
+)
+
+// Valid Method values:
+// Get, Put, SetStat, Rename, Rmdir, Mkdir, Symlink, List, Stat, Readlink
 type Request struct {
 	Method   string
 	Filepath string
@@ -8,11 +17,11 @@ type Request struct {
 	Target   string // for renames and sym-links
 	pktChan  chan packet
 	cur_pkt  packet
-	svr      RequestServer
+	svr      *RequestServer
 }
 
-func NewRequest(path string) *Request {
-	request := &Request{Filepath: path}
+func newRequest(path string, svr *RequestServer) *Request {
+	request := &Request{Filepath: path, svr: svr}
 	go request.requestWorker()
 	return request
 }
@@ -27,8 +36,91 @@ func (r *Request) requestWorker() error {
 	for p := range r.pktChan {
 		r.populate(p)
 		r.cur_pkt = p
+		handlers := r.svr.handlers
+		switch r.Method {
+		case "Get":
+			return fileget(handlers.FileGet, r)
+		case "Put":
+			return fileput(handlers.FilePut, r)
+		case "SetStat", "Rename", "Rmdir", "Mkdir", "Symlink":
+			return filecmd(handlers.FileCmd, r)
+		case "List", "Stat", "Readlink":
+			return fileinfo(handlers.FileInfo, r)
+		}
 	}
 	return nil
+}
+
+func fileget(h FileReader, r *Request) error {
+	reader, err := h.Filereader(r)
+	if err != nil { return r.sendError(syscall.EBADF) }
+	pkt, ok := r.cur_pkt.(*sshFxpReadPacket)
+	if !ok { return r.sendError(syscall.EBADF) }
+	data := make([]byte, clamp(pkt.Len, maxTxPacket))
+	n, err := reader.Read(data)
+	if err != nil && (err != io.EOF || n == 0) {
+		return r.sendError(err)
+	}
+	return r.svr.sendPacket(sshFxpDataPacket{
+		ID:     pkt.ID,
+		Length: uint32(n),
+		Data:   data[:n],
+	})
+}
+func fileput(h FileWriter, r *Request) error {
+	writer, err := h.Filewriter(r)
+	if err != nil { return r.sendError(syscall.EBADF) }
+	pkt, ok := r.cur_pkt.(*sshFxpWritePacket)
+	if !ok { return r.sendError(syscall.EBADF) }
+	_, err = writer.Write(pkt.Data)
+	return r.sendError(err)
+}
+func filecmd(h FileCmder, r *Request) error {
+	err := h.Filecmd(r)
+	return r.sendError(err)
+}
+func fileinfo(h FileInfoer, r *Request) error {
+	finfo, err := h.Fileinfo(r)
+	if err != nil { return r.sendError(err) }
+
+	p, ok := r.cur_pkt.(packet)
+	if !ok { return r.sendError(syscall.EBADF) }
+
+	switch r.Method {
+	case "List":
+		dirname := path.Base(r.Filepath)
+		ret := sshFxpNamePacket{ID: p.id()}
+		for _, fi := range finfo {
+			ret.NameAttrs = append(ret.NameAttrs, sshFxpNameAttr{
+				Name:     fi.Name(),
+				LongName: runLs(dirname, fi),
+				Attrs:    []interface{}{fi},
+			})
+		}
+	case "Stat":
+		if len(finfo) == 0 {
+			err = &os.PathError{"stat", r.Filepath, syscall.ENOENT}
+			return r.sendError(err)
+		}
+		return r.svr.sendPacket(sshFxpStatResponse{
+			ID:   p.id(),
+			info: finfo[0],
+		})
+	case "Readlink":
+		if len(finfo) == 0 {
+			err = &os.PathError{"readlink", r.Filepath, syscall.ENOENT}
+			return r.sendError(err)
+		}
+		return r.svr.sendPacket(sshFxpNamePacket{
+			ID: p.id(),
+			NameAttrs: []sshFxpNameAttr{{
+				Name:     finfo[0].Name(),
+				LongName: finfo[0].Name(),
+				Attrs:    emptyFileStat,
+			}},
+		})
+	}
+	return r.sendError(err)
 }
 
 func (r *Request) populate(p interface{}) {
@@ -66,6 +158,6 @@ func (r *Request) populate(p interface{}) {
 		// data processed elsewhere
 	case *sshFxpMkdirPacket:
 		r.Method = "Mkdir"
-		// attributes are ignored in packet
+		//r.Attrs are ignored in ./packet.go
 	}
 }

--- a/request.go
+++ b/request.go
@@ -131,7 +131,8 @@ func fileinfo(h FileInfoer, r *Request) (responsePacket, error) {
 		return ret, nil
 	case "Stat":
 		if len(finfo) == 0 {
-			err = &os.PathError{"stat", r.Filepath, syscall.ENOENT}
+			err = &os.PathError{Op: "stat", Path: r.Filepath,
+				Err: syscall.ENOENT}
 			return nil, err
 		}
 		return &sshFxpStatResponse{
@@ -140,7 +141,8 @@ func fileinfo(h FileInfoer, r *Request) (responsePacket, error) {
 		}, nil
 	case "Readlink":
 		if len(finfo) == 0 {
-			err = &os.PathError{"readlink", r.Filepath, syscall.ENOENT}
+			err = &os.PathError{Op: "readlink", Path: r.Filepath,
+				Err: syscall.ENOENT}
 			return nil, err
 		}
 		filename := finfo[0].Name()

--- a/request_test.go
+++ b/request_test.go
@@ -18,26 +18,38 @@ type testHandler struct {
 }
 
 func (t *testHandler) Fileread(r *Request) (io.Reader, error) {
-	if t.err != nil { return nil, t.err }
+	if t.err != nil {
+		return nil, t.err
+	}
 	return strings.NewReader(t.filecontents), nil
 }
 
 func (t *testHandler) Filewrite(r *Request) (io.Writer, error) {
-	if t.err != nil { return nil, t.err }
+	if t.err != nil {
+		return nil, t.err
+	}
 	return io.Writer(t.output), nil
 }
 
 func (t *testHandler) Filecmd(r *Request) error {
-	if t.err != nil { return t.err }
+	if t.err != nil {
+		return t.err
+	}
 	return nil
 }
 
 func (t *testHandler) Fileinfo(r *Request) ([]os.FileInfo, error) {
-	if t.err != nil { return nil, t.err }
+	if t.err != nil {
+		return nil, t.err
+	}
 	f, err := os.Open(r.Filepath)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	fi, err := f.Stat()
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return []os.FileInfo{fi}, nil
 }
 
@@ -87,7 +99,7 @@ func statusOk(t *testing.T, p interface{}) {
 	}
 }
 
-func TestGetMethod(t *testing.T) {
+func TestRequestGet(t *testing.T) {
 	handlers := newTestHandlers()
 	request := testRequest("Get")
 	// req.length is 4, so we test reads in 4 byte chunks
@@ -100,7 +112,7 @@ func TestGetMethod(t *testing.T) {
 	}
 }
 
-func TestPutMethod(t *testing.T) {
+func TestRequestPut(t *testing.T) {
 	handlers := newTestHandlers()
 	request := testRequest("Put")
 	pkt, err := request.handle(handlers)
@@ -109,7 +121,7 @@ func TestPutMethod(t *testing.T) {
 	statusOk(t, pkt)
 }
 
-func TestCmdrMethod(t *testing.T) {
+func TestRequestCmdr(t *testing.T) {
 	handlers := newTestHandlers()
 	request := testRequest("Mkdir")
 	pkt, err := request.handle(handlers)
@@ -122,9 +134,9 @@ func TestCmdrMethod(t *testing.T) {
 	assert.Equal(t, err, testError)
 }
 
-func TestInfoListMethod(t *testing.T)     { testInfoMethod(t, "List") }
-func TestInfoReadlinkMethod(t *testing.T) { testInfoMethod(t, "Readlink") }
-func TestInfoStatMethod(t *testing.T) {
+func TestRequestInfoList(t *testing.T)     { testInfoMethod(t, "List") }
+func TestRequestInfoReadlink(t *testing.T) { testInfoMethod(t, "Readlink") }
+func TestRequestInfoStat(t *testing.T) {
 	handlers := newTestHandlers()
 	request := testRequest("Stat")
 	pkt, err := request.handle(handlers)

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,145 @@
+package sftp
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+type testHandler struct {
+	filecontents string    // dummy contents
+	output       io.Writer // dummy file out
+	err          error     // dummy error, should be file related
+}
+
+func (t *testHandler) Fileread(r *Request) (io.Reader, error) {
+	if t.err != nil { return nil, t.err }
+	return strings.NewReader(t.filecontents), nil
+}
+
+func (t *testHandler) Filewrite(r *Request) (io.Writer, error) {
+	if t.err != nil { return nil, t.err }
+	return io.Writer(t.output), nil
+}
+
+func (t *testHandler) Filecmd(r *Request) error {
+	if t.err != nil { return t.err }
+	return nil
+}
+
+func (t *testHandler) Fileinfo(r *Request) ([]os.FileInfo, error) {
+	if t.err != nil { return nil, t.err }
+	f, err := os.Open(r.Filepath)
+	if err != nil { return nil, err }
+	fi, err := f.Stat()
+	if err != nil { return nil, err }
+	return []os.FileInfo{fi}, nil
+}
+
+func testRequest(method string) *Request {
+	return &Request{
+		Filepath: "./request_test.go",
+		Method:   method,
+		Pflags:   1,
+		Attrs:    []byte("foo"),
+		Target:   "foo",
+		pkt_id:   1,
+		data:     []byte("file-data."),
+		length:   5,
+	}
+}
+
+func newTestHandlers() Handlers {
+	handler := &testHandler{
+		filecontents: "file-data.",
+		output:       bytes.NewBuffer([]byte{}),
+		err:          nil,
+	}
+	return Handlers{
+		FileGet:  handler,
+		FilePut:  handler,
+		FileCmd:  handler,
+		FileInfo: handler,
+	}
+}
+
+func (h Handlers) getOut() *bytes.Buffer {
+	handler := h.FilePut.(*testHandler)
+	return handler.output.(*bytes.Buffer)
+}
+
+var testError = errors.New("test error")
+
+func (h *Handlers) returnError() {
+	handler := h.FilePut.(*testHandler)
+	handler.err = testError
+}
+
+func statusOk(t *testing.T, p interface{}) {
+	if pkt, ok := p.(*sshFxpStatusPacket); ok {
+		assert.Equal(t, pkt.id(), uint32(1))
+		assert.Equal(t, pkt.StatusError.Code, uint32(ssh_FX_OK))
+	}
+}
+
+func TestGetMethod(t *testing.T) {
+	handlers := newTestHandlers()
+	request := testRequest("Get")
+	// req.length is 4, so we test reads in 4 byte chunks
+	for _, txt := range []string{"file-", "data."} {
+		resp := request.handleRequest(handlers)
+		assert.Nil(t, resp.err)
+		pkt := resp.pkt.(*sshFxpDataPacket)
+		assert.Equal(t, pkt.id(), uint32(1))
+		assert.Equal(t, string(pkt.Data), txt)
+	}
+}
+
+func TestPutMethod(t *testing.T) {
+	handlers := newTestHandlers()
+	request := testRequest("Put")
+	resp := request.handleRequest(handlers)
+	assert.Nil(t, resp.err)
+	assert.Equal(t, handlers.getOut().String(), "file-data.")
+	statusOk(t, resp.pkt)
+}
+
+func TestCmdrMethod(t *testing.T) {
+	handlers := newTestHandlers()
+	request := testRequest("Mkdir")
+	resp := request.handleRequest(handlers)
+	assert.Nil(t, resp.err)
+	statusOk(t, resp.pkt)
+
+	handlers.returnError()
+	resp = request.handleRequest(handlers)
+	assert.Nil(t, resp.pkt)
+	assert.Equal(t, resp.err, testError)
+}
+
+func TestInfoListMethod(t *testing.T)     { testInfoMethod(t, "List") }
+func TestInfoReadlinkMethod(t *testing.T) { testInfoMethod(t, "Readlink") }
+func TestInfoStatMethod(t *testing.T) {
+	handlers := newTestHandlers()
+	request := testRequest("Stat")
+	resp := request.handleRequest(handlers)
+	assert.Nil(t, resp.err)
+	pkt := resp.pkt.(*sshFxpStatResponse)
+	assert.Equal(t, pkt.info.Name(), "request_test.go")
+}
+
+func testInfoMethod(t *testing.T, method string) {
+	handlers := newTestHandlers()
+	request := testRequest(method)
+	resp := request.handleRequest(handlers)
+	assert.Nil(t, resp.err)
+	pkt, ok := resp.pkt.(*sshFxpNamePacket)
+	assert.True(t, ok)
+	assert.IsType(t, sshFxpNameAttr{}, pkt.NameAttrs[0])
+	assert.Equal(t, pkt.NameAttrs[0].Name, "request_test.go")
+}

--- a/request_test.go
+++ b/request_test.go
@@ -84,11 +84,11 @@ func (h Handlers) getOut() *bytes.Buffer {
 	return handler.output.(*bytes.Buffer)
 }
 
-var testError = errors.New("test error")
+var errTest = errors.New("test error")
 
 func (h *Handlers) returnError() {
 	handler := h.FilePut.(*testHandler)
-	handler.err = testError
+	handler.err = errTest
 }
 
 func statusOk(t *testing.T, p interface{}) {
@@ -130,7 +130,7 @@ func TestRequestCmdr(t *testing.T) {
 	handlers.returnError()
 	pkt, err = request.handle(handlers)
 	assert.Nil(t, pkt)
-	assert.Equal(t, err, testError)
+	assert.Equal(t, err, errTest)
 }
 
 func TestRequestInfoList(t *testing.T)     { testInfoMethod(t, "List") }

--- a/request_test.go
+++ b/request_test.go
@@ -92,34 +92,34 @@ func TestGetMethod(t *testing.T) {
 	request := testRequest("Get")
 	// req.length is 4, so we test reads in 4 byte chunks
 	for _, txt := range []string{"file-", "data."} {
-		resp := request.handleRequest(handlers)
-		assert.Nil(t, resp.err)
-		pkt := resp.pkt.(*sshFxpDataPacket)
-		assert.Equal(t, pkt.id(), uint32(1))
-		assert.Equal(t, string(pkt.Data), txt)
+		pkt, err := request.handleRequest(handlers)
+		assert.Nil(t, err)
+		dpkt := pkt.(*sshFxpDataPacket)
+		assert.Equal(t, dpkt.id(), uint32(1))
+		assert.Equal(t, string(dpkt.Data), txt)
 	}
 }
 
 func TestPutMethod(t *testing.T) {
 	handlers := newTestHandlers()
 	request := testRequest("Put")
-	resp := request.handleRequest(handlers)
-	assert.Nil(t, resp.err)
+	pkt, err := request.handleRequest(handlers)
+	assert.Nil(t, err)
 	assert.Equal(t, handlers.getOut().String(), "file-data.")
-	statusOk(t, resp.pkt)
+	statusOk(t, pkt)
 }
 
 func TestCmdrMethod(t *testing.T) {
 	handlers := newTestHandlers()
 	request := testRequest("Mkdir")
-	resp := request.handleRequest(handlers)
-	assert.Nil(t, resp.err)
-	statusOk(t, resp.pkt)
+	pkt, err := request.handleRequest(handlers)
+	assert.Nil(t, err)
+	statusOk(t, pkt)
 
 	handlers.returnError()
-	resp = request.handleRequest(handlers)
-	assert.Nil(t, resp.pkt)
-	assert.Equal(t, resp.err, testError)
+	pkt, err = request.handleRequest(handlers)
+	assert.Nil(t, pkt)
+	assert.Equal(t, err, testError)
 }
 
 func TestInfoListMethod(t *testing.T)     { testInfoMethod(t, "List") }
@@ -127,19 +127,19 @@ func TestInfoReadlinkMethod(t *testing.T) { testInfoMethod(t, "Readlink") }
 func TestInfoStatMethod(t *testing.T) {
 	handlers := newTestHandlers()
 	request := testRequest("Stat")
-	resp := request.handleRequest(handlers)
-	assert.Nil(t, resp.err)
-	pkt := resp.pkt.(*sshFxpStatResponse)
-	assert.Equal(t, pkt.info.Name(), "request_test.go")
+	pkt, err := request.handleRequest(handlers)
+	assert.Nil(t, err)
+	spkt := pkt.(*sshFxpStatResponse)
+	assert.Equal(t, spkt.info.Name(), "request_test.go")
 }
 
 func testInfoMethod(t *testing.T, method string) {
 	handlers := newTestHandlers()
 	request := testRequest(method)
-	resp := request.handleRequest(handlers)
-	assert.Nil(t, resp.err)
-	pkt, ok := resp.pkt.(*sshFxpNamePacket)
+	pkt, err := request.handleRequest(handlers)
+	assert.Nil(t, err)
+	npkt, ok := pkt.(*sshFxpNamePacket)
 	assert.True(t, ok)
-	assert.IsType(t, sshFxpNameAttr{}, pkt.NameAttrs[0])
-	assert.Equal(t, pkt.NameAttrs[0].Name, "request_test.go")
+	assert.IsType(t, sshFxpNameAttr{}, npkt.NameAttrs[0])
+	assert.Equal(t, npkt.NameAttrs[0].Name, "request_test.go")
 }

--- a/request_test.go
+++ b/request_test.go
@@ -57,7 +57,6 @@ func testRequest(method string) *Request {
 	return &Request{
 		Filepath: "./request_test.go",
 		Method:   method,
-		Pflags:   1,
 		Attrs:    []byte("foo"),
 		Target:   "foo",
 		pkt_id:   1,

--- a/request_test.go
+++ b/request_test.go
@@ -92,7 +92,7 @@ func TestGetMethod(t *testing.T) {
 	request := testRequest("Get")
 	// req.length is 4, so we test reads in 4 byte chunks
 	for _, txt := range []string{"file-", "data."} {
-		pkt, err := request.handleRequest(handlers)
+		pkt, err := request.handle(handlers)
 		assert.Nil(t, err)
 		dpkt := pkt.(*sshFxpDataPacket)
 		assert.Equal(t, dpkt.id(), uint32(1))
@@ -103,7 +103,7 @@ func TestGetMethod(t *testing.T) {
 func TestPutMethod(t *testing.T) {
 	handlers := newTestHandlers()
 	request := testRequest("Put")
-	pkt, err := request.handleRequest(handlers)
+	pkt, err := request.handle(handlers)
 	assert.Nil(t, err)
 	assert.Equal(t, handlers.getOut().String(), "file-data.")
 	statusOk(t, pkt)
@@ -112,12 +112,12 @@ func TestPutMethod(t *testing.T) {
 func TestCmdrMethod(t *testing.T) {
 	handlers := newTestHandlers()
 	request := testRequest("Mkdir")
-	pkt, err := request.handleRequest(handlers)
+	pkt, err := request.handle(handlers)
 	assert.Nil(t, err)
 	statusOk(t, pkt)
 
 	handlers.returnError()
-	pkt, err = request.handleRequest(handlers)
+	pkt, err = request.handle(handlers)
 	assert.Nil(t, pkt)
 	assert.Equal(t, err, testError)
 }
@@ -127,7 +127,7 @@ func TestInfoReadlinkMethod(t *testing.T) { testInfoMethod(t, "Readlink") }
 func TestInfoStatMethod(t *testing.T) {
 	handlers := newTestHandlers()
 	request := testRequest("Stat")
-	pkt, err := request.handleRequest(handlers)
+	pkt, err := request.handle(handlers)
 	assert.Nil(t, err)
 	spkt := pkt.(*sshFxpStatResponse)
 	assert.Equal(t, spkt.info.Name(), "request_test.go")
@@ -136,7 +136,7 @@ func TestInfoStatMethod(t *testing.T) {
 func testInfoMethod(t *testing.T, method string) {
 	handlers := newTestHandlers()
 	request := testRequest(method)
-	pkt, err := request.handleRequest(handlers)
+	pkt, err := request.handle(handlers)
 	assert.Nil(t, err)
 	npkt, ok := pkt.(*sshFxpNamePacket)
 	assert.True(t, ok)


### PR DESCRIPTION
Related ticket: #95 

This PR contains a request based API for extending the SFTP server with arbitrary backends. It was inspired by a mix of the net/http package and the linux inotify system. No existing code is touched, this only adds new code. This required a bit of duplication in places, but I wanted to leave the existing code as is. I specifically tried to make the Handlers code not into a general filesystem abstraction. It is very specific to the SFTP protocol and tries to be lightweight (with 4, 1 method interfaces).

It is mostly done including at least some documentation, examples, and tests. The files are all named starting with "request" as well as ./examples/request-server/main.go. The public method to create the new server is in request-server.go as are the worker threads, so it is a good place to start working through the code. The request-readme.md contains the initial docs which hopefully introduces how it is supposed to work.

If there are any changes you'd like to see or questions you have please let me know. Thanks.