### PR TITLE
cleanPath: use path.IsAbs after converting ToSlash

### DIFF
--- a/request-server.go
+++ b/request-server.go
@@ -232,7 +232,7 @@ func cleanPacketPath(pkt *sshFxpRealpathPacket) responsePacket {
 // Makes sure we have a clean POSIX (/) absolute path to work with
 func cleanPath(p string) string {
 	p = filepath.ToSlash(p)
-	if !filepath.IsAbs(p) {
+	if !path.IsAbs(p) {
 		p = "/" + p
 	}
 	return path.Clean(p)

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -423,4 +423,5 @@ func TestCleanPath(t *testing.T) {
 	assert.Equal(t, "/a", cleanPath("a"+bslash))
 	assert.Equal(t, "/a/b/c",
 		cleanPath(bslash+"a"+bslash+bslash+"b"+bslash+bslash+"c"+bslash))
+	assert.Equal(t, "/C:/a", cleanPath("C:"+bslash+"a"))
 }


### PR DESCRIPTION
we need a POSIX path, filepath.IsAbs could give unexpected results on Windows.

I don't have any specific test case for this anyway I think that filepath.IsAbs could consider an absolute path things like `C:/path` on Windows