### PR TITLE
Add PosixRename method which uses the posix-rename@openssh.com extension

### DIFF
--- a/client.go
+++ b/client.go
@@ -575,6 +575,26 @@ func (c *Client) Rename(oldname, newname string) error {
 	}
 }
 
+// PosixRename renames a file using the posix-rename@openssh.com extension
+// which will replace newname if it already exists.
+func (c *Client) PosixRename(oldname, newname string) error {
+	id := c.nextID()
+	typ, data, err := c.sendPacket(sshFxpPosixRenamePacket{
+		ID:      id,
+		Oldpath: oldname,
+		Newpath: newname,
+	})
+	if err != nil {
+		return err
+	}
+	switch typ {
+	case ssh_FXP_STATUS:
+		return normaliseError(unmarshalStatus(id, data))
+	default:
+		return unimplementedPacketErr(typ)
+	}
+}
+
 func (c *Client) realpath(path string) (string, error) {
 	id := c.nextID()
 	typ, data, err := c.sendPacket(sshFxpRealpathPacket{

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -627,6 +627,27 @@ func TestClientRename(t *testing.T) {
 	}
 }
 
+func TestClientPosixRename(t *testing.T) {
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
+	defer cmd.Wait()
+	defer sftp.Close()
+
+	f, err := ioutil.TempFile("", "sftptest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2 := f.Name() + ".new"
+	if err := sftp.PosixRename(f.Name(), f2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(f.Name()); !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(f2); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestClientGetwd(t *testing.T) {
 	sftp, cmd := testClient(t, READONLY, NO_DELAY)
 	defer cmd.Wait()

--- a/packet-typing.go
+++ b/packet-typing.go
@@ -51,6 +51,7 @@ func (p sshFxpSetstatPacket) getPath() string  { return p.Path }
 func (p sshFxpStatvfsPacket) getPath() string  { return p.Path }
 func (p sshFxpRemovePacket) getPath() string   { return p.Filename }
 func (p sshFxpRenamePacket) getPath() string   { return p.Oldpath }
+func (p sshFxpExtendedPacketPosixRename) getPath() string { return p.Oldpath }
 func (p sshFxpSymlinkPacket) getPath() string  { return p.Targetpath }
 
 // Openers implement hasPath and isOpener
@@ -74,6 +75,7 @@ func (p sshFxpRemovePacket) notReadOnly()   {}
 func (p sshFxpMkdirPacket) notReadOnly()    {}
 func (p sshFxpRmdirPacket) notReadOnly()    {}
 func (p sshFxpRenamePacket) notReadOnly()   {}
+func (p sshFxpExtendedPacketPosixRename) notReadOnly() {}
 func (p sshFxpSymlinkPacket) notReadOnly()  {}
 
 // this has a handle, but is only used for close

--- a/request-example.go
+++ b/request-example.go
@@ -70,9 +70,11 @@ func (fs *root) Filecmd(r *Request) error {
 		if err != nil {
 			return err
 		}
+		if _, ok := r.Packet.(*sshFxpExtendedPacketPosixRename); !ok {
 		if _, ok := fs.files[r.Target]; ok {
 			return &os.LinkError{Op: "rename", Old: r.Filepath, New: r.Target,
 				Err: fmt.Errorf("dest file exists")}
+		}
 		}
 		fs.files[r.Target] = file
 		delete(fs.files, r.Filepath)

--- a/request-server.go
+++ b/request-server.go
@@ -123,6 +123,9 @@ func (rs *RequestServer) Serve() error {
 
 func (rs *RequestServer) packetWorker(pktChan chan requestPacket) error {
 	for pkt := range pktChan {
+		if p, ok := pkt.(*sshFxpExtendedPacket); ok {
+			pkt = p.SpecificPacket
+		}
 		var rpkt responsePacket
 		switch pkt := pkt.(type) {
 		case *sshFxInitPacket:

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -217,6 +217,22 @@ func TestRequestRename(t *testing.T) {
 	assert.Equal(t, err, os.ErrNotExist)
 }
 
+func TestRequestPosixRename(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	_, err := putTestFile(p.cli, "/foo", "hello")
+	assert.Nil(t, err)
+	r := p.testHandler()
+	_, err = r.fetch("/foo")
+	assert.Nil(t, err)
+	err = p.cli.PosixRename("/foo", "/bar")
+	assert.Nil(t, err)
+	_, err = r.fetch("/bar")
+	assert.Nil(t, err)
+	_, err = r.fetch("/foo")
+	assert.Equal(t, err, os.ErrNotExist)
+}
+
 func TestRequestRenameFail(t *testing.T) {
 	p := clientRequestServerPair(t)
 	defer p.Close()
@@ -226,6 +242,17 @@ func TestRequestRenameFail(t *testing.T) {
 	assert.Nil(t, err)
 	err = p.cli.Rename("/foo", "/bar")
 	assert.IsType(t, &StatusError{}, err)
+}
+
+func TestRequestPosixRenameReplaceSuccess(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	_, err := putTestFile(p.cli, "/foo", "hello")
+	assert.Nil(t, err)
+	_, err = putTestFile(p.cli, "/bar", "goodbye")
+	assert.Nil(t, err)
+	err = p.cli.PosixRename("/foo", "/bar")
+	assert.Nil(t, err)
 }
 
 func TestRequestStat(t *testing.T) {

--- a/request.go
+++ b/request.go
@@ -21,8 +21,9 @@ type Request struct {
 	Method   string
 	Filepath string
 	Flags    uint32
-	Attrs    []byte // convert to sub-struct
-	Target   string // for renames and sym-links
+	Attrs    []byte      // convert to sub-struct
+	Target   string      // for renames and sym-links
+	Packet   interface{} // original request packet, can be used to distinguish flattened methods.
 	// reader/writer/readdir from handlers
 	stateLock *sync.RWMutex
 	state     *state
@@ -50,12 +51,15 @@ func (pd packet_data) id() uint32 {
 func requestFromPacket(pkt hasPath) *Request {
 	method := requestMethod(pkt)
 	request := NewRequest(method, pkt.getPath())
+	request.Packet = pkt
 	switch p := pkt.(type) {
 	case *sshFxpSetstatPacket:
 		request.Flags = p.Flags
 		request.Attrs = p.Attrs.([]byte)
 	case *sshFxpRenamePacket:
 		request.Target = cleanPath(p.Newpath)
+	case *sshFxpExtendedPacketPosixRename:
+		request.Target = filepath.Clean(p.Newpath)
 	case *sshFxpSymlinkPacket:
 		request.Target = cleanPath(p.Linkpath)
 	}
@@ -325,7 +329,7 @@ func requestMethod(p hasPath) (method string) {
 		method = "Open"
 	case *sshFxpSetstatPacket:
 		method = "Setstat"
-	case *sshFxpRenamePacket:
+	case *sshFxpRenamePacket, *sshFxpExtendedPacketPosixRename:
 		method = "Rename"
 	case *sshFxpSymlinkPacket:
 		method = "Symlink"


### PR DESCRIPTION
to support actual rename() operations rather than the link() call
effectively mandated by the sftp v3/draft-2 requirement that targets
not be overwritten.

this is my first git/github operation so please be kind if I've prepared
it incorrectly or am not following the right procedure :)

thanks!