### PR TITLE
sftp: get windows compiling and allow tests to run that can pass

### DIFF
--- a/os_unix.go
+++ b/os_unix.go
@@ -1,0 +1,11 @@
+//+build !windows
+
+package sftp
+
+import "syscall"
+
+// fakeFileInfoSys returns a platform dependent value normally
+// returned from the os#FileInfo.Sys method.
+func fakeFileInfoSys() interface{} {
+	return &syscall.Stat_t{Uid: 65534, Gid: 65534}
+}

--- a/os_unix_test.go
+++ b/os_unix_test.go
@@ -1,0 +1,41 @@
+//+build !windows
+
+package sftp
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sock = "/tmp/rstest.sock"
+
+func clientRequestServerPair(t *testing.T) *csPair {
+	ready := make(chan bool)
+	os.Remove(sock) // either this or signal handling
+	var server *RequestServer
+	go func() {
+		l, err := net.Listen("unix", sock)
+		if err != nil {
+			// neither assert nor t.Fatal reliably exit before Accept errors
+			panic(err)
+		}
+		ready <- true
+		fd, err := l.Accept()
+		assert.Nil(t, err)
+		handlers := InMemHandler()
+		server = NewRequestServer(fd, handlers)
+		server.Serve()
+	}()
+	<-ready
+	defer os.Remove(sock)
+	c, err := net.Dial("unix", sock)
+	assert.Nil(t, err)
+	client, err := NewClientPipe(c, c)
+	if err != nil {
+		t.Fatalf("%+v\n", err)
+	}
+	return &csPair{client, server, func() { os.Remove(sock) }}
+}

--- a/os_windows.go
+++ b/os_windows.go
@@ -1,0 +1,9 @@
+package sftp
+
+import "syscall"
+
+// fakeFileInfoSys returns a platform dependent value normally
+// returned from the os#FileInfo.Sys method.
+func fakeFileInfoSys() interface{} {
+	return syscall.Win32FileAttributeData{}
+}

--- a/os_windows_test.go
+++ b/os_windows_test.go
@@ -1,0 +1,10 @@
+package sftp
+
+import "testing"
+
+func clientRequestServerPair(t *testing.T) *csPair {
+	// We skip these tests because running them on windows exposes other underlying
+	// issues with path handling. This allows the package to compile and test
+	// what can be tested on windows.
+	t.Skip("no socket pair")
+}

--- a/request-example.go
+++ b/request-example.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -187,7 +186,7 @@ func (f *memFile) Mode() os.FileMode {
 func (f *memFile) ModTime() time.Time { return f.modtime }
 func (f *memFile) IsDir() bool        { return f.isdir }
 func (f *memFile) Sys() interface{} {
-	return &syscall.Stat_t{Uid: 65534, Gid: 65534}
+	return fakeFileInfoSys()
 }
 
 // Read/Write


### PR DESCRIPTION
Separate out windows specific calls to separate build files.
Unix specific calls, such as unix sockets or unix syscalls
give windows equivalents. Do not yet provide a windows
equivalent to createRequestServerPair as doing so exposes
other windows breakages. For now simply get it to compile on
windows. Passing the client-server tests will be handled in a follow
up PR.

Fixes #157