### PR TITLE
Detect remote disconnect in File methods

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -138,8 +138,9 @@ func (c *clientConn) broadcastErr(err error) {
 		listeners = append(listeners, ch)
 	}
 	c.Unlock()
+	bcastRes := result{err: errors.New("unexpected server disconnect")}
 	for _, ch := range listeners {
-		ch <- result{err: err}
+		ch <- bcastRes
 	}
 	c.err = err
 	close(c.closed)


### PR DESCRIPTION
Fixes #390. Uses @puellanivis's patch, adds a test and adds assertions to existing tests.