### PR TITLE
Fix panics when attempting to get file attributes from too small byte slices

### DIFF
--- a/attrs.go
+++ b/attrs.go
@@ -15,6 +15,9 @@ const (
 	sshFileXferAttrPermissions = 0x00000004
 	sshFileXferAttrACmodTime   = 0x00000008
 	sshFileXferAttrExtented    = 0x80000000
+
+	sshFileXferAttrAll = sshFileXferAttrSize|sshFileXferAttrUIDGID|sshFileXferAttrPermissions|
+		sshFileXferAttrACmodTime|sshFileXferAttrExtented
 )
 
 // fileInfo is an artificial type designed to satisfy os.FileInfo.

--- a/attrs.go
+++ b/attrs.go
@@ -102,30 +102,30 @@ func unmarshalAttrs(b []byte) (*FileStat, []byte) {
 func getFileStat(flags uint32, b []byte) (*FileStat, []byte) {
 	var fs FileStat
 	if flags&sshFileXferAttrSize == sshFileXferAttrSize {
-		fs.Size, b = unmarshalUint64(b)
+		fs.Size, b, _ = unmarshalUint64Safe(b)
 	}
 	if flags&sshFileXferAttrUIDGID == sshFileXferAttrUIDGID {
-		fs.UID, b = unmarshalUint32(b)
+		fs.UID, b, _ = unmarshalUint32Safe(b)
 	}
 	if flags&sshFileXferAttrUIDGID == sshFileXferAttrUIDGID {
-		fs.GID, b = unmarshalUint32(b)
+		fs.GID, b, _ = unmarshalUint32Safe(b)
 	}
 	if flags&sshFileXferAttrPermissions == sshFileXferAttrPermissions {
-		fs.Mode, b = unmarshalUint32(b)
+		fs.Mode, b, _ = unmarshalUint32Safe(b)
 	}
 	if flags&sshFileXferAttrACmodTime == sshFileXferAttrACmodTime {
-		fs.Atime, b = unmarshalUint32(b)
-		fs.Mtime, b = unmarshalUint32(b)
+		fs.Atime, b, _ = unmarshalUint32Safe(b)
+		fs.Mtime, b, _ = unmarshalUint32Safe(b)
 	}
 	if flags&sshFileXferAttrExtented == sshFileXferAttrExtented {
 		var count uint32
-		count, b = unmarshalUint32(b)
+		count, b, _ = unmarshalUint32Safe(b)
 		ext := make([]StatExtended, count)
 		for i := uint32(0); i < count; i++ {
 			var typ string
 			var data string
-			typ, b = unmarshalString(b)
-			data, b = unmarshalString(b)
+			typ, b, _ = unmarshalStringSafe(b)
+			data, b, _ = unmarshalStringSafe(b)
 			ext[i] = StatExtended{typ, data}
 		}
 		fs.Extended = ext

--- a/request-attrs_test.go
+++ b/request-attrs_test.go
@@ -1,12 +1,10 @@
 package sftp
 
 import (
-	"math"
 	"os"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"testing"
 )
 
 func TestRequestPflags(t *testing.T) {
@@ -52,7 +50,7 @@ func TestRequestAttributes(t *testing.T) {
 }
 
 func TestRequestAttributesEmpty(t *testing.T) {
-	fs, b := getFileStat(math.MaxUint32, nil)
+	fs, b := getFileStat(sshFileXferAttrAll, nil)
 	assert.Equal(t, &FileStat{
 		Extended: []StatExtended{},
 	}, fs)

--- a/request-attrs_test.go
+++ b/request-attrs_test.go
@@ -1,6 +1,7 @@
 package sftp
 
 import (
+	"math"
 	"os"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +49,12 @@ func TestRequestAttributes(t *testing.T) {
 	assert.True(t, testFs.FileMode().IsRegular())
 	assert.False(t, testFs.FileMode().IsDir())
 	assert.Equal(t, testFs.FileMode().Perm(), os.FileMode(700).Perm())
+}
+
+func TestRequestAttributesEmpty(t *testing.T) {
+	fs, b := getFileStat(math.MaxUint32, nil)
+	assert.Equal(t, &FileStat{
+		Extended: []StatExtended{},
+	}, fs)
+	assert.Empty(t, b)
 }


### PR DESCRIPTION
Fixes #325 