### PR TITLE
Implement the hardlink@openssh.com extension.

### DIFF
--- a/client.go
+++ b/client.go
@@ -358,6 +358,25 @@ func (c *Client) ReadLink(p string) (string, error) {
 	}
 }
 
+// Link creates a hard link at 'newname', pointing at the same inode as 'oldname'
+func (c *Client) Link(oldname, newname string) error {
+	id := c.nextID()
+	typ, data, err := c.sendPacket(sshFxpHardlinkPacket{
+		ID:      id,
+		Oldpath: oldname,
+		Newpath: newname,
+	})
+	if err != nil {
+		return err
+	}
+	switch typ {
+	case ssh_FXP_STATUS:
+		return normaliseError(unmarshalStatus(id, data))
+	default:
+		return unimplementedPacketErr(typ)
+	}
+}
+
 // Symlink creates a symbolic link at 'newname', pointing at target 'oldname'
 func (c *Client) Symlink(oldname, newname string) error {
 	id := c.nextID()

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -715,6 +715,32 @@ func TestClientReadLink(t *testing.T) {
 	}
 }
 
+func TestClientLink(t *testing.T) {
+	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
+	defer cmd.Wait()
+	defer sftp.Close()
+
+	f, err := ioutil.TempFile("", "sftptest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := []byte("linktest")
+	_, err = f.Write(data)
+	f.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2 := f.Name() + ".link"
+	if err := sftp.Link(f.Name(), f2); err != nil {
+		t.Fatal(err)
+	}
+	if st2, err := sftp.Stat(f2); err != nil {
+		t.Fatal(err)
+	} else if int(st2.Size()) != len(data) {
+		t.Fatalf("unexpected link size: %v, not %v", st2.Size(), len(data))
+	}
+}
+
 func TestClientSymlink(t *testing.T) {
 	sftp, cmd := testClient(t, READWRITE, NO_DELAY)
 	defer cmd.Wait()

--- a/packet-typing.go
+++ b/packet-typing.go
@@ -49,8 +49,9 @@ func (p sshFxpOpendirPacket) getPath() string  { return p.Path }
 func (p sshFxpOpenPacket) getPath() string     { return p.Path }
 
 func (p sshFxpExtendedPacketPosixRename) getPath() string { return p.Oldpath }
+func (p sshFxpExtendedPacketHardlink) getPath() string    { return p.Oldpath }
 
-// hasHandle
+// getHandle
 func (p sshFxpFstatPacket) getHandle() string    { return p.Handle }
 func (p sshFxpFsetstatPacket) getHandle() string { return p.Handle }
 func (p sshFxpReadPacket) getHandle() string     { return p.Handle }
@@ -68,6 +69,7 @@ func (p sshFxpRmdirPacket) notReadOnly()               {}
 func (p sshFxpRenamePacket) notReadOnly()              {}
 func (p sshFxpSymlinkPacket) notReadOnly()             {}
 func (p sshFxpExtendedPacketPosixRename) notReadOnly() {}
+func (p sshFxpExtendedPacketHardlink) notReadOnly()    {}
 
 // some packets with ID are missing id()
 func (p sshFxpDataPacket) id() uint32   { return p.ID }

--- a/request-example.go
+++ b/request-example.go
@@ -102,6 +102,15 @@ func (fs *root) Filecmd(r *Request) error {
 			return err
 		}
 		fs.files[r.Filepath] = newMemFile(r.Filepath, true)
+	case "Link":
+		file, err := fs.fetch(r.Filepath)
+		if err != nil {
+			return err
+		}
+		if file.IsDir() {
+			return fmt.Errorf("hard link not allowed for directory")
+		}
+		fs.files[r.Target] = file
 	case "Symlink":
 		_, err := fs.fetch(r.Filepath)
 		if err != nil {

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -32,7 +32,7 @@ type FileWriter interface {
 
 // FileCmder should return an error
 // Note in cases of an error, the error text will be sent to the client.
-// Called for Methods: Setstat, Rename, Rmdir, Mkdir, Symlink, Remove
+// Called for Methods: Setstat, Rename, Rmdir, Mkdir, Link, Symlink, Remove
 type FileCmder interface {
 	Filecmd(*Request) error
 }

--- a/request-server.go
+++ b/request-server.go
@@ -148,6 +148,10 @@ func (rs *RequestServer) packetWorker(
 	ctx context.Context, pktChan chan orderedRequest,
 ) error {
 	for pkt := range pktChan {
+		if epkt, ok := pkt.requestPacket.(*sshFxpExtendedPacket); ok {
+			pkt.requestPacket = epkt.SpecificPacket
+		}
+
 		var rpkt responsePacket
 		switch pkt := pkt.requestPacket.(type) {
 		case *sshFxInitPacket:

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -313,6 +313,27 @@ func TestRequestStatFail(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestRequestLink(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	_, err := putTestFile(p.cli, "/foo", "hello")
+	assert.Nil(t, err)
+	err = p.cli.Link("/foo", "/bar")
+	assert.Nil(t, err)
+	r := p.testHandler()
+	fi, err := r.fetch("/bar")
+	assert.Nil(t, err)
+	assert.True(t, int(fi.Size()) == len("hello"))
+}
+
+func TestRequestLinkFail(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	err := p.cli.Link("/foo", "/bar")
+	t.Log(err)
+	assert.True(t, os.IsNotExist(err))
+}
+
 func TestRequestSymlink(t *testing.T) {
 	p := clientRequestServerPair(t)
 	defer p.Close()

--- a/server.go
+++ b/server.go
@@ -156,7 +156,12 @@ func handlePacket(s *Server, p orderedRequest) error {
 	var rpkt responsePacket
 	switch p := p.requestPacket.(type) {
 	case *sshFxInitPacket:
-		rpkt = sshFxVersionPacket{Version: sftpProtocolVersion}
+		rpkt = sshFxVersionPacket{
+			Version: sftpProtocolVersion,
+			Extensions: []sshExtensionPair{
+				{"hardlink@openssh.com", "1"},
+			},
+		}
 	case *sshFxpStatPacket:
 		// stat the requested file
 		info, err := os.Stat(p.Path)


### PR DESCRIPTION
Both client and server. This is documented in

  https://github.com/openssh/openssh-portable/blob/master/PROTOCOL

Draft 7 of SFTP added support for SSH_FXP_LINK which supports both
symlinks and hardlinks, but unfortunately OpenSSH doesn't support
that:

  https://tools.ietf.org/html/draft-ietf-secsh-filexfer-07#section-7.7

Adding support for this as an option would be a nice extension to
this.