### PR TITLE
misc test fixes recommended by `go vet`

### DIFF
--- a/client_integration_linux_test.go
+++ b/client_integration_linux_test.go
@@ -29,14 +29,14 @@ func TestClientStatVFS(t *testing.T) {
 
 	// check some stats
 	if vfs.Frsize != uint64(s.Frsize) {
-		t.Fatal("fr_size does not match, expected: %v, got: %v", s.Frsize, vfs.Frsize)
+		t.Fatalf("fr_size does not match, expected: %v, got: %v", s.Frsize, vfs.Frsize)
 	}
 
 	if vfs.Bsize != uint64(s.Bsize) {
-		t.Fatal("f_bsize does not match, expected: %v, got: %v", s.Bsize, vfs.Bsize)
+		t.Fatalf("f_bsize does not match, expected: %v, got: %v", s.Bsize, vfs.Bsize)
 	}
 
 	if vfs.Namemax != uint64(s.Namelen) {
-		t.Fatal("f_namemax does not match, expected: %v, got: %v", s.Namelen, vfs.Namemax)
+		t.Fatalf("f_namemax does not match, expected: %v, got: %v", s.Namelen, vfs.Namemax)
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -10,7 +10,9 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func Example(conn *ssh.Client) {
+func Example() {
+	var conn *ssh.Client
+
 	// open an SFTP session over an existing ssh connection.
 	sftp, err := sftp.NewClient(conn)
 	if err != nil {


### PR DESCRIPTION
**Before**

```
client_integration_linux_test.go:32: possible formatting directive in Fatal call
client_integration_linux_test.go:36: possible formatting directive in Fatal call
client_integration_linux_test.go:40: possible formatting directive in Fatal call
exit status 1
example_test.go:13: Example should be niladic
exit status 1
```

The `Fatal` vs. `Fatalf` calls are trivial fixes. The Example function change is needed because godoc will ignore parameters to Example functions (see https://godoc.org/github.com/pkg/sftp#ex-package)
