### PR TITLE
fix nil panic error

### DIFF
--- a/request-server.go
+++ b/request-server.go
@@ -159,7 +159,9 @@ func (rs *RequestServer) packetWorker(
 ) error {
 	for pkt := range pktChan {
 		if epkt, ok := pkt.requestPacket.(*sshFxpExtendedPacket); ok {
-			pkt.requestPacket = epkt.SpecificPacket
+			if epkt.SpecificPacket != nil {
+				pkt.requestPacket = epkt.SpecificPacket
+			}
 		}
 
 		var rpkt responsePacket


### PR DESCRIPTION
the `shFxpExtendedPacket` field `SpecificPacket `will be nil, as its function `UnmarshalBinary`   got an err , when sftp could not recognize `ExtendedRequest` string.