### PR TITLE
Bug: windows specific issue on request-server.go

### DIFF
--- a/request-server.go
+++ b/request-server.go
@@ -188,15 +188,10 @@ func (rs *RequestServer) packetWorker(
 				request = NewRequest("Stat", request.Filepath)
 				rpkt = request.call(rs.Handlers, pkt)
 			}
-		case *sshFxpExtendedPacket:
-			switch expkt := pkt.SpecificPacket.(type) {
-			default:
-				rpkt = statusFromError(pkt, ErrSSHFxOpUnsupported)
-			case *sshFxpExtendedPacketPosixRename:
-				request := NewRequest("Rename", expkt.Oldpath)
-				request.Target = expkt.Newpath
-				rpkt = request.call(rs.Handlers, pkt)
-			}
+		case *sshFxpExtendedPacketPosixRename:
+			request := NewRequest("Rename", pkt.Oldpath)
+			request.Target = pkt.Newpath
+			rpkt = request.call(rs.Handlers, pkt)
 		case hasHandle:
 			handle := pkt.getHandle()
 			request, ok := rs.getRequest(handle)


### PR DESCRIPTION
I would like you to review the suggestions please.

Both came from practical issues I had using the package. 

The first problem with the Dir() function, like I said in the commit its more specifically clean() function in the Dir() function. It assumes the filesystem separator based on the OS. As its specified as in the Linux format the cleanup starts replacing / with \

The second issue I came about when renaming things. Previous code from an much older commit, didn't have any rename issues, so i'm unclear how this problem came in. Also I've undone some other edit, which might be solving another issue. I'm not certain this is the correct solution but it solves in my instance, i'd appreciate review on that.