### PR TITLE
WIP: add support for check-file extension

### DIFF
--- a/packet-typing.go
+++ b/packet-typing.go
@@ -48,16 +48,18 @@ func (p sshFxpSymlinkPacket) getPath() string  { return p.Targetpath }
 func (p sshFxpOpendirPacket) getPath() string  { return p.Path }
 func (p sshFxpOpenPacket) getPath() string     { return p.Path }
 
-func (p sshFxpExtendedPacketPosixRename) getPath() string { return p.Oldpath }
-func (p sshFxpExtendedPacketHardlink) getPath() string    { return p.Oldpath }
+func (p sshFxpExtendedPacketPosixRename) getPath() string   { return p.Oldpath }
+func (p sshFxpExtendedPacketHardlink) getPath() string      { return p.Oldpath }
+func (p sshFxpExtendedPacketCheckFileName) getPath() string { return p.Path }
 
 // getHandle
-func (p sshFxpFstatPacket) getHandle() string    { return p.Handle }
-func (p sshFxpFsetstatPacket) getHandle() string { return p.Handle }
-func (p sshFxpReadPacket) getHandle() string     { return p.Handle }
-func (p sshFxpWritePacket) getHandle() string    { return p.Handle }
-func (p sshFxpReaddirPacket) getHandle() string  { return p.Handle }
-func (p sshFxpClosePacket) getHandle() string    { return p.Handle }
+func (p sshFxpFstatPacket) getHandle() string                   { return p.Handle }
+func (p sshFxpFsetstatPacket) getHandle() string                { return p.Handle }
+func (p sshFxpReadPacket) getHandle() string                    { return p.Handle }
+func (p sshFxpWritePacket) getHandle() string                   { return p.Handle }
+func (p sshFxpReaddirPacket) getHandle() string                 { return p.Handle }
+func (p sshFxpClosePacket) getHandle() string                   { return p.Handle }
+func (p sshFxpExtendedPacketCheckFileHandle) getHandle() string { return p.Handle }
 
 // notReadOnly
 func (p sshFxpWritePacket) notReadOnly()               {}

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -60,3 +60,8 @@ type ListerAt interface {
 type TransferError interface {
 	TransferError(err error)
 }
+
+// FileChecker is an optional interface to handle file hashing requests
+type FileChecker interface {
+	CheckFile(*Request) (CheckFileResponse, error)
+}


### PR DESCRIPTION
This patch add support for file hashing extension

https://tools.ietf.org/html/draft-ietf-secsh-filexfer-extensions-00#section-3

This is useful to check hash of remote files, for example `rclone` use md5sum/sha1sum system commands over SSH to check files hash, it could use this extension instead.

I tested using the request-server example and this python script (this patch is needed https://github.com/paramiko/paramiko/pull/1563)

```
import paramiko
import os

local_file_path = "/tmp/test_file.txt"
remote_file_path = os.path.basename(local_file_path)

local_file = open(local_file_path,"w")
local_file.write("test content\n")
local_file.close()

transport = paramiko.Transport(("127.0.0.1", 2022))
transport.connect(None, "testuser", "tiger", None)
sftpclient = paramiko.SFTPClient.from_transport(transport)
sftpclient.put(local_file_path,remote_file_path)
dirlist = sftpclient.listdir(".")
print(dirlist)
f=sftpclient.open(remote_file_path)
print(f.check("md5",0,0,0))

sftpclient.close()
```

This patch is missing client side code and test cases. Before finishing this work I would like to know if this is an acceptable addition for pkg/sftp since it supports v3 protocol and this extension comes from v6 protocol. Since this is an extension maybe we can reasonably support it backported.

The extension should be announced as `supported2` extension (v6 protocol) so I should avoid to announce it for now or we should advertise v6 protocol server version.

Please let me know what do you think about this patch. If acceptable I could add support for other file xfer extensions too.
