### PR TITLE
Remove sudo setting from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - os: osx
       go: tip
 
-sudo: false
+
 
 addons:
   ssh_known_hosts:


### PR DESCRIPTION
# Overview
Remove `sudo: false` setting from `travis.yml` .

# Context
According to the following posts, Travis-CI had two Linux infrastructures which are containers and virtual machines, but recently Travis-CI was combined two Linux infrastructures into a virtual machine-based Linux infrastructures.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures

Now Container-based environment is duplicated.

[Build Environment Overview - Travis CI](https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments)

> If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon.

quoted by
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration