### PR TITLE
Fix example error

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -22,7 +22,7 @@ func Example() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer sftp.Close()
+	defer client.Close()
 
 	// walk a directory
 	w := client.Walk("/home/user")


### PR DESCRIPTION
Replace from `sftp.Close()` to `client.Close()`.

Fixes #358.