### PR TITLE
Calm down go race detector and fix livelock with concurrent clients

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -102,11 +102,13 @@ func (c *clientConn) sendPacket(p idmarshaler) (byte, []byte, error) {
 func (c *clientConn) dispatchRequest(ch chan<- result, p idmarshaler) {
 	c.Lock()
 	c.inflight[p.id()] = ch
+	c.Unlock()
 	if err := c.conn.sendPacket(p); err != nil {
+		c.Lock()
 		delete(c.inflight, p.id())
+		c.Unlock()
 		ch <- result{err: err}
 	}
-	c.Unlock()
 }
 
 // broadcastErr sends an error to all goroutines waiting for a response.

--- a/packet-manager.go
+++ b/packet-manager.go
@@ -14,7 +14,7 @@ type packetManager struct {
 	requests  chan requestPacket
 	responses chan responsePacket
 	fini      chan struct{}
-	incoming  []uint32
+	incoming  requestPacketIDs
 	outgoing  responsePackets
 	sender    packetSender // connection object
 }
@@ -55,6 +55,9 @@ func (s *packetManager) worker() {
 		case pkt := <-s.requests:
 			debug("incoming id: %v", pkt.id())
 			s.incoming = append(s.incoming, pkt.id())
+			if len(s.incoming) > 1 {
+				s.incoming.Sort()
+			}
 		case pkt := <-s.responses:
 			debug("outgoing pkt: %v", pkt.id())
 			s.outgoing = append(s.outgoing, pkt)

--- a/packet-manager_go1.8.go
+++ b/packet-manager_go1.8.go
@@ -11,3 +11,11 @@ func (r responsePackets) Sort() {
 		return r[i].id() < r[j].id()
 	})
 }
+
+type requestPacketIDs []uint32
+
+func (r requestPacketIDs) Sort() {
+	sort.Slice(r, func(i, j int) bool {
+		return r[i] < r[j]
+	})
+}

--- a/packet-manager_legacy.go
+++ b/packet-manager_legacy.go
@@ -4,10 +4,18 @@ package sftp
 
 import "sort"
 
-// for sorting/ordering incoming/outgoing
+// for sorting/ordering outgoing
 type responsePackets []responsePacket
 
 func (r responsePackets) Len() int           { return len(r) }
 func (r responsePackets) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r responsePackets) Less(i, j int) bool { return r[i].id() < r[j].id() }
 func (r responsePackets) Sort()              { sort.Sort(r) }
+
+// for sorting/ordering incoming
+type requestPacketIDs []uint32
+
+func (r requestPacketIDs) Len() int           { return len(r) }
+func (r requestPacketIDs) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r requestPacketIDs) Less(i, j int) bool { return r[i] < r[j] }
+func (r requestPacketIDs) Sort()              { sort.Sort(r) }

--- a/request-server.go
+++ b/request-server.go
@@ -186,7 +186,7 @@ func (rs *RequestServer) handle(request Request, pkt requestPacket) responsePack
 }
 
 // Wrap underlying connection methods to use packetManager
-func (rs RequestServer) sendPacket(m encoding.BinaryMarshaler) error {
+func (rs *RequestServer) sendPacket(m encoding.BinaryMarshaler) error {
 	if pkt, ok := m.(responsePacket); ok {
 		rs.pktMgr.readyPacket(pkt)
 	} else {
@@ -195,7 +195,7 @@ func (rs RequestServer) sendPacket(m encoding.BinaryMarshaler) error {
 	return nil
 }
 
-func (rs RequestServer) sendError(p ider, err error) error {
+func (rs *RequestServer) sendError(p ider, err error) error {
 	return rs.sendPacket(statusFromError(p, err))
 }
 

--- a/server.go
+++ b/server.go
@@ -328,7 +328,7 @@ func (svr *Server) Serve() error {
 }
 
 // Wrap underlying connection methods to use packetManager
-func (svr Server) sendPacket(m encoding.BinaryMarshaler) error {
+func (svr *Server) sendPacket(m encoding.BinaryMarshaler) error {
 	if pkt, ok := m.(responsePacket); ok {
 		svr.pktMgr.readyPacket(pkt)
 	} else {
@@ -337,7 +337,7 @@ func (svr Server) sendPacket(m encoding.BinaryMarshaler) error {
 	return nil
 }
 
-func (svr Server) sendError(p ider, err error) error {
+func (svr *Server) sendError(p ider, err error) error {
 	return svr.sendPacket(statusFromError(p, err))
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -46,8 +46,10 @@ func (p sshFxpTestBadExtendedPacket) MarshalBinary() ([]byte, error) {
 
 // test that errors are sent back when we request an invalid extended packet operation
 func TestInvalidExtendedPacket(t *testing.T) {
-	client, _ := clientServerPair(t)
+	client, server := clientServerPair(t)
 	defer client.Close()
+	defer server.Close()
+
 	badPacket := sshFxpTestBadExtendedPacket{client.nextID(), "thisDoesn'tExist", "foobar"}
 	_, _, err := client.clientConn.sendPacket(badPacket)
 	if err == nil {


### PR DESCRIPTION
The first patch in the pull request fixes go race detector errors by defining Server methods on pointer receiver instead of on the value one to avoid copying.

The second patch fixes livelock when the server is accessed by a concurrent client (for example, sftp.Client used from multiple goroutines simultaneously).