### PR TITLE
Add ability to set restricted root directory

### DIFF
--- a/server.go
+++ b/server.go
@@ -138,7 +138,7 @@ func (svr *Server) sftpServerWorker(pktChan chan requestPacket) error {
 
 		// permission checks
 		permiss := true
-		if svr.systemRoot != "" {
+		if stat, err := os.Stat(svr.systemRoot); err == nil && stat.IsDir() {
 			switch pkt := pkt.(type) {
 				case *sshFxpRenamePacket:
 					rel, e := filepath.Rel(svr.systemRoot, pkt.Oldpath)

--- a/server.go
+++ b/server.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"strings"
 )
 
 const (
@@ -34,6 +35,7 @@ type Server struct {
 	openFilesLock sync.RWMutex
 	handleCount   int
 	maxTxPacket   uint32
+	systemRoot string
 }
 
 func (svr *Server) nextHandle(f *os.File) string {
@@ -117,6 +119,13 @@ func ReadOnly() ServerOption {
 	}
 }
 
+func RootDirectory(root string) ServerOption {
+	return func(s *Server) error {
+		s.systemRoot = root
+		return nil
+	}
+}
+
 type rxPacket struct {
 	pktType  fxp
 	pktBytes []byte
@@ -126,20 +135,32 @@ type rxPacket struct {
 func (svr *Server) sftpServerWorker(pktChan chan requestPacket) error {
 	for pkt := range pktChan {
 
-		// readonly checks
+		// readonly and permission checks
 		readonly := true
+		permiss := true
 		switch pkt := pkt.(type) {
-		case notReadOnly:
-			readonly = false
-		case *sshFxpOpenPacket:
-			readonly = pkt.readonly()
-		case *sshFxpExtendedPacket:
-			readonly = pkt.readonly()
+			case *sshFxpRenamePacket:
+				rel, e := filepath.Rel(svr.systemRoot, pkt.Oldpath)
+				rel2, e2 := filepath.Rel(svr.systemRoot, pkt.Newpath)
+				permiss = e == nil && e2 == nil && !strings.Contains(rel, "..") && !strings.Contains(rel2, "..")
+			case *sshFxpSymlinkPacket:
+				rel, e := filepath.Rel(svr.systemRoot, pkt.Targetpath)
+				rel2, e2 := filepath.Rel(svr.systemRoot, pkt.Linkpath)
+				permiss = e == nil && e2 == nil && !strings.Contains(rel, "..") && !strings.Contains(rel2, "..")
+			case hasPath:
+				rel, e := filepath.Rel(svr.systemRoot, pkt.getPath())
+				permiss = e == nil && !strings.Contains(rel, "..")
+			case notReadOnly:
+				readonly = false
+			case *sshFxpOpenPacket:
+				readonly = pkt.readonly()
+			case *sshFxpExtendedPacket:
+				readonly = pkt.readonly()
 		}
 
-		// If server is operating read-only and a write operation is requested,
-		// return permission denied
-		if !readonly && svr.readOnly {
+		// If server is operating read-only and a write operation is requested, or a restricted file is requested,
+		// return permission denied.
+		if !permiss || (!readonly && svr.readOnly) {
 			if err := svr.sendError(pkt, syscall.EPERM); err != nil {
 				return errors.Wrap(err, "failed to send read only packet response")
 			}


### PR DESCRIPTION
I would like to see the ability to set the root directory of the SSH server, so that users cannot access files and directories outside that new root. I'm not sure whether or not it is possible to limit the filesystem served, so as an alternative this PR denies clients permission when that is attempted.

This was an experiment, and there might be a much better way of doing so. I figured I should PR it anyway in case it sparks someone to think of something brilliant, and to hopefully get this functionality implemented.