### PR TITLE
Write length and payload separately for double the throughput

### DIFF
--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -2033,7 +2033,7 @@ func benchmarkWrite(b *testing.B, bufsize int, delay time.Duration) {
 	// open sftp client
 	sftp, cmd := testClient(b, false, delay)
 	defer cmd.Wait()
-	// defer sftp.Close()
+	defer sftp.Close()
 
 	data := make([]byte, size)
 


### PR DESCRIPTION
This patch greatly improves the throughput of sendPacket by avoiding a copy of each packet before it is sent, and by avoiding copying the payload of Write and Data packets at all.

Benchmarked against OpenSSH using
    
    TMPDIR=/dev/shm go test -run=- -integration -bench='kWrite([0-9]*k|1MiB)' -benchmem
    
on Linux/amd64. Results:
    
    name         old time/op    new time/op    delta
    Write1k-8       312ms ±12%     305ms ± 5%      ~     (p=0.684 n=10+10)
    Write16k-8     56.9ms ± 2%    31.9ms ± 4%   -43.92%  (p=0.000 n=10+10)
    Write32k-8     43.2ms ± 3%    18.1ms ± 6%   -58.22%  (p=0.000 n=10+10)
    Write128k-8    31.1ms ± 2%    13.5ms ± 4%   -56.72%  (p=0.000 n=10+9)
    Write512k-8    17.5ms ± 5%    10.1ms ± 4%   -42.30%  (p=0.000 n=10+10)
    Write1MiB-8    14.9ms ± 1%     9.3ms ± 4%   -37.72%  (p=0.000 n=8+10)
    
    name         old speed      new speed      delta
    Write1k-8    33.7MB/s ±11%  34.4MB/s ± 5%      ~     (p=0.684 n=10+10)
    Write16k-8    184MB/s ± 2%   329MB/s ± 4%   +78.39%  (p=0.000 n=10+10)
    Write32k-8    243MB/s ± 3%   581MB/s ± 6%  +139.45%  (p=0.000 n=10+10)
    Write128k-8   337MB/s ± 2%   778MB/s ± 4%  +131.11%  (p=0.000 n=10+9)
    Write512k-8   599MB/s ± 5%  1038MB/s ± 4%   +73.29%  (p=0.000 n=10+10)
    Write1MiB-8   702MB/s ± 1%  1128MB/s ± 4%   +60.67%  (p=0.000 n=8+10)
    
    name         old alloc/op   new alloc/op   delta
    Write1k-8      61.6MB ± 0%    35.7MB ± 0%   -42.01%  (p=0.000 n=10+10)
    Write16k-8     27.9MB ± 0%     2.2MB ± 0%   -91.99%  (p=0.000 n=10+10)
    Write32k-8     29.9MB ± 0%     1.1MB ± 0%   -96.26%  (p=0.000 n=10+7)
    Write128k-8    29.2MB ± 0%     0.3MB ± 0%   -98.87%  (p=0.000 n=10+10)
    Write512k-8    29.0MB ± 0%     0.1MB ± 0%   -99.55%  (p=0.000 n=10+10)
    Write1MiB-8    28.9MB ± 0%     0.1MB ± 0%   -99.66%  (p=0.000 n=10+10)
    
    name         old allocs/op  new allocs/op  delta
    Write1k-8       92.2k ± 0%     82.0k ± 0%   -11.09%  (p=0.000 n=9+9)
    Write16k-8      5.81k ± 0%     5.17k ± 0%   -11.07%  (p=0.000 n=10+10)
    Write32k-8      2.93k ± 0%     2.60k ± 0%   -11.04%  (p=0.000 n=10+9)
    Write128k-8     2.45k ± 0%     2.12k ± 0%   -13.21%  (p=0.000 n=8+10)
    Write512k-8     2.33k ± 0%     2.00k ± 0%   -13.91%  (p=0.000 n=9+9)
    Write1MiB-8     2.31k ± 0%     1.99k ± 0%   -14.03%  (p=0.000 n=6+10)

I had to fix the benchmark to get this to work; the 4MiB version still hangs indefinitely.