### PR TITLE
Use Stat rather than Fstat in File.WriteTo to work around server bugs

### DIFF
--- a/client.go
+++ b/client.go
@@ -884,7 +884,7 @@ func (f *File) Read(b []byte) (int, error) {
 // maximise throughput for transferring the entire file (especially
 // over high latency links).
 func (f *File) WriteTo(w io.Writer) (int64, error) {
-	fi, err := f.Stat()
+	fi, err := f.c.Stat(f.path)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Before this change in File.WriteTo() we used Fstat to discover the
length of the file being transferred.  It appears that some SFTP
servers do not implement this properly perhaps because it is a seldom
used call.

After this change we replace the Fstat on the file handle with a Stat
of the path.  Stat is commonly used function and implemented correctly
in both the servers that had the problem with Fstat, thus working
around the problem.

The code before and after uses the same number of SFTP roundtrips so
performance should be identical.

Fixes #288