### PR TITLE
Add a mutex to protect f.offset in new File.Read

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -815,6 +816,8 @@ type File struct {
 	c      *Client
 	path   string
 	handle string
+
+	mu sync.Mutex
 	offset uint64 // current offset within remote file
 }
 
@@ -839,6 +842,9 @@ func (f *File) Name() string {
 // than calling Read multiple times. io.Copy will do this
 // automatically.
 func (f *File) Read(b []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	r, err := f.ReadAt(b, int64( f.offset ))
 	f.offset += uint64(r)
 	return r, err


### PR DESCRIPTION
With the new `ReaderAt` support, we have a safer concurrent access method, but `offset` itself could end up in race-conditions if `Read` is called by multiple parallel threads.

This puts a mutex in there just to be safe. No other fields of `File` seem to need any protection, as they are not mutated over time.