### PR TITLE
request server: fix handles leak in error case

### DIFF
--- a/request-server.go
+++ b/request-server.go
@@ -198,12 +198,20 @@ func (rs *RequestServer) packetWorker(
 			rpkt = cleanPacketPath(pkt)
 		case *sshFxpOpendirPacket:
 			request := requestFromPacket(ctx, pkt)
-			rs.nextRequest(request)
+			handle := rs.nextRequest(request)
 			rpkt = request.opendir(rs.Handlers, pkt)
+			if _, ok := rpkt.(*sshFxpHandlePacket); !ok {
+				// if we return an error we have to remove the handle from the active ones
+				rs.closeRequest(handle)
+			}
 		case *sshFxpOpenPacket:
 			request := requestFromPacket(ctx, pkt)
-			rs.nextRequest(request)
+			handle := rs.nextRequest(request)
 			rpkt = request.open(rs.Handlers, pkt)
+			if _, ok := rpkt.(*sshFxpHandlePacket); !ok {
+				// if we return an error we have to remove the handle from the active ones
+				rs.closeRequest(handle)
+			}
 		case *sshFxpFstatPacket:
 			handle := pkt.getHandle()
 			request, ok := rs.getRequest(handle)

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -228,6 +228,9 @@ func TestRequestOpenFail(t *testing.T) {
 	rf, err := p.cli.Open("/foo")
 	assert.Exactly(t, os.ErrNotExist, err)
 	assert.Nil(t, rf)
+	// if we return an error the sftp client will not close the handle
+	// ensure that we close it ourself
+	assert.Len(t, p.svr.openRequests, 0)
 	checkRequestServerAllocator(t, p)
 }
 
@@ -711,6 +714,7 @@ func TestRequestReaddir(t *testing.T) {
 	require.Len(t, di, 100)
 	names := []string{di[18].Name(), di[81].Name()}
 	assert.Equal(t, []string{"foo_18", "foo_81"}, names)
+	assert.Len(t, p.svr.openRequests, 0)
 	checkRequestServerAllocator(t, p)
 }
 


### PR DESCRIPTION
For open/opendir requests we create a new handle and close it
when the client sends an SSH_FXP_CLOSE but if we return an error the
client will never send the close packet so we have to close the handle
ourselves.

You can easily see the bug running the modified test cases without the patch.

The open handles will be closed when the client closes the whole connection, but if we have a client connected for a long time we accumulate handles every time we return an error for open/opendir.

This bug is more evident after applying #392 since the `EOF` will be converted to `ErrUnexpectedEOF` if open requests are found when the client disconnects 