### PR TITLE
client: satisfy go vet

### DIFF
--- a/client.go
+++ b/client.go
@@ -490,18 +490,13 @@ func (c *Client) Join(elem ...string) string { return path.Join(elem...) }
 // is not empty.
 func (c *Client) Remove(path string) error {
 	err := c.removeFile(path)
-	switch err := err.(type) {
-	case *StatusError:
+	if err, ok := err.(*StatusError); ok {
 		switch err.Code {
 		// some servers, *cough* osx *cough*, return EPERM, not ENODIR.
 		// serv-u returns ssh_FX_FILE_IS_A_DIRECTORY
 		case ssh_FX_PERMISSION_DENIED, ssh_FX_FAILURE, ssh_FX_FILE_IS_A_DIRECTORY:
 			return c.removeDirectory(path)
-		default:
-			return err
 		}
-	default:
-		return err
 	}
 	return err
 }


### PR DESCRIPTION
The specific issue was:
```
client.go:506: unreachable code
```

There's one additional `vet` issue:
```
example_test.go:13: Example should be niladic
```
but I'm not sure how that one ought to be fixed