### PR TITLE
Fixes #177: adds HostKeyCallback to ssh.ClientConfig

### DIFF
--- a/examples/buffered-read-benchmark/main.go
+++ b/examples/buffered-read-benchmark/main.go
@@ -42,6 +42,7 @@ func main() {
 	config := ssh.ClientConfig{
 		User: *USER,
 		Auth: auths,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 	addr := fmt.Sprintf("%s:%d", *HOST, *PORT)
 	conn, err := ssh.Dial("tcp", addr, &config)

--- a/examples/buffered-write-benchmark/main.go
+++ b/examples/buffered-write-benchmark/main.go
@@ -42,6 +42,7 @@ func main() {
 	config := ssh.ClientConfig{
 		User: *USER,
 		Auth: auths,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 	addr := fmt.Sprintf("%s:%d", *HOST, *PORT)
 	conn, err := ssh.Dial("tcp", addr, &config)

--- a/examples/streaming-read-benchmark/main.go
+++ b/examples/streaming-read-benchmark/main.go
@@ -43,6 +43,7 @@ func main() {
 	config := ssh.ClientConfig{
 		User: *USER,
 		Auth: auths,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 	addr := fmt.Sprintf("%s:%d", *HOST, *PORT)
 	conn, err := ssh.Dial("tcp", addr, &config)

--- a/examples/streaming-write-benchmark/main.go
+++ b/examples/streaming-write-benchmark/main.go
@@ -43,6 +43,7 @@ func main() {
 	config := ssh.ClientConfig{
 		User: *USER,
 		Auth: auths,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 	addr := fmt.Sprintf("%s:%d", *HOST, *PORT)
 	conn, err := ssh.Dial("tcp", addr, &config)


### PR DESCRIPTION
Fixes #177 
This is needed since https://github.com/golang/go/issues/19767