### PR TITLE
fix S_IFMT value on windows, plan9 and js/wasm

### DIFF
--- a/attrs.go
+++ b/attrs.go
@@ -16,8 +16,8 @@ const (
 	sshFileXferAttrACmodTime   = 0x00000008
 	sshFileXferAttrExtented    = 0x80000000
 
-	sshFileXferAttrAll = sshFileXferAttrSize|sshFileXferAttrUIDGID|sshFileXferAttrPermissions|
-		sshFileXferAttrACmodTime|sshFileXferAttrExtented
+	sshFileXferAttrAll = sshFileXferAttrSize | sshFileXferAttrUIDGID | sshFileXferAttrPermissions |
+		sshFileXferAttrACmodTime | sshFileXferAttrExtented
 )
 
 // fileInfo is an artificial type designed to satisfy os.FileInfo.
@@ -176,7 +176,7 @@ func marshalFileInfo(b []byte, fi os.FileInfo) []byte {
 // toFileMode converts sftp filemode bits to the os.FileMode specification
 func toFileMode(mode uint32) os.FileMode {
 	var fm = os.FileMode(mode & 0777)
-	switch mode & syscall.S_IFMT {
+	switch mode & S_IFMT {
 	case syscall.S_IFBLK:
 		fm |= os.ModeDevice
 	case syscall.S_IFCHR:

--- a/syscall_fixed.go
+++ b/syscall_fixed.go
@@ -1,0 +1,9 @@
+// +build plan9 windows js,wasm
+
+// Go defines S_IFMT on windows, plan9 and js/wasm as 0x1f000 instead of
+// 0xf000. None of the the other S_IFxyz values include the "1" (in 0x1f000)
+// which prevents them from matching the bitmask.
+
+package sftp
+
+const S_IFMT = 0xf000

--- a/syscall_good.go
+++ b/syscall_good.go
@@ -1,0 +1,8 @@
+// +build !plan9,!windows
+// +build !js !wasm
+
+package sftp
+
+import "syscall"
+
+const S_IFMT = syscall.S_IFMT


### PR DESCRIPTION
Go defines S_IFMT on windows, plan9 and js/wasm as 0x1f000 instead of 0xf000. None of the the other S_IFxyz values include the "1" (in 0x1f000) which prevents them from matching the bitmask.

This fixes that by overriding the S_IFMT value on the effected platforms to be 0xf000, as it it on all the others.

Fixes #291 