### PR TITLE
request-server: implement Open method

### DIFF
--- a/request-example.go
+++ b/request-example.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -122,7 +121,7 @@ func (fs *root) Filecmd(r *Request) error {
 			}
 		}
 	case "Rmdir", "Remove":
-		file, err := fs.fetch(filepath.Dir(r.Filepath))
+		file, err := fs.fetch(path.Dir(r.Filepath))
 		if err != nil {
 			return err
 		}
@@ -142,7 +141,7 @@ func (fs *root) Filecmd(r *Request) error {
 		delete(fs.files, r.Filepath)
 
 	case "Mkdir":
-		_, err := fs.fetch(filepath.Dir(r.Filepath))
+		_, err := fs.fetch(path.Dir(r.Filepath))
 		if err != nil {
 			return err
 		}
@@ -203,7 +202,7 @@ func (fs *root) Filelist(r *Request) (ListerAt, error) {
 		}
 		orderedNames := []string{}
 		for fn := range fs.files {
-			if filepath.Dir(fn) == r.Filepath {
+			if path.Dir(fn) == r.Filepath {
 				orderedNames = append(orderedNames, fn)
 			}
 		}
@@ -274,7 +273,7 @@ func newMemFile(name string, isdir bool) *memFile {
 }
 
 // Have memFile fulfill os.FileInfo interface
-func (f *memFile) Name() string { return filepath.Base(f.name) }
+func (f *memFile) Name() string { return path.Base(f.name) }
 func (f *memFile) Size() int64  { return int64(len(f.content)) }
 func (f *memFile) Mode() os.FileMode {
 	ret := os.FileMode(0644)

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -5,6 +5,13 @@ import (
 	"os"
 )
 
+// WriterAtReaderAt defines the interface to return when a file is to
+// be opened for reading and writing
+type WriterAtReaderAt interface {
+	io.WriterAt
+	io.ReaderAt
+}
+
 // Interfaces are differentiated based on required returned values.
 // All input arguments are to be pulled from Request (the only arg).
 
@@ -30,6 +37,16 @@ type FileReader interface {
 // Called for Methods: Put, Open
 type FileWriter interface {
 	Filewrite(*Request) (io.WriterAt, error)
+}
+
+// OpenFileWriter is a FileWriter that implements the generic OpenFile
+// method.
+// You need to implement this optional interface if you want to be able
+// to read and write from/to the same handle.
+// Called for Methods: Open
+type OpenFileWriter interface {
+	FileWriter
+	OpenFile(*Request) (WriterAtReaderAt, error)
 }
 
 // FileCmder should return an error

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -228,6 +228,25 @@ func TestRequestCreate(t *testing.T) {
 	checkRequestServerAllocator(t, p)
 }
 
+func TestRequestReadAndWrite(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	file, err := p.cli.OpenFile("/foo", os.O_RDWR)
+	require.NoError(t, err)
+
+	defer file.Close()
+
+	n, err := file.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	buf := make([]byte, 4)
+	n, err = file.ReadAt(buf, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, []byte{'e', 'l', 'l', 'o'}, buf)
+	checkRequestServerAllocator(t, p)
+}
+
 func TestRequestMkdir(t *testing.T) {
 	p := clientRequestServerPair(t)
 	defer p.Close()

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -80,7 +80,7 @@ func TestRequestSplitWrite(t *testing.T) {
 	p := clientRequestServerPair(t)
 	defer p.Close()
 	w, err := p.cli.Create("/foo")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	p.cli.maxPacket = 3 // force it to send in small chunks
 	contents := "one two three four five six seven eight nine ten"
 	w.Write([]byte(contents))

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -80,7 +80,7 @@ func TestRequestSplitWrite(t *testing.T) {
 	p := clientRequestServerPair(t)
 	defer p.Close()
 	w, err := p.cli.Create("/foo")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	p.cli.maxPacket = 3 // force it to send in small chunks
 	contents := "one two three four five six seven eight nine ten"
 	w.Write([]byte(contents))

--- a/request.go
+++ b/request.go
@@ -235,16 +235,16 @@ func (r *Request) open(h Handlers, pkt requestPacket) responsePacket {
 					return statusFromError(pkt, err)
 				}
 				r.state.writerReaderAt = rw
+				return &sshFxpHandlePacket{ID: pkt.id(), Handle: r.handle}
 			}
 		}
-		if r.Method == "" {
-			r.Method = "Put"
-			wr, err := h.FilePut.Filewrite(r)
-			if err != nil {
-				return statusFromError(pkt, err)
-			}
-			r.state.writerAt = wr
+
+		r.Method = "Put"
+		wr, err := h.FilePut.Filewrite(r)
+		if err != nil {
+			return statusFromError(pkt, err)
 		}
+		r.state.writerAt = wr
 	case flags.Read:
 		r.Method = "Get"
 		rd, err := h.FileGet.Fileread(r)

--- a/request.go
+++ b/request.go
@@ -34,10 +34,11 @@ type Request struct {
 
 type state struct {
 	*sync.RWMutex
-	writerAt io.WriterAt
-	readerAt io.ReaderAt
-	listerAt ListerAt
-	lsoffset int64
+	writerAt       io.WriterAt
+	readerAt       io.ReaderAt
+	writerReaderAt WriterAtReaderAt
+	listerAt       ListerAt
+	lsoffset       int64
 }
 
 // New Request initialized based on packet data
@@ -142,6 +143,7 @@ func (r *Request) close() error {
 	r.state.RLock()
 	wr := r.state.writerAt
 	rd := r.state.readerAt
+	writerReader := r.state.writerReaderAt
 	r.state.RUnlock()
 
 	var err error
@@ -155,6 +157,14 @@ func (r *Request) close() error {
 		}
 	}
 
+	if c, ok := writerReader.(io.Closer); ok {
+		if err2 := c.Close(); err == nil {
+			// update error if it is still nil
+			err = err2
+			r.state.writerReaderAt = nil
+		}
+	}
+
 	if c, ok := rd.(io.Closer); ok {
 		if err2 := c.Close(); err == nil {
 			// update error if it is still nil
@@ -165,7 +175,7 @@ func (r *Request) close() error {
 	return err
 }
 
-// Close reader/writer if possible
+// Notify transfer error if any
 func (r *Request) transferError(err error) {
 	if err == nil {
 		return
@@ -174,7 +184,12 @@ func (r *Request) transferError(err error) {
 	r.state.RLock()
 	wr := r.state.writerAt
 	rd := r.state.readerAt
+	writerReader := r.state.writerReaderAt
 	r.state.RUnlock()
+
+	if t, ok := writerReader.(TransferError); ok {
+		t.TransferError(err)
+	}
 
 	if t, ok := wr.(TransferError); ok {
 		t.TransferError(err)
@@ -192,6 +207,8 @@ func (r *Request) call(handlers Handlers, pkt requestPacket, alloc *allocator, o
 		return fileget(handlers.FileGet, r, pkt, alloc, orderID)
 	case "Put":
 		return fileput(handlers.FilePut, r, pkt, alloc, orderID)
+	case "Open":
+		return fileputget(handlers.FilePut, r, pkt, alloc, orderID)
 	case "Setstat", "Rename", "Rmdir", "Mkdir", "Link", "Symlink", "Remove":
 		return filecmd(handlers.FileCmd, r, pkt)
 	case "List":
@@ -210,8 +227,13 @@ func (r *Request) open(h Handlers, pkt requestPacket) responsePacket {
 	var err error
 	switch {
 	case flags.Write, flags.Append, flags.Creat, flags.Trunc:
-		r.Method = "Put"
-		r.state.writerAt, err = h.FilePut.Filewrite(r)
+		if openFileWriter, ok := h.FilePut.(OpenFileWriter); ok && flags.Read {
+			r.Method = "Open"
+			r.state.writerReaderAt, err = openFileWriter.OpenFile(r)
+		} else {
+			r.Method = "Put"
+			r.state.writerAt, err = h.FilePut.Filewrite(r)
+		}
 	case flags.Read:
 		r.Method = "Get"
 		r.state.readerAt, err = h.FileGet.Fileread(r)
@@ -249,7 +271,7 @@ func fileget(h FileReader, r *Request, pkt requestPacket, alloc *allocator, orde
 
 	data, offset, _ := packetData(pkt, alloc, orderID)
 	n, err := reader.ReadAt(data, offset)
-	// only return EOF erro if no data left to read
+	// only return EOF error if no data left to read
 	if err != nil && (err != io.EOF || n == 0) {
 		return statusFromError(pkt, err)
 	}
@@ -273,6 +295,36 @@ func fileput(h FileWriter, r *Request, pkt requestPacket, alloc *allocator, orde
 	data, offset, _ := packetData(pkt, alloc, orderID)
 	_, err := writer.WriteAt(data, offset)
 	return statusFromError(pkt, err)
+}
+
+// wrap OpenFileWriter handler
+func fileputget(h FileWriter, r *Request, pkt requestPacket, alloc *allocator, orderID uint32) responsePacket {
+	r.state.RLock()
+	writerReader := r.state.writerReaderAt
+	r.state.RUnlock()
+	if writerReader == nil {
+		return statusFromError(pkt, errors.New("unexpected write and read packet"))
+	}
+	switch pkt.(type) {
+	case *sshFxpReadPacket:
+		data, offset, _ := packetData(pkt, alloc, orderID)
+		n, err := writerReader.ReadAt(data, offset)
+		// only return EOF error if no data left to read
+		if err != nil && (err != io.EOF || n == 0) {
+			return statusFromError(pkt, err)
+		}
+		return &sshFxpDataPacket{
+			ID:     pkt.id(),
+			Length: uint32(n),
+			Data:   data[:n],
+		}
+	case *sshFxpWritePacket:
+		data, offset, _ := packetData(pkt, alloc, orderID)
+		_, err := writerReader.WriteAt(data, offset)
+		return statusFromError(pkt, err)
+	default:
+		return statusFromError(pkt, errors.New("unexpected packet type for read or write"))
+	}
 }
 
 // file data for additional read/write packets


### PR DESCRIPTION
add an optional interface to FileWriter to allow to open a file for both
writing and reading

Fixes #374

I noticed that an `Open` method is documented but not implemented, see [here](https://github.com/pkg/sftp/blob/master/request-interfaces.go#L30). I implemented this method. The change is backward compatible and implementing the new optional Filewriter interface the request server can handle both reading and writing to the same file fixing the corruption issue reported in #374

I know that we want something different for v2 and so I'll not push this change myself.  

However I cannot wait until we implement v2 to fix a file corruption issue in SFTPGo, so if we don't agree to merge this change I'll maintain it in my fork until we have an alternative, thank you