### PR TITLE
Opendir return an error status when not found

### DIFF
--- a/request-server_test.go
+++ b/request-server_test.go
@@ -355,6 +355,11 @@ func TestRequestReaddir(t *testing.T) {
 		_, err := putTestFile(p.cli, fname, fname)
 		assert.Nil(t, err)
 	}
+	_, err := p.cli.ReadDir("/foo_01")
+	assert.Equal(t, &StatusError{Code: ssh_FX_FAILURE,
+		msg: " /foo_01: not a directory"}, err)
+	_, err = p.cli.ReadDir("/does_not_exist")
+	assert.Equal(t, os.ErrNotExist, err)
 	di, err := p.cli.ReadDir("/")
 	assert.Nil(t, err)
 	assert.Len(t, di, 100)

--- a/request.go
+++ b/request.go
@@ -338,8 +338,10 @@ func requestMethod(p requestPacket) (method string) {
 		method = "Put"
 	case *sshFxpReaddirPacket:
 		method = "List"
-	case *sshFxpOpenPacket, *sshFxpOpendirPacket:
+	case *sshFxpOpenPacket:
 		method = "Open"
+	case *sshFxpOpendirPacket:
+		method = "Stat"
 	case *sshFxpSetstatPacket, *sshFxpFsetstatPacket:
 		method = "Setstat"
 	case *sshFxpRenamePacket:

--- a/server.go
+++ b/server.go
@@ -240,6 +240,12 @@ func handlePacket(s *Server, p interface{}) error {
 			}},
 		})
 	case *sshFxpOpendirPacket:
+		if stat, err := os.Stat(p.Path); err != nil {
+			return s.sendError(p, err)
+		} else if !stat.IsDir() {
+			return s.sendError(p, &os.PathError{
+				Path: p.Path, Err: syscall.ENOTDIR})
+		}
 		return sshFxpOpenPacket{
 			ID:     p.ID,
 			Path:   p.Path,


### PR DESCRIPTION
The initial Opendir packet is supposed to repond with an error status if
the directory wasn't found. It was just returning a handle without
checking, now it does a Stat on the path and only returns the handle if
the Stat is successful, otherwise it returns an error.

Fixes #253