### PR TITLE
various improvements / potential fix for issue #8

### DIFF
--- a/packet-manager.go
+++ b/packet-manager.go
@@ -25,11 +25,11 @@ type packetManager struct {
 
 func newPktMgr(sender packetSender) packetManager {
 	s := packetManager{
-		requests:  make(chan requestPacket, sftpServerWorkerCount),
-		responses: make(chan responsePacket, sftpServerWorkerCount),
+		requests:  make(chan requestPacket, SftpServerWorkerCount),
+		responses: make(chan responsePacket, SftpServerWorkerCount),
 		fini:      make(chan struct{}),
-		incoming:  make([]uint32, 0, sftpServerWorkerCount),
-		outgoing:  make([]responsePacket, 0, sftpServerWorkerCount),
+		incoming:  make([]uint32, 0, SftpServerWorkerCount),
+		outgoing:  make([]responsePacket, 0, SftpServerWorkerCount),
 		sender:    sender,
 		working:   &sync.WaitGroup{},
 	}
@@ -41,7 +41,7 @@ func newPktMgr(sender packetSender) packetManager {
 // send id of 0 for packets without id
 func (s packetManager) incomingPacket(pkt requestPacket) {
 	s.working.Add(1)
-	s.requests <- pkt // buffer == sftpServerWorkerCount
+	s.requests <- pkt // buffer == SftpServerWorkerCount
 }
 
 // register outgoing packets as being ready
@@ -63,15 +63,15 @@ func (s packetManager) close() {
 // transfers.
 func (s *packetManager) workerChan(runWorker func(requestChan)) requestChan {
 
-	rwChan := make(chan requestPacket, sftpServerWorkerCount)
-	for i := 0; i < sftpServerWorkerCount; i++ {
+	rwChan := make(chan requestPacket, SftpServerWorkerCount)
+	for i := 0; i < SftpServerWorkerCount; i++ {
 		runWorker(rwChan)
 	}
 
 	cmdChan := make(chan requestPacket)
 	runWorker(cmdChan)
 
-	pktChan := make(chan requestPacket, sftpServerWorkerCount)
+	pktChan := make(chan requestPacket, SftpServerWorkerCount)
 	go func() {
 		// start with cmdChan
 		curChan := cmdChan
@@ -147,10 +147,10 @@ func (s *packetManager) maybeSendPackets() {
 	}
 }
 
-func outfilter(o []responsePacket) []uint32 {
-	res := make([]uint32, 0, len(o))
-	for _, v := range o {
-		res = append(res, v.id())
-	}
-	return res
-}
+//func outfilter(o []responsePacket) []uint32 {
+//	res := make([]uint32, 0, len(o))
+//	for _, v := range o {
+//		res = append(res, v.id())
+//	}
+//	return res
+//}

--- a/request-server.go
+++ b/request-server.go
@@ -131,7 +131,7 @@ func (rs *RequestServer) packetWorker(pktChan chan requestPacket) error {
 			rs.closeRequest(handle)
 			rpkt = statusFromError(pkt, nil)
 		case *sshFxpRealpathPacket:
-			rpkt = cleanPath(pkt)
+			rpkt = cleanPacketPath(pkt)
 		case isOpener:
 			handle := rs.nextRequest(requestFromPacket(pkt))
 			rpkt = sshFxpHandlePacket{pkt.id(), handle}
@@ -181,23 +181,24 @@ func (rs *RequestServer) packetWorker(pktChan chan requestPacket) error {
 	return nil
 }
 
-func cleanPath(pkt *sshFxpRealpathPacket) responsePacket {
-	path := pkt.getPath()
-	if !filepath.IsAbs(path) {
-		// prevent double slash (e.g. on windows, / paths are not absolute)
-		path = "/" + strings.TrimPrefix(path, "/")
-	} // all paths are absolute
-
-	cleaned_path := filepath.ToSlash(filepath.Clean(path))
-
+func cleanPacketPath(pkt *sshFxpRealpathPacket) responsePacket {
+	path := cleanPath(pkt.getPath())
 	return &sshFxpNamePacket{
 		ID: pkt.id(),
 		NameAttrs: []sshFxpNameAttr{{
-			Name:     cleaned_path,
-			LongName: cleaned_path,
+			Name:     path,
+			LongName: path,
 			Attrs:    emptyFileStat,
 		}},
 	}
+}
+
+func cleanPath(path string) string {
+	cleanSlashPath := filepath.ToSlash(filepath.Clean(path))
+	if !strings.HasPrefix(cleanSlashPath, "/") {
+		return "/" + cleanSlashPath
+	}
+	return cleanSlashPath
 }
 
 func (rs *RequestServer) handle(request Request, pkt requestPacket) responsePacket {

--- a/request-server.go
+++ b/request-server.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"strings"
 )
 
 var maxTxPacket uint32 = 1 << 15
@@ -183,7 +184,8 @@ func (rs *RequestServer) packetWorker(pktChan chan requestPacket) error {
 func cleanPath(pkt *sshFxpRealpathPacket) responsePacket {
 	path := pkt.getPath()
 	if !filepath.IsAbs(path) {
-		path = "/" + path
+		// prevent double slash (e.g. on windows, / paths are not absolute)
+		path = "/" + strings.TrimPrefix(path, "/")
 	} // all paths are absolute
 
 	cleaned_path := filepath.ToSlash(filepath.Clean(path))

--- a/request-server.go
+++ b/request-server.go
@@ -186,7 +186,8 @@ func cleanPath(pkt *sshFxpRealpathPacket) responsePacket {
 		path = "/" + path
 	} // all paths are absolute
 
-	cleaned_path := filepath.Clean(path)
+	cleaned_path := filepath.ToSlash(filepath.Clean(path))
+
 	return &sshFxpNamePacket{
 		ID: pkt.id(),
 		NameAttrs: []sshFxpNameAttr{{

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -327,3 +327,20 @@ func TestRequestReaddir(t *testing.T) {
 	names := []string{di[18].Name(), di[81].Name()}
 	assert.Equal(t, []string{"foo_18", "foo_81"}, names)
 }
+
+func TestCleanPath(t *testing.T) {
+	assert.Equal(t, "/", cleanPath("/"))
+	assert.Equal(t, "/", cleanPath("//"))
+	assert.Equal(t, "/a", cleanPath("/a/"))
+	assert.Equal(t, "/a", cleanPath("a/"))
+	assert.Equal(t, "/a/b/c", cleanPath("/a//b//c/"))
+
+	// filepath.ToSlash does not touch \ as char on unix systems, so os.PathSeparator is used for windows compatible tests
+	bslash := string(os.PathSeparator)
+	assert.Equal(t, "/", cleanPath(bslash))
+	assert.Equal(t, "/", cleanPath(bslash+bslash))
+	assert.Equal(t, "/a", cleanPath(bslash+"a"+bslash))
+	assert.Equal(t, "/a", cleanPath("a"+bslash))
+	assert.Equal(t, "/a/b/c", cleanPath(bslash+"a"+bslash+bslash+"b"+bslash+bslash+"c"+bslash))
+
+}

--- a/request.go
+++ b/request.go
@@ -52,16 +52,16 @@ func requestFromPacket(pkt hasPath) Request {
 		request.Flags = p.Flags
 		request.Attrs = p.Attrs.([]byte)
 	case *sshFxpRenamePacket:
-		request.Target = filepath.Clean(p.Newpath)
+		request.Target = filepath.ToSlash(filepath.Clean(p.Newpath))
 	case *sshFxpSymlinkPacket:
-		request.Target = filepath.Clean(p.Linkpath)
+		request.Target = filepath.ToSlash(filepath.Clean(p.Linkpath))
 	}
 	return request
 }
 
 // NewRequest creates a new Request object.
 func NewRequest(method, path string) Request {
-	request := Request{Method: method, Filepath: filepath.Clean(path)}
+	request := Request{Method: method, Filepath: filepath.ToSlash(filepath.Clean(path))}
 	request.packets = make(chan packet_data, sftpServerWorkerCount)
 	request.state = &state{}
 	request.stateLock = &sync.RWMutex{}
@@ -239,7 +239,7 @@ func fileinfo(h FileInfoer, r Request) (responsePacket, error) {
 	switch r.Method {
 	case "List":
 		pd := r.popPacket()
-		dirname := path.Base(r.Filepath)
+		dirname := filepath.ToSlash(path.Base(r.Filepath))
 		ret := &sshFxpNamePacket{ID: pd.id}
 		for _, fi := range finfo {
 			ret.NameAttrs = append(ret.NameAttrs, sshFxpNameAttr{

--- a/request.go
+++ b/request.go
@@ -52,17 +52,17 @@ func requestFromPacket(pkt hasPath) Request {
 		request.Flags = p.Flags
 		request.Attrs = p.Attrs.([]byte)
 	case *sshFxpRenamePacket:
-		request.Target = filepath.ToSlash(filepath.Clean(p.Newpath))
+		request.Target = cleanPath(p.Newpath)
 	case *sshFxpSymlinkPacket:
-		request.Target = filepath.ToSlash(filepath.Clean(p.Linkpath))
+		request.Target = cleanPath(p.Linkpath)
 	}
 	return request
 }
 
 // NewRequest creates a new Request object.
 func NewRequest(method, path string) Request {
-	request := Request{Method: method, Filepath: filepath.ToSlash(filepath.Clean(path))}
-	request.packets = make(chan packet_data, sftpServerWorkerCount)
+	request := Request{Method: method, Filepath: cleanPath(path)}
+	request.packets = make(chan packet_data, SftpServerWorkerCount)
 	request.state = &state{}
 	request.stateLock = &sync.RWMutex{}
 	return request

--- a/request_test.go
+++ b/request_test.go
@@ -65,13 +65,13 @@ func testRequest(method string) Request {
 		Method:    method,
 		Attrs:     []byte("foo"),
 		Target:    "foo",
-		packets:   make(chan packet_data, sftpServerWorkerCount),
+		packets:   make(chan packet_data, SftpServerWorkerCount),
 		state:     &state{},
 		stateLock: &sync.RWMutex{},
 	}
 	for _, p := range []packet_data{
-		packet_data{id: 1, data: filecontents[:5], length: 5},
-		packet_data{id: 2, data: filecontents[5:], length: 5, offset: 5}} {
+		{id: 1, data: filecontents[:5], length: 5},
+		{id: 2, data: filecontents[5:], length: 5, offset: 5}} {
 		request.packets <- p
 	}
 	return request

--- a/server.go
+++ b/server.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	sftpServerWorkerCount = 8
+	SftpServerWorkerCount = 8
 )
 
 // Server is an SSH File Transfer Protocol (sftp) server.
@@ -230,8 +230,7 @@ func handlePacket(s *Server, p interface{}) error {
 		if err != nil {
 			return s.sendError(p, err)
 		}
-		f = filepath.Clean(f)
-		f = filepath.ToSlash(f) // make path more Unix like on windows servers
+		f = cleanPath(f)
 		return s.sendPacket(sshFxpNamePacket{
 			ID: p.ID,
 			NameAttrs: []sshFxpNameAttr{{

--- a/server.go
+++ b/server.go
@@ -573,3 +573,92 @@ func clamp(v, max uint32) uint32 {
 	}
 	return v
 }
+
+func runLsTypeWord(dirent os.FileInfo) string {
+	// find first character, the type char
+	// b     Block special file.
+	// c     Character special file.
+	// d     Directory.
+	// l     Symbolic link.
+	// s     Socket link.
+	// p     FIFO.
+	// -     Regular file.
+	tc := '-'
+	mode := dirent.Mode()
+	if (mode & os.ModeDir) != 0 {
+		tc = 'd'
+	} else if (mode & os.ModeDevice) != 0 {
+		tc = 'b'
+		if (mode & os.ModeCharDevice) != 0 {
+			tc = 'c'
+		}
+	} else if (mode & os.ModeSymlink) != 0 {
+		tc = 'l'
+	} else if (mode & os.ModeSocket) != 0 {
+		tc = 's'
+	} else if (mode & os.ModeNamedPipe) != 0 {
+		tc = 'p'
+	}
+
+	// owner
+	orc := '-'
+	if (mode & 0400) != 0 {
+		orc = 'r'
+	}
+	owc := '-'
+	if (mode & 0200) != 0 {
+		owc = 'w'
+	}
+	oxc := '-'
+	ox := (mode & 0100) != 0
+	setuid := (mode & os.ModeSetuid) != 0
+	if ox && setuid {
+		oxc = 's'
+	} else if setuid {
+		oxc = 'S'
+	} else if ox {
+		oxc = 'x'
+	}
+
+	// group
+	grc := '-'
+	if (mode & 040) != 0 {
+		grc = 'r'
+	}
+	gwc := '-'
+	if (mode & 020) != 0 {
+		gwc = 'w'
+	}
+	gxc := '-'
+	gx := (mode & 010) != 0
+	setgid := (mode & os.ModeSetgid) != 0
+	if gx && setgid {
+		gxc = 's'
+	} else if setgid {
+		gxc = 'S'
+	} else if gx {
+		gxc = 'x'
+	}
+
+	// all / others
+	arc := '-'
+	if (mode & 04) != 0 {
+		arc = 'r'
+	}
+	awc := '-'
+	if (mode & 02) != 0 {
+		awc = 'w'
+	}
+	axc := '-'
+	ax := (mode & 01) != 0
+	sticky := (mode & os.ModeSticky) != 0
+	if ax && sticky {
+		axc = 't'
+	} else if sticky {
+		axc = 'T'
+	} else if ax {
+		axc = 'x'
+	}
+
+	return fmt.Sprintf("%c%c%c%c%c%c%c%c%c%c", tc, orc, owc, oxc, grc, gwc, gxc, arc, awc, axc)
+}

--- a/server_stubs.go
+++ b/server_stubs.go
@@ -4,13 +4,15 @@ package sftp
 
 import (
 	"os"
+	"time"
+	"fmt"
 )
 
 func runLs(dirname string, dirent os.FileInfo) string {
 	typeword := runLsTypeWord(dirent)
 	numLinks := 1
-	username := ""
-	groupname := ""
+	username := "-"
+	groupname := "-"
 	mtime := dirent.ModTime()
 	monthStr := mtime.Month().String()[0:3]
 	day := mtime.Day()

--- a/server_stubs.go
+++ b/server_stubs.go
@@ -11,8 +11,11 @@ import (
 func runLs(dirname string, dirent os.FileInfo) string {
 	typeword := runLsTypeWord(dirent)
 	numLinks := 1
-	username := "-"
-	groupname := "-"
+	if dirent.IsDir() {
+		numLinks = 0
+	}
+	username := "root"
+	groupname := "root"
 	mtime := dirent.ModTime()
 	monthStr := mtime.Month().String()[0:3]
 	day := mtime.Day()

--- a/server_stubs.go
+++ b/server_stubs.go
@@ -4,9 +4,24 @@ package sftp
 
 import (
 	"os"
-	"path"
 )
 
 func runLs(dirname string, dirent os.FileInfo) string {
-	return path.Join(dirname, dirent.Name())
+	typeword := runLsTypeWord(dirent)
+	numLinks := 1
+	username := ""
+	groupname := ""
+	mtime := dirent.ModTime()
+	monthStr := mtime.Month().String()[0:3]
+	day := mtime.Day()
+	year := mtime.Year()
+	now := time.Now()
+	isOld := mtime.Before(now.Add(-time.Hour * 24 * 365 / 2))
+
+	yearOrTime := fmt.Sprintf("%02d:%02d", mtime.Hour(), mtime.Minute())
+	if isOld {
+		yearOrTime = fmt.Sprintf("%d", year)
+	}
+
+	return fmt.Sprintf("%s %4d %-8s %-8s %8d %s %2d %5s %s", typeword, numLinks, username, groupname, dirent.Size(), monthStr, day, yearOrTime, dirent.Name())
 }

--- a/server_test.go
+++ b/server_test.go
@@ -4,6 +4,14 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"os"
+	"regexp"
+	"time"
+)
+
+const (
+	TYPE_DIRECTORY = "d"
+	TYPE_FILE = "[^d]"
 )
 
 func clientServerPair(t *testing.T) (*Client, *Server) {
@@ -94,6 +102,24 @@ func TestConcurrentRequests(t *testing.T) {
 	wg.Wait()
 }
 
+
+
+
+func TestRunLsWithExamplesDirectory(t *testing.T) {
+	path := "examples"
+	item,_ := os.Stat(path)
+	result := runLs(path, item)
+	runLsTestHelper(t, result, TYPE_DIRECTORY, path)
+}
+
+
+func TestRunLsWithLicensesFile(t *testing.T) {
+	path := "LICENSE"
+	item,_ := os.Stat(path)
+	result := runLs(path, item)
+	runLsTestHelper(t, result, TYPE_FILE, path)
+}
+
 /*
    The format of the `longname' field is unspecified by this protocol.
    It MUST be suitable for use in the output of a directory listing
@@ -128,6 +154,91 @@ func TestConcurrentRequests(t *testing.T) {
    where `id' is the request identifier, and `attrs' is the returned
    file attributes as described in Section ``File Attributes''.
  */
-func TestRunLs(t *testing.T) {
+func runLsTestHelper(t *testing.T, result, expectedType, path string) {
+	// using regular expressions to make tests work on all systems
+	// a virtual file system (like afero) would be needed to mock valid filesystem checks
+	// expected layout is:
+	// drwxr-xr-x   8 501      20            272 Aug  9 19:46 examples
 
+
+	// permissions (len 10, "drwxr-xr-x")
+	got := result[0:10]
+	if ok, err := regexp.MatchString("^" + expectedType + "[rwx-]{9}$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): permission field mismatch, expected dir, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// space
+	got = result[10:11]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 1 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// link count (len 3, number)
+	got = result[12:15]
+	if ok, err := regexp.MatchString("^\\s*[0-9]+$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): link count field mismatch, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// spacer
+	got = result[15:16]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 2 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// username / uid (len 8, number or string)
+	got = result[16:24]
+	if ok, err := regexp.MatchString("^[^\\s]{1,8}\\s*$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): username / uid mismatch, expected user, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// spacer
+	got = result[24:25]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 3 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// groupname / gid (len 8, number or string)
+	got = result[25:33]
+	if ok, err := regexp.MatchString("^[^\\s]{1,8}\\s*$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): groupname / gid mismatch, expected group, got: %#v, err: %#v", path,  got, err)
+	}
+
+
+	// spacer
+	got = result[33:34]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 4 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// filesize (len 8)
+	got = result[34:42]
+	if ok, err := regexp.MatchString("^\\s*[0-9]+$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): filesize field mismatch, expected size in bytes, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// spacer
+	got = result[42:43]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 5 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// mod time (len 12, e.g. Aug  9 19:46)
+	got = result[43:55]
+	layout := "Jan  1 15:04"
+	_, err := time.Parse(layout, got)
+	if err != nil {
+		t.Errorf("runLs(%#v, *FileInfo): mod time field mismatch, expected date layout %s, got: %#v, err: %#v",  path, layout, got, err)
+	}
+
+	// spacer
+	got = result[55:56]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 6 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// filename
+	got = result[56:]
+	if ok, err := regexp.MatchString("^"+path+"$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): name field mismatch, expected examples, got: %#v, err: %#v", path,  got, err)
+	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,18 +1,155 @@
 package sftp
 
 import (
-	"io"
-	"sync"
 	"testing"
 	"os"
 	"regexp"
 	"time"
+	"io"
+	"sync"
 )
 
 const (
 	TYPE_DIRECTORY = "d"
 	TYPE_FILE = "[^d]"
 )
+
+func TestRunLsWithExamplesDirectory(t *testing.T) {
+	path := "examples"
+	item,_ := os.Stat(path)
+	result := runLs(path, item)
+	runLsTestHelper(t, result, TYPE_DIRECTORY, path)
+}
+
+
+func TestRunLsWithLicensesFile(t *testing.T) {
+	path := "LICENSE"
+	item,_ := os.Stat(path)
+	result := runLs(path, item)
+	runLsTestHelper(t, result, TYPE_FILE, path)
+}
+
+/*
+   The format of the `longname' field is unspecified by this protocol.
+   It MUST be suitable for use in the output of a directory listing
+   command (in fact, the recommended operation for a directory listing
+   command is to simply display this data).  However, clients SHOULD NOT
+   attempt to parse the longname field for file attributes; they SHOULD
+   use the attrs field instead.
+
+    The recommended format for the longname field is as follows:
+
+        -rwxr-xr-x   1 mjos     staff      348911 Mar 25 14:29 t-filexfer
+        1234567890 123 12345678 12345678 12345678 123456789012
+
+   Here, the first line is sample output, and the second field indicates
+   widths of the various fields.  Fields are separated by spaces.  The
+   first field lists file permissions for user, group, and others; the
+   second field is link count; the third field is the name of the user
+   who owns the file; the fourth field is the name of the group that
+   owns the file; the fifth field is the size of the file in bytes; the
+   sixth field (which actually may contain spaces, but is fixed to 12
+   characters) is the file modification time, and the seventh field is
+   the file name.  Each field is specified to be a minimum of certain
+   number of character positions (indicated by the second line above),
+   but may also be longer if the data does not fit in the specified
+   length.
+
+    The SSH_FXP_ATTRS response has the following format:
+
+        uint32     id
+        ATTRS      attrs
+
+   where `id' is the request identifier, and `attrs' is the returned
+   file attributes as described in Section ``File Attributes''.
+ */
+func runLsTestHelper(t *testing.T, result, expectedType, path string) {
+	// using regular expressions to make tests work on all systems
+	// a virtual file system (like afero) would be needed to mock valid filesystem checks
+	// expected layout is:
+	// drwxr-xr-x   8 501      20            272 Aug  9 19:46 examples
+
+	// permissions (len 10, "drwxr-xr-x")
+	got := result[0:10]
+	if ok, err := regexp.MatchString("^" + expectedType + "[rwx-]{9}$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): permission field mismatch, expected dir, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// space
+	got = result[10:11]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 1 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// link count (len 3, number)
+	got = result[12:15]
+	if ok, err := regexp.MatchString("^\\s*[0-9]+$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): link count field mismatch, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// spacer
+	got = result[15:16]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 2 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// username / uid (len 8, number or string)
+	got = result[16:24]
+	if ok, err := regexp.MatchString("^[^\\s]{1,8}\\s*$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): username / uid mismatch, expected user, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// spacer
+	got = result[24:25]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 3 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// groupname / gid (len 8, number or string)
+	got = result[25:33]
+	if ok, err := regexp.MatchString("^[^\\s]{1,8}\\s*$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): groupname / gid mismatch, expected group, got: %#v, err: %#v", path,  got, err)
+	}
+
+
+	// spacer
+	got = result[33:34]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 4 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// filesize (len 8)
+	got = result[34:42]
+	if ok, err := regexp.MatchString("^\\s*[0-9]+$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): filesize field mismatch, expected size in bytes, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// spacer
+	got = result[42:43]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 5 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// mod time (len 12, e.g. Aug  9 19:46)
+	got = result[43:55]
+	layout := "Jan  2 15:04"
+	_, err := time.Parse(layout, got)
+	if err != nil {
+		t.Errorf("runLs(%#v, *FileInfo): mod time field mismatch, expected date layout %s, got: %#v, err: %#v",  path, layout, got, err)
+	}
+
+	// spacer
+	got = result[55:56]
+	if ok, err := regexp.MatchString("^\\s$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): spacer 6 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+	}
+
+	// filename
+	got = result[56:]
+	if ok, err := regexp.MatchString("^"+path+"$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): name field mismatch, expected examples, got: %#v, err: %#v", path,  got, err)
+	}
+}
 
 func clientServerPair(t *testing.T) (*Client, *Server) {
 	cr, sw := io.Pipe()
@@ -100,145 +237,4 @@ func TestConcurrentRequests(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-}
-
-
-
-
-func TestRunLsWithExamplesDirectory(t *testing.T) {
-	path := "examples"
-	item,_ := os.Stat(path)
-	result := runLs(path, item)
-	runLsTestHelper(t, result, TYPE_DIRECTORY, path)
-}
-
-
-func TestRunLsWithLicensesFile(t *testing.T) {
-	path := "LICENSE"
-	item,_ := os.Stat(path)
-	result := runLs(path, item)
-	runLsTestHelper(t, result, TYPE_FILE, path)
-}
-
-/*
-   The format of the `longname' field is unspecified by this protocol.
-   It MUST be suitable for use in the output of a directory listing
-   command (in fact, the recommended operation for a directory listing
-   command is to simply display this data).  However, clients SHOULD NOT
-   attempt to parse the longname field for file attributes; they SHOULD
-   use the attrs field instead.
-
-    The recommended format for the longname field is as follows:
-
-        -rwxr-xr-x   1 mjos     staff      348911 Mar 25 14:29 t-filexfer
-        1234567890 123 12345678 12345678 12345678 123456789012
-
-   Here, the first line is sample output, and the second field indicates
-   widths of the various fields.  Fields are separated by spaces.  The
-   first field lists file permissions for user, group, and others; the
-   second field is link count; the third field is the name of the user
-   who owns the file; the fourth field is the name of the group that
-   owns the file; the fifth field is the size of the file in bytes; the
-   sixth field (which actually may contain spaces, but is fixed to 12
-   characters) is the file modification time, and the seventh field is
-   the file name.  Each field is specified to be a minimum of certain
-   number of character positions (indicated by the second line above),
-   but may also be longer if the data does not fit in the specified
-   length.
-
-    The SSH_FXP_ATTRS response has the following format:
-
-        uint32     id
-        ATTRS      attrs
-
-   where `id' is the request identifier, and `attrs' is the returned
-   file attributes as described in Section ``File Attributes''.
- */
-func runLsTestHelper(t *testing.T, result, expectedType, path string) {
-	// using regular expressions to make tests work on all systems
-	// a virtual file system (like afero) would be needed to mock valid filesystem checks
-	// expected layout is:
-	// drwxr-xr-x   8 501      20            272 Aug  9 19:46 examples
-
-
-	// permissions (len 10, "drwxr-xr-x")
-	got := result[0:10]
-	if ok, err := regexp.MatchString("^" + expectedType + "[rwx-]{9}$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): permission field mismatch, expected dir, got: %#v, err: %#v", path,  got, err)
-	}
-
-	// space
-	got = result[10:11]
-	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 1 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
-	}
-
-	// link count (len 3, number)
-	got = result[12:15]
-	if ok, err := regexp.MatchString("^\\s*[0-9]+$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): link count field mismatch, got: %#v, err: %#v", path,  got, err)
-	}
-
-	// spacer
-	got = result[15:16]
-	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 2 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
-	}
-
-	// username / uid (len 8, number or string)
-	got = result[16:24]
-	if ok, err := regexp.MatchString("^[^\\s]{1,8}\\s*$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): username / uid mismatch, expected user, got: %#v, err: %#v", path,  got, err)
-	}
-
-	// spacer
-	got = result[24:25]
-	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 3 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
-	}
-
-	// groupname / gid (len 8, number or string)
-	got = result[25:33]
-	if ok, err := regexp.MatchString("^[^\\s]{1,8}\\s*$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): groupname / gid mismatch, expected group, got: %#v, err: %#v", path,  got, err)
-	}
-
-
-	// spacer
-	got = result[33:34]
-	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 4 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
-	}
-
-	// filesize (len 8)
-	got = result[34:42]
-	if ok, err := regexp.MatchString("^\\s*[0-9]+$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): filesize field mismatch, expected size in bytes, got: %#v, err: %#v", path,  got, err)
-	}
-
-	// spacer
-	got = result[42:43]
-	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 5 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
-	}
-
-	// mod time (len 12, e.g. Aug  9 19:46)
-	got = result[43:55]
-	layout := "Jan  1 15:04"
-	_, err := time.Parse(layout, got)
-	if err != nil {
-		t.Errorf("runLs(%#v, *FileInfo): mod time field mismatch, expected date layout %s, got: %#v, err: %#v",  path, layout, got, err)
-	}
-
-	// spacer
-	got = result[55:56]
-	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 6 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
-	}
-
-	// filename
-	got = result[56:]
-	if ok, err := regexp.MatchString("^"+path+"$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): name field mismatch, expected examples, got: %#v, err: %#v", path,  got, err)
-	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -10,23 +10,22 @@ import (
 )
 
 const (
-	TYPE_DIRECTORY = "d"
-	TYPE_FILE = "[^d]"
+	typeDirectory = "d"
+	typeFile      = "[^d]"
 )
 
 func TestRunLsWithExamplesDirectory(t *testing.T) {
 	path := "examples"
-	item,_ := os.Stat(path)
+	item, _ := os.Stat(path)
 	result := runLs(path, item)
-	runLsTestHelper(t, result, TYPE_DIRECTORY, path)
+	runLsTestHelper(t, result, typeDirectory, path)
 }
-
 
 func TestRunLsWithLicensesFile(t *testing.T) {
 	path := "LICENSE"
-	item,_ := os.Stat(path)
+	item, _ := os.Stat(path)
 	result := runLs(path, item)
-	runLsTestHelper(t, result, TYPE_FILE, path)
+	runLsTestHelper(t, result, typeFile, path)
 }
 
 /*
@@ -71,83 +70,87 @@ func runLsTestHelper(t *testing.T, result, expectedType, path string) {
 
 	// permissions (len 10, "drwxr-xr-x")
 	got := result[0:10]
-	if ok, err := regexp.MatchString("^" + expectedType + "[rwx-]{9}$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): permission field mismatch, expected dir, got: %#v, err: %#v", path,  got, err)
+	if ok, err := regexp.MatchString("^"+expectedType+"[rwx-]{9}$", got); !ok {
+		t.Errorf("runLs(%#v, *FileInfo): permission field mismatch, expected dir, got: %#v, err: %#v", path, got, err)
 	}
 
 	// space
 	got = result[10:11]
 	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 1 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): spacer 1 mismatch, expected whitespace, got: %#v, err: %#v", path, got, err)
 	}
 
 	// link count (len 3, number)
 	got = result[12:15]
 	if ok, err := regexp.MatchString("^\\s*[0-9]+$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): link count field mismatch, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): link count field mismatch, got: %#v, err: %#v", path, got, err)
 	}
 
 	// spacer
 	got = result[15:16]
 	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 2 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): spacer 2 mismatch, expected whitespace, got: %#v, err: %#v", path, got, err)
 	}
 
 	// username / uid (len 8, number or string)
 	got = result[16:24]
 	if ok, err := regexp.MatchString("^[^\\s]{1,8}\\s*$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): username / uid mismatch, expected user, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): username / uid mismatch, expected user, got: %#v, err: %#v", path, got, err)
 	}
 
 	// spacer
 	got = result[24:25]
 	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 3 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): spacer 3 mismatch, expected whitespace, got: %#v, err: %#v", path, got, err)
 	}
 
 	// groupname / gid (len 8, number or string)
 	got = result[25:33]
 	if ok, err := regexp.MatchString("^[^\\s]{1,8}\\s*$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): groupname / gid mismatch, expected group, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): groupname / gid mismatch, expected group, got: %#v, err: %#v", path, got, err)
 	}
-
 
 	// spacer
 	got = result[33:34]
 	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 4 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): spacer 4 mismatch, expected whitespace, got: %#v, err: %#v", path, got, err)
 	}
 
 	// filesize (len 8)
 	got = result[34:42]
 	if ok, err := regexp.MatchString("^\\s*[0-9]+$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): filesize field mismatch, expected size in bytes, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): filesize field mismatch, expected size in bytes, got: %#v, err: %#v", path, got, err)
 	}
 
 	// spacer
 	got = result[42:43]
 	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 5 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): spacer 5 mismatch, expected whitespace, got: %#v, err: %#v", path, got, err)
 	}
 
 	// mod time (len 12, e.g. Aug  9 19:46)
 	got = result[43:55]
 	layout := "Jan  2 15:04"
 	_, err := time.Parse(layout, got)
+
 	if err != nil {
-		t.Errorf("runLs(%#v, *FileInfo): mod time field mismatch, expected date layout %s, got: %#v, err: %#v",  path, layout, got, err)
+		layout = "Jan  2 2006"
+		_, err = time.Parse(layout, got)
+	}
+	if err != nil {
+		t.Errorf("runLs(%#v, *FileInfo): mod time field mismatch, expected date layout %s, got: %#v, err: %#v", path, layout, got, err)
 	}
 
 	// spacer
 	got = result[55:56]
 	if ok, err := regexp.MatchString("^\\s$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): spacer 6 mismatch, expected whitespace, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): spacer 6 mismatch, expected whitespace, got: %#v, err: %#v", path, got, err)
 	}
 
 	// filename
 	got = result[56:]
 	if ok, err := regexp.MatchString("^"+path+"$", got); !ok {
-		t.Errorf("runLs(%#v, *FileInfo): name field mismatch, expected examples, got: %#v, err: %#v", path,  got, err)
+		t.Errorf("runLs(%#v, *FileInfo): name field mismatch, expected examples, got: %#v, err: %#v", path, got, err)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -93,3 +93,41 @@ func TestConcurrentRequests(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+/*
+   The format of the `longname' field is unspecified by this protocol.
+   It MUST be suitable for use in the output of a directory listing
+   command (in fact, the recommended operation for a directory listing
+   command is to simply display this data).  However, clients SHOULD NOT
+   attempt to parse the longname field for file attributes; they SHOULD
+   use the attrs field instead.
+
+    The recommended format for the longname field is as follows:
+
+        -rwxr-xr-x   1 mjos     staff      348911 Mar 25 14:29 t-filexfer
+        1234567890 123 12345678 12345678 12345678 123456789012
+
+   Here, the first line is sample output, and the second field indicates
+   widths of the various fields.  Fields are separated by spaces.  The
+   first field lists file permissions for user, group, and others; the
+   second field is link count; the third field is the name of the user
+   who owns the file; the fourth field is the name of the group that
+   owns the file; the fifth field is the size of the file in bytes; the
+   sixth field (which actually may contain spaces, but is fixed to 12
+   characters) is the file modification time, and the seventh field is
+   the file name.  Each field is specified to be a minimum of certain
+   number of character positions (indicated by the second line above),
+   but may also be longer if the data does not fit in the specified
+   length.
+
+    The SSH_FXP_ATTRS response has the following format:
+
+        uint32     id
+        ATTRS      attrs
+
+   where `id' is the request identifier, and `attrs' is the returned
+   file attributes as described in Section ``File Attributes''.
+ */
+func TestRunLs(t *testing.T) {
+
+}

--- a/server_unix.go
+++ b/server_unix.go
@@ -11,96 +11,7 @@ import (
 	"time"
 )
 
-func runLsTypeWord(dirent os.FileInfo) string {
-	// find first character, the type char
-	// b     Block special file.
-	// c     Character special file.
-	// d     Directory.
-	// l     Symbolic link.
-	// s     Socket link.
-	// p     FIFO.
-	// -     Regular file.
-	tc := '-'
-	mode := dirent.Mode()
-	if (mode & os.ModeDir) != 0 {
-		tc = 'd'
-	} else if (mode & os.ModeDevice) != 0 {
-		tc = 'b'
-		if (mode & os.ModeCharDevice) != 0 {
-			tc = 'c'
-		}
-	} else if (mode & os.ModeSymlink) != 0 {
-		tc = 'l'
-	} else if (mode & os.ModeSocket) != 0 {
-		tc = 's'
-	} else if (mode & os.ModeNamedPipe) != 0 {
-		tc = 'p'
-	}
-
-	// owner
-	orc := '-'
-	if (mode & 0400) != 0 {
-		orc = 'r'
-	}
-	owc := '-'
-	if (mode & 0200) != 0 {
-		owc = 'w'
-	}
-	oxc := '-'
-	ox := (mode & 0100) != 0
-	setuid := (mode & os.ModeSetuid) != 0
-	if ox && setuid {
-		oxc = 's'
-	} else if setuid {
-		oxc = 'S'
-	} else if ox {
-		oxc = 'x'
-	}
-
-	// group
-	grc := '-'
-	if (mode & 040) != 0 {
-		grc = 'r'
-	}
-	gwc := '-'
-	if (mode & 020) != 0 {
-		gwc = 'w'
-	}
-	gxc := '-'
-	gx := (mode & 010) != 0
-	setgid := (mode & os.ModeSetgid) != 0
-	if gx && setgid {
-		gxc = 's'
-	} else if setgid {
-		gxc = 'S'
-	} else if gx {
-		gxc = 'x'
-	}
-
-	// all / others
-	arc := '-'
-	if (mode & 04) != 0 {
-		arc = 'r'
-	}
-	awc := '-'
-	if (mode & 02) != 0 {
-		awc = 'w'
-	}
-	axc := '-'
-	ax := (mode & 01) != 0
-	sticky := (mode & os.ModeSticky) != 0
-	if ax && sticky {
-		axc = 't'
-	} else if sticky {
-		axc = 'T'
-	} else if ax {
-		axc = 'x'
-	}
-
-	return fmt.Sprintf("%c%c%c%c%c%c%c%c%c%c", tc, orc, owc, oxc, grc, gwc, gxc, arc, awc, axc)
-}
-
-func runLsStatt(dirname string, dirent os.FileInfo, statt *syscall.Stat_t) string {
+func runLsStatt(dirent os.FileInfo, statt *syscall.Stat_t) string {
 	// example from openssh sftp server:
 	// crw-rw-rw-    1 root     wheel           0 Jul 31 20:52 ttyvd
 	// format:
@@ -136,7 +47,7 @@ func runLs(dirname string, dirent os.FileInfo) string {
 	if dsys == nil {
 	} else if statt, ok := dsys.(*syscall.Stat_t); !ok {
 	} else {
-		return runLsStatt(dirname, dirent, statt)
+		return runLsStatt(dirent, statt)
 	}
 
 	return path.Join(dirname, dirent.Name())


### PR DESCRIPTION
On windows systems the directory separator is a backslash (\). This leads to misbehavior of the library in some cases. I tried to fix this issues without changing to much code.

According to RFC https://tools.ietf.org/html/draft-ietf-secsh-filexfer-02, SFTP always uses slashes. 

Other improvements:
- added elementary unit-test for runLs (server.go)
- changed stub version of "runLs" to provide an as valid as possible longname attribute (i tried to follow the windows 10 ubuntu layer ls command, which is an improvement, because widely used open source sftp client FileZilla can now be used connecting windows sftp servers)
