### PR TITLE
fix connection close race

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -31,6 +31,12 @@ func (c *conn) sendPacket(m encoding.BinaryMarshaler) error {
 	return sendPacket(c, m)
 }
 
+func (c *conn) Close() error {
+	c.Lock()
+	defer c.Unlock()
+	return c.WriteCloser.Close()
+}
+
 type clientConn struct {
 	conn
 	wg         sync.WaitGroup
@@ -67,9 +73,7 @@ func (c *clientConn) loop() {
 // appropriate channel.
 func (c *clientConn) recv() error {
 	defer func() {
-		c.conn.Lock()
 		c.conn.Close()
-		c.conn.Unlock()
 	}()
 	for {
 		typ, data, err := c.recvPacket()


### PR DESCRIPTION
Need to prevent Close from being called at the same time. The lock
already existed, but was only used in one place where it should be
applied generally.

Fixes #333