### PR TITLE
New method Client.Extensions to list server extensions

### DIFF
--- a/client_integration_linux_test.go
+++ b/client_integration_linux_test.go
@@ -3,6 +3,8 @@ package sftp
 import (
 	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientStatVFS(t *testing.T) {
@@ -12,6 +14,9 @@ func TestClientStatVFS(t *testing.T) {
 	sftp, cmd := testClient(t, READWRITE, NODELAY)
 	defer cmd.Wait()
 	defer sftp.Close()
+
+	_, ok := sftp.HasExtension("statvfs@openssh.com")
+	require.True(t, ok, "server doesn't list statvfs extension")
 
 	vfs, err := sftp.StatVFS("/")
 	if err != nil {


### PR DESCRIPTION
This allows clients to check for extensions such as posix-rename without having to try an operation that depends on them.