### PR TITLE
Send unsupported error on extended packets.

### DIFF
--- a/packet-typing.go
+++ b/packet-typing.go
@@ -127,7 +127,9 @@ func makePacket(p rxPacket) (requestPacket, error) {
 		return nil, errors.Errorf("unhandled packet type: %s", p.pktType)
 	}
 	if err := pkt.UnmarshalBinary(p.pktBytes); err != nil {
-		return nil, err
+		// Return partially unpacked packet to allow callers to return
+		// error messages appropriately with necessary id() method.
+		return pkt, err
 	}
 	return pkt, nil
 }

--- a/packet.go
+++ b/packet.go
@@ -874,10 +874,18 @@ type sshFxpExtendedPacket struct {
 	}
 }
 
-func (p sshFxpExtendedPacket) id() uint32     { return p.ID }
-func (p sshFxpExtendedPacket) readonly() bool { return p.SpecificPacket.readonly() }
+func (p sshFxpExtendedPacket) id() uint32 { return p.ID }
+func (p sshFxpExtendedPacket) readonly() bool {
+	if p.SpecificPacket == nil {
+		return true
+	}
+	return p.SpecificPacket.readonly()
+}
 
 func (p sshFxpExtendedPacket) respond(svr *Server) error {
+	if p.SpecificPacket == nil {
+		return nil
+	}
 	return p.SpecificPacket.respond(svr)
 }
 
@@ -897,7 +905,7 @@ func (p *sshFxpExtendedPacket) UnmarshalBinary(b []byte) error {
 	case "posix-rename@openssh.com":
 		p.SpecificPacket = &sshFxpExtendedPacketPosixRename{}
 	default:
-		return errUnknownExtendedPacket
+		return errors.Wrapf(errUnknownExtendedPacket, "packet type %v", p.SpecificPacket)
 	}
 
 	return p.SpecificPacket.UnmarshalBinary(bOrig)

--- a/request-server.go
+++ b/request-server.go
@@ -130,7 +130,11 @@ func (rs *RequestServer) Serve() error {
 		if err != nil {
 			switch errors.Cause(err) {
 			case errUnknownExtendedPacket:
-				rs.serverConn.sendError(pkt, ErrSshFxOpUnsupported)
+				if err := rs.serverConn.sendError(pkt, ErrSshFxOpUnsupported); err != nil {
+					debug("failed to send err packet: %v", err)
+					rs.conn.Close() // shuts down recvPacket
+					break
+				}
 			default:
 				debug("makePacket err: %v", err)
 				rs.conn.Close() // shuts down recvPacket

--- a/request-server.go
+++ b/request-server.go
@@ -128,9 +128,14 @@ func (rs *RequestServer) Serve() error {
 
 		pkt, err = makePacket(rxPacket{fxp(pktType), pktBytes})
 		if err != nil {
-			debug("makePacket err: %v", err)
-			rs.conn.Close() // shuts down recvPacket
-			break
+			switch errors.Cause(err) {
+			case errUnknownExtendedPacket:
+				rs.serverConn.sendError(pkt, ErrSshFxOpUnsupported)
+			default:
+				debug("makePacket err: %v", err)
+				rs.conn.Close() // shuts down recvPacket
+				break
+			}
 		}
 
 		pktChan <- pkt


### PR DESCRIPTION
Following the rules outlined here:

https://tools.ietf.org/html/draft-ietf-secsh-filexfer-extensions-00

Return an SSH_FXP_STATUS with appropriate status error for extended
packets that we do not support.

Fixes #233 