### PR TITLE
Make remove directory public

### DIFF
--- a/client.go
+++ b/client.go
@@ -495,7 +495,7 @@ func (c *Client) Remove(path string) error {
 		// some servers, *cough* osx *cough*, return EPERM, not ENODIR.
 		// serv-u returns ssh_FX_FILE_IS_A_DIRECTORY
 		case ssh_FX_PERMISSION_DENIED, ssh_FX_FAILURE, ssh_FX_FILE_IS_A_DIRECTORY:
-			return c.removeDirectory(path)
+			return c.RemoveDirectory(path)
 		}
 	}
 	return err
@@ -518,7 +518,8 @@ func (c *Client) removeFile(path string) error {
 	}
 }
 
-func (c *Client) removeDirectory(path string) error {
+// RemoveDirectory removes a directory path.
+func (c *Client) RemoveDirectory(path string) error {
 	id := c.nextID()
 	typ, data, err := c.sendPacket(sshFxpRmdirPacket{
 		ID:   id,


### PR DESCRIPTION
This addresses #146, after further investigation whatever server I'm dealing with (I think it's a GlobalScape something or other), I do not get an sftp.StatusError back, just a string error stating "file does not exist". 

In my use case, I've already done a file stat so I just check IsDir() and use RemoveDirectory directly. 
