### PR TITLE
server: use os.IsNotExist to map sshFxNoSuchFile

### DIFF
--- a/server.go
+++ b/server.go
@@ -594,7 +594,9 @@ func statusFromError(p ider, err error) sshFxpStatusPacket {
 		ret.StatusError.Code = translateErrno(e)
 	case *os.PathError:
 		debug("statusFromError,pathError: error is %T %#v", e.Err, e.Err)
-		if errno, ok := e.Err.(syscall.Errno); ok {
+		if os.IsNotExist(err) {
+			ret.StatusError.Code = sshFxNoSuchFile
+		} else if errno, ok := e.Err.(syscall.Errno); ok {
 			ret.StatusError.Code = translateErrno(errno)
 		}
 	case fxerr:

--- a/server_test.go
+++ b/server_test.go
@@ -354,7 +354,7 @@ func TestStatNonExistent(t *testing.T) {
 
 	for _, file := range []string{"/doesnotexist", "/doesnotexist/a/b"} {
 		_, err := client.Stat(file)
-		if err == nil || !os.IsNotExist(err) {
+		if !os.IsNotExist(err) {
 			t.Errorf("expected 'does not exist' err for file %q.  got: %v", file, err)
 		}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -344,3 +344,18 @@ func TestOpenStatRace(t *testing.T) {
 	os.Remove(tmppath)
 	checkServerAllocator(t, server)
 }
+
+// Ensure that proper error codes are returned for non existent files, such
+// that they are mapped back to a 'not exists' error on the client side.
+func TestStatNonExistent(t *testing.T) {
+	client, server := clientServerPair(t)
+	defer client.Close()
+	defer server.Close()
+
+	for _, file := range []string{"/doesnotexist", "/doesnotexist/a/b"} {
+		_, err := client.Stat(file)
+		if err == nil || !os.IsNotExist(err) {
+			t.Errorf("expected 'does not exist' err for file %q.  got: %v", file, err)
+		}
+	}
+}


### PR DESCRIPTION
Always use os.IsNotExist to identify any OS specific error types that represent missing files or directories.  This resolves an issue on Windows where some system errors (ENOTDIR) were not being identified as 'not found' errors and mapped to sshFxNoSuchFile.

fixes #381