### PR TITLE
added build tags required for gcc-go on AIX

### DIFF
--- a/attrs_unix.go
+++ b/attrs_unix.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd !android,linux netbsd openbsd solaris
+// +build darwin dragonfly freebsd !android,linux netbsd openbsd solaris aix
 // +build cgo
 
 package sftp

--- a/server_unix.go
+++ b/server_unix.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd !android,linux netbsd openbsd solaris
+// +build darwin dragonfly freebsd !android,linux netbsd openbsd solaris aix
 // +build cgo
 
 package sftp


### PR DESCRIPTION
while building on AIX Unix, as os name is "aix" these files are not included in the build hence the failure.
with the added build tag it works fine and build is successful.