### PR TITLE
Add io.ReaderAt interface compatibility

### DIFF
--- a/client.go
+++ b/client.go
@@ -790,8 +790,6 @@ func (f *File) Read(b []byte) (int, error) {
 	return r, err
 }
 
-
-
 // ReadAt reads up to len(b) byte from the File at a given offset `off`. It returns 
 // the number of bytes read and an error, if any. ReadAt follows io.ReaderAt semantics, 
 // so the file offset is not altered during the read.
@@ -886,9 +884,6 @@ func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 	}
 	return read, firstErr.err
 }
-
-
-
 
 // WriteTo writes the file to w. The return value is the number of bytes
 // written. Any error encountered during the write is also returned.

--- a/client.go
+++ b/client.go
@@ -785,13 +785,24 @@ func (f *File) Name() string {
 // than calling Read multiple times. io.Copy will do this
 // automatically.
 func (f *File) Read(b []byte) (int, error) {
+	r, err := f.ReadAt(b, int64( f.offset ))
+	f.offset = uint64(r)
+	return r, err
+}
+
+
+
+// ReadAt reads up to len(b) byte from the File at a given offset `off`. It returns 
+// the number of bytes read and an error, if any. ReadAt follows io.ReaderAt semantics, 
+// so the file offset is not altered during the read.
+func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
 	// Split the read into multiple maxPacket sized concurrent reads
 	// bounded by maxConcurrentRequests. This allows reads with a suitably
 	// large buffer to transfer data at a much faster rate due to
 	// overlapping round trip times.
 	inFlight := 0
 	desiredInFlight := 1
-	offset := f.offset
+	offset := uint64( off )
 	// maxConcurrentRequests buffer to deal with broadcastErr() floods
 	// also must have a buffer of max value of (desiredInFlight - inFlight)
 	ch := make(chan result, f.c.maxConcurrentRequests+1)
@@ -873,9 +884,11 @@ func (f *File) Read(b []byte) (int, error) {
 	if firstErr.err != nil && firstErr.err != io.EOF {
 		read = 0
 	}
-	f.offset += uint64(read)
 	return read, firstErr.err
 }
+
+
+
 
 // WriteTo writes the file to w. The return value is the number of bytes
 // written. Any error encountered during the write is also returned.

--- a/client.go
+++ b/client.go
@@ -786,7 +786,7 @@ func (f *File) Name() string {
 // automatically.
 func (f *File) Read(b []byte) (int, error) {
 	r, err := f.ReadAt(b, int64( f.offset ))
-	f.offset = uint64(r)
+	f.offset += uint64(r)
 	return r, err
 }
 


### PR DESCRIPTION
Read is now a proxy for ReadAt. Read uses the returned bytes count to set the new offset for the file, since ReadAt does not alter the offset.