### PR TITLE
Don't crash when the packet length is zero

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,22 @@
+// +build gofuzz
+
+package sftp
+
+import "bytes"
+
+type sink struct{}
+
+func (*sink) Close() error                { return nil }
+func (*sink) Write(p []byte) (int, error) { return len(p), nil }
+
+var devnull = &sink{}
+
+// To run: go-fuzz-build && go-fuzz
+func Fuzz(data []byte) int {
+	c, err := NewClientPipe(bytes.NewReader(data), devnull)
+	if err != nil {
+		return 0
+	}
+	c.Close()
+	return 1
+}

--- a/packet.go
+++ b/packet.go
@@ -154,6 +154,10 @@ func recvPacket(r io.Reader, alloc *allocator, orderID uint32) (uint8, []byte, e
 		debug("recv packet %d bytes too long", length)
 		return 0, nil, errLongPacket
 	}
+	if length == 0 {
+		debug("recv packet of 0 bytes too short")
+		return 0, nil, errShortPacket
+	}
 	if alloc == nil {
 		b = make([]byte, length)
 	}


### PR DESCRIPTION
A packet with an invalid length causes a panic in recvPacket. Patch includes the fuzz test that found this out in a few seconds.