### PR TITLE
fileget: allocate a slice with enough capacity

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -826,6 +826,8 @@ type sshFxpDataPacket struct {
 	Data   []byte
 }
 
+// MarshalBinary encodes the receiver into a binary form and returns the result.
+// To avoid a new allocation the Data slice must have a capacity >= Length + 9
 func (p sshFxpDataPacket) MarshalBinary() ([]byte, error) {
 	b := append(p.Data, make([]byte, 9)...)
 	copy(b[9:], p.Data[:p.Length])

--- a/packet.go
+++ b/packet.go
@@ -820,10 +820,11 @@ type sshFxpDataPacket struct {
 }
 
 func (p sshFxpDataPacket) MarshalBinary() ([]byte, error) {
-	b := []byte{sshFxpData}
-	b = marshalUint32(b, p.ID)
-	b = marshalUint32(b, p.Length)
-	b = append(b, p.Data[:p.Length]...)
+	b := append(p.Data, make([]byte, 9)...)
+	copy(b[9:], p.Data[:p.Length])
+	b[0] = sshFxpData
+	binary.BigEndian.PutUint32(b[1:5], p.ID)
+	binary.BigEndian.PutUint32(b[5:9], p.Length)
 	return b, nil
 }
 

--- a/packet.go
+++ b/packet.go
@@ -586,9 +586,9 @@ func (p *sshFxpReadPacket) UnmarshalBinary(b []byte) error {
 
 func (p *sshFxpReadPacket) getDataSlice() []byte {
 	dataLen := clamp(p.Len, maxTxPacket)
-	// we allocate a slice with a bigger capacity so we avoid a new allocation in MarshalBinary and in sendPacket
-	// we need 9 bytes in MarshalBinary and 4 bytes in sendPacket
-	return make([]byte, dataLen, dataLen+13)
+	// we allocate a slice with a bigger capacity so we avoid a new allocation in sshFxpDataPacket.MarshalBinary
+	// and in sendPacket, we need 9 bytes in MarshalBinary and 4 bytes in sendPacket
+	return make([]byte, dataLen, dataLen+9+4)
 }
 
 type sshFxpRenamePacket struct {

--- a/packet.go
+++ b/packet.go
@@ -584,6 +584,13 @@ func (p *sshFxpReadPacket) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
+func (p *sshFxpReadPacket) getDataSlice() []byte {
+	dataLen := clamp(p.Len, maxTxPacket)
+	// we allocate a slice with a bigger capacity so we avoid a new allocation in MarshalBinary and in sendPacket
+	// we need 9 bytes in MarshalBinary and 4 bytes in sendPacket
+	return make([]byte, dataLen, dataLen+13)
+}
+
 type sshFxpRenamePacket struct {
 	ID      uint32
 	Oldpath string

--- a/request.go
+++ b/request.go
@@ -216,7 +216,10 @@ func fileget(h FileReader, r *Request, pkt requestPacket) responsePacket {
 	}
 
 	_, offset, length := packetData(pkt)
-	data := make([]byte, clamp(length, maxTxPacket))
+	dataLen := clamp(length, maxTxPacket)
+	// we allocate a slice with a bigger capacity so we avoid a new allocation in MarshalBinary and in sendPacket
+	// we need 9 bytes in MarshalBinary and 4 bytes in sendPacket
+	data := make([]byte, dataLen, dataLen+13)
 	n, err := reader.ReadAt(data, offset)
 	// only return EOF erro if no data left to read
 	if err != nil && (err != io.EOF || n == 0) {

--- a/request.go
+++ b/request.go
@@ -215,11 +215,7 @@ func fileget(h FileReader, r *Request, pkt requestPacket) responsePacket {
 		return statusFromError(pkt, errors.New("unexpected read packet"))
 	}
 
-	_, offset, length := packetData(pkt)
-	dataLen := clamp(length, maxTxPacket)
-	// we allocate a slice with a bigger capacity so we avoid a new allocation in MarshalBinary and in sendPacket
-	// we need 9 bytes in MarshalBinary and 4 bytes in sendPacket
-	data := make([]byte, dataLen, dataLen+13)
+	data, offset, _ := packetData(pkt)
 	n, err := reader.ReadAt(data, offset)
 	// only return EOF erro if no data left to read
 	if err != nil && (err != io.EOF || n == 0) {
@@ -253,6 +249,7 @@ func packetData(p requestPacket) (data []byte, offset int64, length uint32) {
 	case *sshFxpReadPacket:
 		length = p.Len
 		offset = int64(p.Offset)
+		data = p.getDataSlice()
 	case *sshFxpWritePacket:
 		data = p.Data
 		length = p.Length

--- a/server.go
+++ b/server.go
@@ -265,6 +265,7 @@ func handlePacket(s *Server, p orderedRequest) error {
 				ID:     p.ID,
 				Length: uint32(n),
 				Data:   data[:n],
+				// do not use data[:n:n] here to clamp the capacity, we allocated extra capacity above to avoid reallocations
 			}
 		}
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -34,7 +34,6 @@ type Server struct {
 	openFiles     map[string]*os.File
 	openFilesLock sync.RWMutex
 	handleCount   int
-	maxTxPacket   uint32
 }
 
 func (svr *Server) nextHandle(f *os.File) string {
@@ -87,7 +86,6 @@ func NewServer(rwc io.ReadWriteCloser, options ...ServerOption) (*Server, error)
 		debugStream: ioutil.Discard,
 		pktMgr:      newPktMgr(svrConn),
 		openFiles:   make(map[string]*os.File),
-		maxTxPacket: 1 << 15,
 	}
 
 	for _, o := range options {

--- a/server.go
+++ b/server.go
@@ -258,7 +258,7 @@ func handlePacket(s *Server, p orderedRequest) error {
 		f, ok := s.getHandle(p.Handle)
 		if ok {
 			err = nil
-			data := make([]byte, clamp(p.Len, s.maxTxPacket))
+			data := p.getDataSlice()
 			n, _err := f.ReadAt(data, int64(p.Offset))
 			if _err != nil && (_err != io.EOF || n == 0) {
 				err = _err


### PR DESCRIPTION
so a new allocation is not needed in MarshalBinary and sendPacket.

Here are some profiling results while downloading a file (file size is about 1GB),

before this patch:

```
1254.24MB 55.18% 55.18%  1254.24MB 55.18%  github.com/pkg/sftp.sshFxpDataPacket.MarshalBinary
  991.81MB 43.63% 98.81%   991.81MB 43.63%  github.com/pkg/sftp.fileget
       1MB 0.044% 98.86%  1255.24MB 55.22%  github.com/pkg/sftp.(*packetManager).maybeSendPackets
    0.50MB 0.022% 98.88%  1260.24MB 55.44%  github.com/pkg/sftp.(*packetManager).controller
         0     0% 98.88%   991.81MB 43.63%  github.com/pkg/sftp.(*Request).call
         0     0% 98.88%   993.31MB 43.70%  github.com/pkg/sftp.(*RequestServer).Serve.func1.1
         0     0% 98.88%   993.31MB 43.70%  github.com/pkg/sftp.(*RequestServer).packetWorker
         0     0% 98.88%  1254.24MB 55.18%  github.com/pkg/sftp.(*conn).sendPacket
         0     0% 98.88%  1254.24MB 55.18%  github.com/pkg/sftp.sendPacket
```

with this patch:

```
1209.48MB 98.46% 98.46%  1209.48MB 98.46%  github.com/pkg/sftp.fileget
       2MB  0.16% 98.63%     7.50MB  0.61%  github.com/pkg/sftp.recvPacket
         0     0% 98.63%        8MB  0.65%  github.com/drakkan/sftpgo/sftpd.Configuration.handleSftpConnection
         0     0% 98.63%  1209.48MB 98.46%  github.com/pkg/sftp.(*Request).call
         0     0% 98.63%        8MB  0.65%  github.com/pkg/sftp.(*RequestServer).Serve
         0     0% 98.63%  1209.98MB 98.50%  github.com/pkg/sftp.(*RequestServer).Serve.func1.1
         0     0% 98.63%  1209.98MB 98.50%  github.com/pkg/sftp.(*RequestServer).packetWorker
         0     0% 98.63%     7.50MB  0.61%  github.com/pkg/sftp.(*conn).recvPacket (inline)
```