### PR TITLE
Bug with sub folders/files of a renamed/removed path

### DIFF
--- a/request-example.go
+++ b/request-example.go
@@ -93,10 +93,8 @@ func (fs *root) Filecmd(r *Request) error {
 		delete(fs.files, r.Filepath)
 
 		if file.IsDir() {
-			fmt.Printf("Rename Dir %v, %v, %v\n", r.Target, file.name, r.Filepath)
 			for path, file := range fs.files {
 				if strings.HasPrefix(path, r.Filepath+"/") {
-					fmt.Printf("renaming %v from %v to %v\n", file.name, path, r.Target+path[len(r.Filepath):])
 					file.name = r.Target + path[len(r.Filepath):]
 					fs.files[r.Target+path[len(r.Filepath):]] = file
 					delete(fs.files, path)
@@ -123,13 +121,6 @@ func (fs *root) Filecmd(r *Request) error {
 
 		delete(fs.files, r.Filepath)
 
-		if file.IsDir() {
-			for path := range fs.files {
-				if strings.HasPrefix(path, r.Filepath+"/") {
-					delete(fs.files, path)
-				}
-			}
-		}
 	case "Mkdir":
 		_, err := fs.fetch(filepath.Dir(r.Filepath))
 		if err != nil {


### PR DESCRIPTION
When removing or renaming a folder, sub files/folders of the path were not being updated. I just created a loop to update anything with a matching path.