### PR TITLE
respect create flag in open packet

### DIFF
--- a/request-server.go
+++ b/request-server.go
@@ -152,7 +152,12 @@ func (rs *RequestServer) packetWorker(pktChan chan requestPacket) error {
 		case *sshFxpRealpathPacket:
 			rpkt = cleanPacketPath(pkt)
 		case isOpener:
-			handle := rs.nextRequest(requestFromPacket(pkt))
+			request := requestFromPacket(pkt)
+			handle := rs.nextRequest(request)
+			p, ok := pkt.(*sshFxpOpenPacket)
+			if ok && p.hasPflags(ssh_FXF_CREAT) {
+				request.call(rs.Handlers, pkt)
+			}
 			rpkt = sshFxpHandlePacket{pkt.id(), handle}
 		case *sshFxpFstatPacket:
 			handle := pkt.getHandle()

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -127,6 +127,20 @@ func TestRequestWrite(t *testing.T) {
 	assert.Equal(t, f.content, []byte("hello"))
 }
 
+func TestRequestWriteEmpty(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	n, err := putTestFile(p.cli, "/foo", "")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, n)
+	r := p.testHandler()
+	f, err := r.fetch("/foo")
+	if assert.Nil(t, err) {
+		assert.False(t, f.isdir)
+		assert.Equal(t, f.content, []byte(""))
+	}
+}
+
 // needs fail check
 func TestRequestFilename(t *testing.T) {
 	p := clientRequestServerPair(t)

--- a/request.go
+++ b/request.go
@@ -135,7 +135,7 @@ func (r *Request) call(handlers Handlers, pkt requestPacket) responsePacket {
 	switch r.Method {
 	case "Get":
 		return fileget(handlers.FileGet, r, pd)
-	case "Put": // add "Append" to this to handle append only file writes
+	case "Put", "Open": // add "Append" to handle append only file writes
 		return fileput(handlers.FilePut, r, pd)
 	case "Setstat", "Rename", "Rmdir", "Mkdir", "Symlink", "Remove":
 		return filecmd(handlers.FileCmd, r, pd)


### PR DESCRIPTION
When the SSH_FXP_OPEN packet has the SSH_FXF_CREAT pflag set the file
should get created even if no data is sent. We do this by having the
Open method call through to the FilePut Handler with empty packet data.

Fixes #214