### PR TITLE
fix issue with reusing opendir file handle

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -198,3 +198,16 @@ func testInfoMethod(t *testing.T, method string) {
 	assert.IsType(t, sshFxpNameAttr{}, npkt.NameAttrs[0])
 	assert.Equal(t, npkt.NameAttrs[0].Name, "request_test.go")
 }
+
+func TestOpendirHandleReuse(t *testing.T) {
+	handlers := newTestHandlers()
+	request := testRequest("Stat")
+	pkt := fakePacket{myid: 1}
+	rpkt := request.call(handlers, pkt)
+	assert.IsType(t, &sshFxpStatResponse{}, rpkt)
+
+	request.Method = "List"
+	pkt = fakePacket{myid: 2}
+	rpkt = request.call(handlers, pkt)
+	assert.IsType(t, &sshFxpNamePacket{}, rpkt)
+}


### PR DESCRIPTION
This is my proposed solution to issue #256. Instead of introducing any new state is simple keeps no state for calls that don't need it (Stat and Readlink). Only keeping the list state for when it is doing a file list (List method).

Includes a simple test that replicated the issue.