### PR TITLE
request-server: add lstat support

### DIFF
--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -63,6 +63,13 @@ type FileLister interface {
 	Filelist(*Request) (ListerAt, error)
 }
 
+// LstatFileLister is a FileLister that implements the Lstat method.
+// If this interface is implemented Lstat requests will call it
+// otherwise they will be handled in the same way as Stat
+type LstatFileLister interface {
+	Lstat(*Request) (ListerAt, error)
+}
+
 // ListerAt does for file lists what io.ReaderAt does for files.
 // ListAt should return the number of entries copied and an io.EOF
 // error if at end of list. This is testable by comparing how many you

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -405,6 +405,19 @@ func TestRequestStatFail(t *testing.T) {
 	checkRequestServerAllocator(t, p)
 }
 
+func TestRequestLstat(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+	_, err := putTestFile(p.cli, "/foo", "hello")
+	require.NoError(t, err)
+	err = p.cli.Symlink("/foo", "/bar")
+	require.NoError(t, err)
+	fi, err := p.cli.Lstat("/bar")
+	require.NoError(t, err)
+	assert.True(t, fi.Mode()&os.ModeSymlink == os.ModeSymlink)
+	checkRequestServerAllocator(t, p)
+}
+
 func TestRequestLink(t *testing.T) {
 	p := clientRequestServerPair(t)
 	defer p.Close()


### PR DESCRIPTION
Add LstatFileLister, an optional interface for FileLister, if this
interface is implemented Lstat requests will call it otherwirse they
will be handled in the same way as Stat, as before