### PR TITLE
Example needs to use client.Close

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -22,7 +22,7 @@ func Example() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer sftp.Close()
+	defer client.Close()
 
 	// walk a directory
 	w := client.Walk("/home/user")


### PR DESCRIPTION
When changing the example code to use `client` instead of shadowing the `sftp` package with the client variable, it was missed that we need to call `client.Close()` instead of `sftp.Close()`