### PR TITLE
Fix parsing of '.' for Cyberduck client

### DIFF
--- a/request-server.go
+++ b/request-server.go
@@ -199,6 +199,12 @@ func cleanPacketPath(pkt *sshFxpRealpathPacket) responsePacket {
 
 func cleanPath(path string) string {
 	cleanSlashPath := filepath.ToSlash(filepath.Clean(path))
+	if cleanSlashPath == "." || cleanSlashPath == ".." {
+		//At this stage, the path is not valid
+		//This occurs when there is root .. or . in the path, which clean did not remove. This will point to root.
+		return "/"
+	}
+
 	if !strings.HasPrefix(cleanSlashPath, "/") {
 		return "/" + cleanSlashPath
 	}

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -335,6 +335,12 @@ func TestCleanPath(t *testing.T) {
 	assert.Equal(t, "/a", cleanPath("/a/"))
 	assert.Equal(t, "/a", cleanPath("a/"))
 	assert.Equal(t, "/a/b/c", cleanPath("/a//b//c/"))
+	assert.Equal(t, "/", cleanPath("/."))
+	assert.Equal(t, "/", cleanPath("."))
+	assert.Equal(t, "/", cleanPath(".."))
+	assert.Equal(t, "/", cleanPath("/./a/.."))
+	assert.Equal(t, "/", cleanPath("/a/.."))
+	assert.Equal(t, "/", cleanPath("/.."))
 
 	// filepath.ToSlash does not touch \ as char on unix systems, so os.PathSeparator is used for windows compatible tests
 	bslash := string(os.PathSeparator)


### PR DESCRIPTION
This PR resolves the issue identified here:
https://github.com/pkg/sftp/issues/207

Cyberduck requests the REALPATH of ".", which after filepath.Clean, returns as ".", which is invalid.

This fixes such logic to ensure that if the clean returns ".", it changes it to "/", following the old, correct logic.