### PR TITLE
Fix memory leak and hangs in WriteTo.

### DIFF
--- a/client.go
+++ b/client.go
@@ -830,7 +830,13 @@ func (f *File) WriteTo(w io.Writer) (int64, error) {
 						desiredInFlight++
 					}
 					writeOffset += uint64(nbytes)
-					for pendingData, ok := pendingWrites[writeOffset]; ok; pendingData, ok = pendingWrites[writeOffset] {
+					for {
+						pendingData, ok := pendingWrites[writeOffset]
+						if !ok {
+							break
+						}
+						// Give go a chance to free the memory.
+						delete(pendingWrites, writeOffset)
 						nbytes, err := w.Write(pendingData)
 						if err != nil {
 							firstErr = offsetErr{offset: writeOffset + uint64(nbytes), err: err}


### PR DESCRIPTION
Leak is when requests are arriving out of order - they are never cleaned from the map. Hang is when Writer returns an error - because of the way inFlight is used, the function is stuck forever on receiving from channel.

This may fix #150. I don't have tests sadly, to properly test this and other corner cases I'll need to do a larger refactoring. I tested this in production instead.