### PR TITLE
server integration test: add /usr/lib/ssh/sftp-server to search paths

### DIFF
--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -39,6 +39,7 @@ func TestMain(m *testing.M) {
 	lookSFTPServer := []string{
 		"/usr/libexec/sftp-server",
 		"/usr/lib/openssh/sftp-server",
+		"/usr/lib/ssh/sftp-server",
 	}
 	sftpServer, _ := exec.LookPath("sftp-server")
 	if len(sftpServer) == 0 {


### PR DESCRIPTION
os some distro, for example ArchLinux, the sftp-server CLI is in this
path