### PR TITLE
Fixes to mkdir example

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -104,14 +104,26 @@ func ExampleClient_Mkdir_parents() {
 	}
 	defer client.Close()
 
-	ssh_fx_failure := uint32(4)
+	sshFxFailure := uint32(4)
 	mkdirParents := func(client *sftp.Client, dir string) (err error) {
 		var parents string
+		
+		if path.IsAbs(dir) {
+			// Otherwise, an absolute path given below would be turned in to a relative one
+			// by splitting on "/"
+			parents = "/"
+		}
+		
 		for _, name := range strings.Split(dir, "/") {
+			if name == "" {
+				// Paths with double-/ in them should just move along
+				// this will also catch the case of the first character being a "/", i.e. an absolute path
+				continue
+			}
 			parents = path.Join(parents, name)
 			err = client.Mkdir(parents)
 			if status, ok := err.(*sftp.StatusError); ok {
-				if status.Code == ssh_fx_failure {
+				if status.Code == sshFxFailure {
 					var fi os.FileInfo
 					fi, err = client.Stat(parents)
 					if err == nil {


### PR DESCRIPTION
* Adjusting name of `ssh_fx_failure` variable to match go formatting
* Fixing logic error for absolute paths