### PR TITLE
Fix race between client's close and write

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -56,9 +56,9 @@ func (c *clientConn) loop() {
 // appropriate channel.
 func (c *clientConn) recv() error {
 	defer func() {
-		c.Lock()
+		c.conn.Lock()
 		c.conn.Close()
-		c.Unlock()
+		c.conn.Unlock()
 	}()
 	for {
 		typ, data, err := c.recvPacket()


### PR DESCRIPTION
After commit 506f3a7 which removed clientConn mutex around
conn.sendPacket, it is now possible for conn.Close and conn.Write to
race (https://travis-ci.org/pkg/sftp/jobs/219048782#L1838). The problem
is really hard to reproduce, but I believe this patch fixes it.

Now clientConn.Mutex protects 'inflight' map only, and conn.Mutex
serializes connection writes/close.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>