### PR TITLE
More optimization

### DIFF
--- a/client.go
+++ b/client.go
@@ -271,7 +271,7 @@ func (c *Client) ReadDir(p string) ([]os.FileInfo, error) {
 	var done = false
 	for !done {
 		id := c.nextID()
-		typ, data, err1 := c.sendPacket(sshFxpReaddirPacket{
+		typ, data, err1 := c.sendPacket(nil, sshFxpReaddirPacket{
 			ID:     id,
 			Handle: handle,
 		})
@@ -314,7 +314,7 @@ func (c *Client) ReadDir(p string) ([]os.FileInfo, error) {
 
 func (c *Client) opendir(path string) (string, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpOpendirPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpOpendirPacket{
 		ID:   id,
 		Path: path,
 	})
@@ -340,7 +340,7 @@ func (c *Client) opendir(path string) (string, error) {
 // If 'p' is a symbolic link, the returned FileInfo structure describes the referent file.
 func (c *Client) Stat(p string) (os.FileInfo, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpStatPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpStatPacket{
 		ID:   id,
 		Path: p,
 	})
@@ -366,7 +366,7 @@ func (c *Client) Stat(p string) (os.FileInfo, error) {
 // If 'p' is a symbolic link, the returned FileInfo structure describes the symbolic link.
 func (c *Client) Lstat(p string) (os.FileInfo, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpLstatPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpLstatPacket{
 		ID:   id,
 		Path: p,
 	})
@@ -391,7 +391,7 @@ func (c *Client) Lstat(p string) (os.FileInfo, error) {
 // ReadLink reads the target of a symbolic link.
 func (c *Client) ReadLink(p string) (string, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpReadlinkPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpReadlinkPacket{
 		ID:   id,
 		Path: p,
 	})
@@ -420,7 +420,7 @@ func (c *Client) ReadLink(p string) (string, error) {
 // Link creates a hard link at 'newname', pointing at the same inode as 'oldname'
 func (c *Client) Link(oldname, newname string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpHardlinkPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpHardlinkPacket{
 		ID:      id,
 		Oldpath: oldname,
 		Newpath: newname,
@@ -439,7 +439,7 @@ func (c *Client) Link(oldname, newname string) error {
 // Symlink creates a symbolic link at 'newname', pointing at target 'oldname'
 func (c *Client) Symlink(oldname, newname string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpSymlinkPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpSymlinkPacket{
 		ID:         id,
 		Linkpath:   newname,
 		Targetpath: oldname,
@@ -457,7 +457,7 @@ func (c *Client) Symlink(oldname, newname string) error {
 
 func (c *Client) setfstat(handle string, flags uint32, attrs interface{}) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpFsetstatPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpFsetstatPacket{
 		ID:     id,
 		Handle: handle,
 		Flags:  flags,
@@ -477,7 +477,7 @@ func (c *Client) setfstat(handle string, flags uint32, attrs interface{}) error 
 // setstat is a convience wrapper to allow for changing of various parts of the file descriptor.
 func (c *Client) setstat(path string, flags uint32, attrs interface{}) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpSetstatPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpSetstatPacket{
 		ID:    id,
 		Path:  path,
 		Flags: flags,
@@ -543,7 +543,7 @@ func (c *Client) OpenFile(path string, f int) (*File, error) {
 
 func (c *Client) open(path string, pflags uint32) (*File, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpOpenPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpOpenPacket{
 		ID:     id,
 		Path:   path,
 		Pflags: pflags,
@@ -571,7 +571,7 @@ func (c *Client) open(path string, pflags uint32) (*File, error) {
 // immediately after this request has been sent.
 func (c *Client) close(handle string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpClosePacket{
+	typ, data, err := c.sendPacket(nil, sshFxpClosePacket{
 		ID:     id,
 		Handle: handle,
 	})
@@ -588,7 +588,7 @@ func (c *Client) close(handle string) error {
 
 func (c *Client) fstat(handle string) (*FileStat, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpFstatPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpFstatPacket{
 		ID:     id,
 		Handle: handle,
 	})
@@ -617,7 +617,7 @@ func (c *Client) fstat(handle string) (*FileStat, error) {
 func (c *Client) StatVFS(path string) (*StatVFS, error) {
 	// send the StatVFS packet to the server
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpStatvfsPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpStatvfsPacket{
 		ID:   id,
 		Path: path,
 	})
@@ -672,7 +672,7 @@ func (c *Client) Remove(path string) error {
 
 func (c *Client) removeFile(path string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpRemovePacket{
+	typ, data, err := c.sendPacket(nil, sshFxpRemovePacket{
 		ID:       id,
 		Filename: path,
 	})
@@ -690,7 +690,7 @@ func (c *Client) removeFile(path string) error {
 // RemoveDirectory removes a directory path.
 func (c *Client) RemoveDirectory(path string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpRmdirPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpRmdirPacket{
 		ID:   id,
 		Path: path,
 	})
@@ -708,7 +708,7 @@ func (c *Client) RemoveDirectory(path string) error {
 // Rename renames a file.
 func (c *Client) Rename(oldname, newname string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpRenamePacket{
+	typ, data, err := c.sendPacket(nil, sshFxpRenamePacket{
 		ID:      id,
 		Oldpath: oldname,
 		Newpath: newname,
@@ -728,7 +728,7 @@ func (c *Client) Rename(oldname, newname string) error {
 // which will replace newname if it already exists.
 func (c *Client) PosixRename(oldname, newname string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpPosixRenamePacket{
+	typ, data, err := c.sendPacket(nil, sshFxpPosixRenamePacket{
 		ID:      id,
 		Oldpath: oldname,
 		Newpath: newname,
@@ -746,7 +746,7 @@ func (c *Client) PosixRename(oldname, newname string) error {
 
 func (c *Client) realpath(path string) (string, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpRealpathPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpRealpathPacket{
 		ID:   id,
 		Path: path,
 	})
@@ -783,7 +783,7 @@ func (c *Client) Getwd() (string, error) {
 // parent folder does not exist (the method cannot create complete paths).
 func (c *Client) Mkdir(path string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(sshFxpMkdirPacket{
+	typ, data, err := c.sendPacket(nil, sshFxpMkdirPacket{
 		ID:   id,
 		Path: path,
 	})
@@ -1326,7 +1326,7 @@ func (f *File) Chmod(mode os.FileMode) error {
 // Sync requires the server to support the fsync@openssh.com extension.
 func (f *File) Sync() error {
 	id := f.c.nextID()
-	typ, data, err := f.c.sendPacket(sshFxpFsyncPacket{
+	typ, data, err := f.c.sendPacket(nil, sshFxpFsyncPacket{
 		ID:     id,
 		Handle: f.handle,
 	})

--- a/client.go
+++ b/client.go
@@ -1274,19 +1274,19 @@ func (f *File) WriteAt(b []byte, off int64) (int, error) {
 		offset := off
 
 		for len(b) > 0 {
-			rb := b
-			if len(rb) > f.c.maxPacket {
-				rb = rb[:f.c.maxPacket]
+			wb := b
+			if len(wb) > f.c.maxPacket {
+				wb = wb[:f.c.maxPacket]
 			}
 
 			select {
-			case workCh <- work{rb, offset}:
+			case workCh <- work{wb, offset}:
 			case <-cancel:
 				return
 			}
 
-			offset += int64(len(rb))
-			b = b[len(rb):]
+			offset += int64(len(wb))
+			b = b[len(wb):]
 		}
 	}()
 
@@ -1298,7 +1298,7 @@ func (f *File) WriteAt(b []byte, off int64) (int, error) {
 	var wg sync.WaitGroup
 	wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {
-		// Map_i: each worker gets work, and does the Read into each buffer from its respective offset.
+		// Map_i: each worker gets work, and does the Write from each buffer to its respective offset.
 		go func() {
 			defer wg.Done()
 
@@ -1469,7 +1469,7 @@ func (f *File) ReadFrom(r io.Reader) (int64, error) {
 	var wg sync.WaitGroup
 	wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {
-		// Map_i: each worker gets work, and does the Read into each buffer from its respective offset.
+		// Map_i: each worker gets work, and does the Write from each buffer to its respective offset.
 		go func() {
 			defer wg.Done()
 

--- a/client.go
+++ b/client.go
@@ -235,7 +235,7 @@ func (c *Client) Create(path string) (*File, error) {
 const sftpProtocolVersion = 3 // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-02
 
 func (c *Client) sendInit() error {
-	return c.clientConn.conn.sendPacket(sshFxInitPacket{
+	return c.clientConn.conn.sendPacket(&sshFxInitPacket{
 		Version: sftpProtocolVersion, // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-02
 	})
 }
@@ -297,7 +297,7 @@ func (c *Client) ReadDir(p string) ([]os.FileInfo, error) {
 	var done = false
 	for !done {
 		id := c.nextID()
-		typ, data, err1 := c.sendPacket(nil, sshFxpReaddirPacket{
+		typ, data, err1 := c.sendPacket(nil, &sshFxpReaddirPacket{
 			ID:     id,
 			Handle: handle,
 		})
@@ -340,7 +340,7 @@ func (c *Client) ReadDir(p string) ([]os.FileInfo, error) {
 
 func (c *Client) opendir(path string) (string, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpOpendirPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpOpendirPacket{
 		ID:   id,
 		Path: path,
 	})
@@ -366,7 +366,7 @@ func (c *Client) opendir(path string) (string, error) {
 // If 'p' is a symbolic link, the returned FileInfo structure describes the referent file.
 func (c *Client) Stat(p string) (os.FileInfo, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpStatPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpStatPacket{
 		ID:   id,
 		Path: p,
 	})
@@ -392,7 +392,7 @@ func (c *Client) Stat(p string) (os.FileInfo, error) {
 // If 'p' is a symbolic link, the returned FileInfo structure describes the symbolic link.
 func (c *Client) Lstat(p string) (os.FileInfo, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpLstatPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpLstatPacket{
 		ID:   id,
 		Path: p,
 	})
@@ -417,7 +417,7 @@ func (c *Client) Lstat(p string) (os.FileInfo, error) {
 // ReadLink reads the target of a symbolic link.
 func (c *Client) ReadLink(p string) (string, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpReadlinkPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpReadlinkPacket{
 		ID:   id,
 		Path: p,
 	})
@@ -446,7 +446,7 @@ func (c *Client) ReadLink(p string) (string, error) {
 // Link creates a hard link at 'newname', pointing at the same inode as 'oldname'
 func (c *Client) Link(oldname, newname string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpHardlinkPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpHardlinkPacket{
 		ID:      id,
 		Oldpath: oldname,
 		Newpath: newname,
@@ -465,7 +465,7 @@ func (c *Client) Link(oldname, newname string) error {
 // Symlink creates a symbolic link at 'newname', pointing at target 'oldname'
 func (c *Client) Symlink(oldname, newname string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpSymlinkPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpSymlinkPacket{
 		ID:         id,
 		Linkpath:   newname,
 		Targetpath: oldname,
@@ -483,7 +483,7 @@ func (c *Client) Symlink(oldname, newname string) error {
 
 func (c *Client) setfstat(handle string, flags uint32, attrs interface{}) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpFsetstatPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpFsetstatPacket{
 		ID:     id,
 		Handle: handle,
 		Flags:  flags,
@@ -503,7 +503,7 @@ func (c *Client) setfstat(handle string, flags uint32, attrs interface{}) error 
 // setstat is a convience wrapper to allow for changing of various parts of the file descriptor.
 func (c *Client) setstat(path string, flags uint32, attrs interface{}) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpSetstatPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpSetstatPacket{
 		ID:    id,
 		Path:  path,
 		Flags: flags,
@@ -569,7 +569,7 @@ func (c *Client) OpenFile(path string, f int) (*File, error) {
 
 func (c *Client) open(path string, pflags uint32) (*File, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpOpenPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpOpenPacket{
 		ID:     id,
 		Path:   path,
 		Pflags: pflags,
@@ -597,7 +597,7 @@ func (c *Client) open(path string, pflags uint32) (*File, error) {
 // immediately after this request has been sent.
 func (c *Client) close(handle string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpClosePacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpClosePacket{
 		ID:     id,
 		Handle: handle,
 	})
@@ -614,7 +614,7 @@ func (c *Client) close(handle string) error {
 
 func (c *Client) fstat(handle string) (*FileStat, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpFstatPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpFstatPacket{
 		ID:     id,
 		Handle: handle,
 	})
@@ -643,7 +643,7 @@ func (c *Client) fstat(handle string) (*FileStat, error) {
 func (c *Client) StatVFS(path string) (*StatVFS, error) {
 	// send the StatVFS packet to the server
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpStatvfsPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpStatvfsPacket{
 		ID:   id,
 		Path: path,
 	})
@@ -698,7 +698,7 @@ func (c *Client) Remove(path string) error {
 
 func (c *Client) removeFile(path string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpRemovePacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpRemovePacket{
 		ID:       id,
 		Filename: path,
 	})
@@ -716,7 +716,7 @@ func (c *Client) removeFile(path string) error {
 // RemoveDirectory removes a directory path.
 func (c *Client) RemoveDirectory(path string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpRmdirPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpRmdirPacket{
 		ID:   id,
 		Path: path,
 	})
@@ -734,7 +734,7 @@ func (c *Client) RemoveDirectory(path string) error {
 // Rename renames a file.
 func (c *Client) Rename(oldname, newname string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpRenamePacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpRenamePacket{
 		ID:      id,
 		Oldpath: oldname,
 		Newpath: newname,
@@ -754,7 +754,7 @@ func (c *Client) Rename(oldname, newname string) error {
 // which will replace newname if it already exists.
 func (c *Client) PosixRename(oldname, newname string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpPosixRenamePacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpPosixRenamePacket{
 		ID:      id,
 		Oldpath: oldname,
 		Newpath: newname,
@@ -772,7 +772,7 @@ func (c *Client) PosixRename(oldname, newname string) error {
 
 func (c *Client) realpath(path string) (string, error) {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpRealpathPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpRealpathPacket{
 		ID:   id,
 		Path: path,
 	})
@@ -809,7 +809,7 @@ func (c *Client) Getwd() (string, error) {
 // parent folder does not exist (the method cannot create complete paths).
 func (c *Client) Mkdir(path string) error {
 	id := c.nextID()
-	typ, data, err := c.sendPacket(nil, sshFxpMkdirPacket{
+	typ, data, err := c.sendPacket(nil, &sshFxpMkdirPacket{
 		ID:   id,
 		Path: path,
 	})
@@ -916,7 +916,7 @@ func (f *File) Read(b []byte) (int, error) {
 func (f *File) readChunkAt(ch chan result, b []byte, off int64) (n int, err error) {
 	for err == nil && n < len(b) {
 		id := f.c.nextID()
-		typ, data, err := f.c.sendPacket(ch, sshFxpReadPacket{
+		typ, data, err := f.c.sendPacket(ch, &sshFxpReadPacket{
 			ID:     id,
 			Handle: f.handle,
 			Offset: uint64(off) + uint64(n),
@@ -1282,7 +1282,7 @@ func (f *File) Write(b []byte) (int, error) {
 }
 
 func (f *File) writeChunkAt(ch chan result, b []byte, off int64) (int, error) {
-	typ, data, err := f.c.sendPacket(ch, sshFxpWritePacket{
+	typ, data, err := f.c.sendPacket(ch, &sshFxpWritePacket{
 		ID:     f.c.nextID(),
 		Handle: f.handle,
 		Offset: uint64(off),
@@ -1674,7 +1674,7 @@ func (f *File) Chmod(mode os.FileMode) error {
 // Sync requires the server to support the fsync@openssh.com extension.
 func (f *File) Sync() error {
 	id := f.c.nextID()
-	typ, data, err := f.c.sendPacket(nil, sshFxpFsyncPacket{
+	typ, data, err := f.c.sendPacket(nil, &sshFxpFsyncPacket{
 		ID:     id,
 		Handle: f.handle,
 	})

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -2024,7 +2024,7 @@ func benchmarkRead(b *testing.B, bufsize int, delay time.Duration) {
 	// open sftp client
 	sftp, cmd := testClient(b, READONLY, delay)
 	defer cmd.Wait()
-	// defer sftp.Close()
+	defer sftp.Close()
 
 	buf := make([]byte, bufsize)
 
@@ -2102,7 +2102,7 @@ func benchmarkWrite(b *testing.B, bufsize int, delay time.Duration) {
 	// open sftp client
 	sftp, cmd := testClient(b, false, delay)
 	defer cmd.Wait()
-	// defer sftp.Close()
+	defer sftp.Close()
 
 	data := make([]byte, size)
 
@@ -2198,7 +2198,7 @@ func benchmarkReadFrom(b *testing.B, bufsize int, delay time.Duration) {
 	// open sftp client
 	sftp, cmd := testClient(b, false, delay)
 	defer cmd.Wait()
-	// defer sftp.Close()
+	defer sftp.Close()
 
 	data := make([]byte, size)
 
@@ -2300,7 +2300,7 @@ func benchmarkCopyDown(b *testing.B, fileSize int64, delay time.Duration) {
 
 	sftp, cmd := testClient(b, READONLY, delay)
 	defer cmd.Wait()
-	// defer sftp.Close()
+	defer sftp.Close()
 	b.ResetTimer()
 	b.SetBytes(fileSize)
 
@@ -2374,7 +2374,7 @@ func benchmarkCopyUp(b *testing.B, fileSize int64, delay time.Duration) {
 
 	sftp, cmd := testClient(b, false, delay)
 	defer cmd.Wait()
-	// defer sftp.Close()
+	defer sftp.Close()
 
 	b.ResetTimer()
 	b.SetBytes(fileSize)

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -2038,7 +2038,6 @@ func benchmarkRead(b *testing.B, bufsize int, delay time.Duration) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		defer f2.Close()
 
 		for offset < size {
 			n, err := io.ReadFull(f2, buf)
@@ -2053,6 +2052,8 @@ func benchmarkRead(b *testing.B, bufsize int, delay time.Duration) {
 
 			offset += n
 		}
+
+		f2.Close()
 	}
 }
 
@@ -2116,13 +2117,12 @@ func benchmarkWrite(b *testing.B, bufsize int, delay time.Duration) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		defer os.Remove(f.Name())
+		defer os.Remove(f.Name()) // actually queue up a series of removes for these files
 
 		f2, err := sftp.Create(f.Name())
 		if err != nil {
 			b.Fatal(err)
 		}
-		defer f2.Close()
 
 		for offset < size {
 			n, err := f2.Write(data[offset:min(len(data), offset+bufsize)])

--- a/conn.go
+++ b/conn.go
@@ -105,7 +105,7 @@ func (c *clientConn) putChannel(ch chan<- result, sid uint32) bool {
 	select {
 	case <-c.closed:
 		// already closed with broadcastErr, return error on chan.
-		ch <- result{err: c.err}
+		ch <- result{err: errors.New("unexpected server disconnect")}
 		return false
 	default:
 	}

--- a/conn.go
+++ b/conn.go
@@ -105,7 +105,7 @@ func (c *clientConn) putChannel(ch chan<- result, sid uint32) bool {
 	select {
 	case <-c.closed:
 		// already closed with broadcastErr, return error on chan.
-		ch <- result{err: errors.New("unexpected server disconnect")}
+		ch <- result{err: ErrSSHFxConnectionLost}
 		return false
 	default:
 	}
@@ -168,7 +168,7 @@ func (c *clientConn) broadcastErr(err error) {
 	c.Lock()
 	defer c.Unlock()
 
-	bcastRes := result{err: errors.New("unexpected server disconnect")}
+	bcastRes := result{err: ErrSSHFxConnectionLost}
 	for sid, ch := range c.inflight {
 		ch <- bcastRes
 

--- a/conn.go
+++ b/conn.go
@@ -186,6 +186,6 @@ type serverConn struct {
 	conn
 }
 
-func (s *serverConn) sendError(p ider, err error) error {
-	return s.sendPacket(statusFromError(p, err))
+func (s *serverConn) sendError(id uint32, err error) error {
+	return s.sendPacket(statusFromError(id, err))
 }

--- a/conn.go
+++ b/conn.go
@@ -91,7 +91,7 @@ func (c *clientConn) recv() error {
 			// This is an unexpected occurrence. Send the error
 			// back to all listeners so that they terminate
 			// gracefully.
-			return errors.Errorf("sid: %v not fond", sid)
+			return errors.Errorf("sid not found: %v", sid)
 		}
 
 		ch <- result{typ: typ, data: data}

--- a/packet-manager_test.go
+++ b/packet-manager_test.go
@@ -31,7 +31,7 @@ func fake(rid, order uint32) fakepacket {
 }
 
 func (fakepacket) MarshalBinary() ([]byte, error) {
-	return []byte{}, nil
+	return make([]byte, 4), nil
 }
 
 func (fakepacket) UnmarshalBinary([]byte) error {

--- a/packet-typing.go
+++ b/packet-typing.go
@@ -34,51 +34,51 @@ type notReadOnly interface {
 
 //// define types by adding methods
 // hasPath
-func (p sshFxpLstatPacket) getPath() string    { return p.Path }
-func (p sshFxpStatPacket) getPath() string     { return p.Path }
-func (p sshFxpRmdirPacket) getPath() string    { return p.Path }
-func (p sshFxpReadlinkPacket) getPath() string { return p.Path }
-func (p sshFxpRealpathPacket) getPath() string { return p.Path }
-func (p sshFxpMkdirPacket) getPath() string    { return p.Path }
-func (p sshFxpSetstatPacket) getPath() string  { return p.Path }
-func (p sshFxpStatvfsPacket) getPath() string  { return p.Path }
-func (p sshFxpRemovePacket) getPath() string   { return p.Filename }
-func (p sshFxpRenamePacket) getPath() string   { return p.Oldpath }
-func (p sshFxpSymlinkPacket) getPath() string  { return p.Targetpath }
-func (p sshFxpOpendirPacket) getPath() string  { return p.Path }
-func (p sshFxpOpenPacket) getPath() string     { return p.Path }
+func (p *sshFxpLstatPacket) getPath() string    { return p.Path }
+func (p *sshFxpStatPacket) getPath() string     { return p.Path }
+func (p *sshFxpRmdirPacket) getPath() string    { return p.Path }
+func (p *sshFxpReadlinkPacket) getPath() string { return p.Path }
+func (p *sshFxpRealpathPacket) getPath() string { return p.Path }
+func (p *sshFxpMkdirPacket) getPath() string    { return p.Path }
+func (p *sshFxpSetstatPacket) getPath() string  { return p.Path }
+func (p *sshFxpStatvfsPacket) getPath() string  { return p.Path }
+func (p *sshFxpRemovePacket) getPath() string   { return p.Filename }
+func (p *sshFxpRenamePacket) getPath() string   { return p.Oldpath }
+func (p *sshFxpSymlinkPacket) getPath() string  { return p.Targetpath }
+func (p *sshFxpOpendirPacket) getPath() string  { return p.Path }
+func (p *sshFxpOpenPacket) getPath() string     { return p.Path }
 
-func (p sshFxpExtendedPacketPosixRename) getPath() string { return p.Oldpath }
-func (p sshFxpExtendedPacketHardlink) getPath() string    { return p.Oldpath }
+func (p *sshFxpExtendedPacketPosixRename) getPath() string { return p.Oldpath }
+func (p *sshFxpExtendedPacketHardlink) getPath() string    { return p.Oldpath }
 
 // getHandle
-func (p sshFxpFstatPacket) getHandle() string    { return p.Handle }
-func (p sshFxpFsetstatPacket) getHandle() string { return p.Handle }
-func (p sshFxpReadPacket) getHandle() string     { return p.Handle }
-func (p sshFxpWritePacket) getHandle() string    { return p.Handle }
-func (p sshFxpReaddirPacket) getHandle() string  { return p.Handle }
-func (p sshFxpClosePacket) getHandle() string    { return p.Handle }
+func (p *sshFxpFstatPacket) getHandle() string    { return p.Handle }
+func (p *sshFxpFsetstatPacket) getHandle() string { return p.Handle }
+func (p *sshFxpReadPacket) getHandle() string     { return p.Handle }
+func (p *sshFxpWritePacket) getHandle() string    { return p.Handle }
+func (p *sshFxpReaddirPacket) getHandle() string  { return p.Handle }
+func (p *sshFxpClosePacket) getHandle() string    { return p.Handle }
 
 // notReadOnly
-func (p sshFxpWritePacket) notReadOnly()               {}
-func (p sshFxpSetstatPacket) notReadOnly()             {}
-func (p sshFxpFsetstatPacket) notReadOnly()            {}
-func (p sshFxpRemovePacket) notReadOnly()              {}
-func (p sshFxpMkdirPacket) notReadOnly()               {}
-func (p sshFxpRmdirPacket) notReadOnly()               {}
-func (p sshFxpRenamePacket) notReadOnly()              {}
-func (p sshFxpSymlinkPacket) notReadOnly()             {}
-func (p sshFxpExtendedPacketPosixRename) notReadOnly() {}
-func (p sshFxpExtendedPacketHardlink) notReadOnly()    {}
+func (p *sshFxpWritePacket) notReadOnly()               {}
+func (p *sshFxpSetstatPacket) notReadOnly()             {}
+func (p *sshFxpFsetstatPacket) notReadOnly()            {}
+func (p *sshFxpRemovePacket) notReadOnly()              {}
+func (p *sshFxpMkdirPacket) notReadOnly()               {}
+func (p *sshFxpRmdirPacket) notReadOnly()               {}
+func (p *sshFxpRenamePacket) notReadOnly()              {}
+func (p *sshFxpSymlinkPacket) notReadOnly()             {}
+func (p *sshFxpExtendedPacketPosixRename) notReadOnly() {}
+func (p *sshFxpExtendedPacketHardlink) notReadOnly()    {}
 
 // some packets with ID are missing id()
-func (p sshFxpDataPacket) id() uint32   { return p.ID }
-func (p sshFxpStatusPacket) id() uint32 { return p.ID }
-func (p sshFxpStatResponse) id() uint32 { return p.ID }
-func (p sshFxpNamePacket) id() uint32   { return p.ID }
-func (p sshFxpHandlePacket) id() uint32 { return p.ID }
-func (p StatVFS) id() uint32            { return p.ID }
-func (p sshFxVersionPacket) id() uint32 { return 0 }
+func (p *sshFxpDataPacket) id() uint32   { return p.ID }
+func (p *sshFxpStatusPacket) id() uint32 { return p.ID }
+func (p *sshFxpStatResponse) id() uint32 { return p.ID }
+func (p *sshFxpNamePacket) id() uint32   { return p.ID }
+func (p *sshFxpHandlePacket) id() uint32 { return p.ID }
+func (p *StatVFS) id() uint32            { return p.ID }
+func (p *sshFxVersionPacket) id() uint32 { return 0 }
 
 // take raw incoming packet data and build packet objects
 func makePacket(p rxPacket) (requestPacket, error) {

--- a/packet.go
+++ b/packet.go
@@ -57,12 +57,12 @@ func marshal(b []byte, v interface{}) []byte {
 		switch d := reflect.ValueOf(v); d.Kind() {
 		case reflect.Struct:
 			for i, n := 0, d.NumField(); i < n; i++ {
-				b = append(marshal(b, d.Field(i).Interface()))
+				b = marshal(b, d.Field(i).Interface())
 			}
 			return b
 		case reflect.Slice:
 			for i, n := 0, d.Len(); i < n; i++ {
-				b = append(marshal(b, d.Index(i).Interface()))
+				b = marshal(b, d.Index(i).Interface())
 			}
 			return b
 		default:

--- a/packet.go
+++ b/packet.go
@@ -218,7 +218,7 @@ type sshFxInitPacket struct {
 	Extensions []extensionPair
 }
 
-func (p sshFxInitPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxInitPacket) MarshalBinary() ([]byte, error) {
 	l := 4 + 1 + 4 // uint32(length) + byte(type) + uint32(version)
 	for _, e := range p.Extensions {
 		l += 4 + len(e.Name) + 4 + len(e.Data)
@@ -261,7 +261,7 @@ type sshExtensionPair struct {
 	Name, Data string
 }
 
-func (p sshFxVersionPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxVersionPacket) MarshalBinary() ([]byte, error) {
 	l := 4 + 1 + 4 // uint32(length) + byte(type) + uint32(version)
 	for _, e := range p.Extensions {
 		l += 4 + len(e.Name) + 4 + len(e.Data)
@@ -306,9 +306,9 @@ type sshFxpReaddirPacket struct {
 	Handle string
 }
 
-func (p sshFxpReaddirPacket) id() uint32 { return p.ID }
+func (p *sshFxpReaddirPacket) id() uint32 { return p.ID }
 
-func (p sshFxpReaddirPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpReaddirPacket) MarshalBinary() ([]byte, error) {
 	return marshalIDStringPacket(sshFxpReaddir, p.ID, p.Handle)
 }
 
@@ -321,9 +321,9 @@ type sshFxpOpendirPacket struct {
 	Path string
 }
 
-func (p sshFxpOpendirPacket) id() uint32 { return p.ID }
+func (p *sshFxpOpendirPacket) id() uint32 { return p.ID }
 
-func (p sshFxpOpendirPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpOpendirPacket) MarshalBinary() ([]byte, error) {
 	return marshalIDStringPacket(sshFxpOpendir, p.ID, p.Path)
 }
 
@@ -336,9 +336,9 @@ type sshFxpLstatPacket struct {
 	Path string
 }
 
-func (p sshFxpLstatPacket) id() uint32 { return p.ID }
+func (p *sshFxpLstatPacket) id() uint32 { return p.ID }
 
-func (p sshFxpLstatPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpLstatPacket) MarshalBinary() ([]byte, error) {
 	return marshalIDStringPacket(sshFxpLstat, p.ID, p.Path)
 }
 
@@ -351,9 +351,9 @@ type sshFxpStatPacket struct {
 	Path string
 }
 
-func (p sshFxpStatPacket) id() uint32 { return p.ID }
+func (p *sshFxpStatPacket) id() uint32 { return p.ID }
 
-func (p sshFxpStatPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpStatPacket) MarshalBinary() ([]byte, error) {
 	return marshalIDStringPacket(sshFxpStat, p.ID, p.Path)
 }
 
@@ -366,9 +366,9 @@ type sshFxpFstatPacket struct {
 	Handle string
 }
 
-func (p sshFxpFstatPacket) id() uint32 { return p.ID }
+func (p *sshFxpFstatPacket) id() uint32 { return p.ID }
 
-func (p sshFxpFstatPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpFstatPacket) MarshalBinary() ([]byte, error) {
 	return marshalIDStringPacket(sshFxpFstat, p.ID, p.Handle)
 }
 
@@ -381,9 +381,9 @@ type sshFxpClosePacket struct {
 	Handle string
 }
 
-func (p sshFxpClosePacket) id() uint32 { return p.ID }
+func (p *sshFxpClosePacket) id() uint32 { return p.ID }
 
-func (p sshFxpClosePacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpClosePacket) MarshalBinary() ([]byte, error) {
 	return marshalIDStringPacket(sshFxpClose, p.ID, p.Handle)
 }
 
@@ -396,9 +396,9 @@ type sshFxpRemovePacket struct {
 	Filename string
 }
 
-func (p sshFxpRemovePacket) id() uint32 { return p.ID }
+func (p *sshFxpRemovePacket) id() uint32 { return p.ID }
 
-func (p sshFxpRemovePacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpRemovePacket) MarshalBinary() ([]byte, error) {
 	return marshalIDStringPacket(sshFxpRemove, p.ID, p.Filename)
 }
 
@@ -411,9 +411,9 @@ type sshFxpRmdirPacket struct {
 	Path string
 }
 
-func (p sshFxpRmdirPacket) id() uint32 { return p.ID }
+func (p *sshFxpRmdirPacket) id() uint32 { return p.ID }
 
-func (p sshFxpRmdirPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpRmdirPacket) MarshalBinary() ([]byte, error) {
 	return marshalIDStringPacket(sshFxpRmdir, p.ID, p.Path)
 }
 
@@ -427,9 +427,9 @@ type sshFxpSymlinkPacket struct {
 	Linkpath   string
 }
 
-func (p sshFxpSymlinkPacket) id() uint32 { return p.ID }
+func (p *sshFxpSymlinkPacket) id() uint32 { return p.ID }
 
-func (p sshFxpSymlinkPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpSymlinkPacket) MarshalBinary() ([]byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Targetpath) +
 		4 + len(p.Linkpath)
@@ -461,9 +461,9 @@ type sshFxpHardlinkPacket struct {
 	Newpath string
 }
 
-func (p sshFxpHardlinkPacket) id() uint32 { return p.ID }
+func (p *sshFxpHardlinkPacket) id() uint32 { return p.ID }
 
-func (p sshFxpHardlinkPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpHardlinkPacket) MarshalBinary() ([]byte, error) {
 	const ext = "hardlink@openssh.com"
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(ext) +
@@ -485,9 +485,9 @@ type sshFxpReadlinkPacket struct {
 	Path string
 }
 
-func (p sshFxpReadlinkPacket) id() uint32 { return p.ID }
+func (p *sshFxpReadlinkPacket) id() uint32 { return p.ID }
 
-func (p sshFxpReadlinkPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpReadlinkPacket) MarshalBinary() ([]byte, error) {
 	return marshalIDStringPacket(sshFxpReadlink, p.ID, p.Path)
 }
 
@@ -500,9 +500,9 @@ type sshFxpRealpathPacket struct {
 	Path string
 }
 
-func (p sshFxpRealpathPacket) id() uint32 { return p.ID }
+func (p *sshFxpRealpathPacket) id() uint32 { return p.ID }
 
-func (p sshFxpRealpathPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpRealpathPacket) MarshalBinary() ([]byte, error) {
 	return marshalIDStringPacket(sshFxpRealpath, p.ID, p.Path)
 }
 
@@ -516,7 +516,7 @@ type sshFxpNameAttr struct {
 	Attrs    []interface{}
 }
 
-func (p sshFxpNameAttr) MarshalBinary() ([]byte, error) {
+func (p *sshFxpNameAttr) MarshalBinary() ([]byte, error) {
 	var b []byte
 	b = marshalString(b, p.Name)
 	b = marshalString(b, p.LongName)
@@ -528,10 +528,10 @@ func (p sshFxpNameAttr) MarshalBinary() ([]byte, error) {
 
 type sshFxpNamePacket struct {
 	ID        uint32
-	NameAttrs []sshFxpNameAttr
+	NameAttrs []*sshFxpNameAttr
 }
 
-func (p sshFxpNamePacket) marshalPacket() ([]byte, []byte, error) {
+func (p *sshFxpNamePacket) marshalPacket() ([]byte, []byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4
 
@@ -553,7 +553,7 @@ func (p sshFxpNamePacket) marshalPacket() ([]byte, []byte, error) {
 	return b, payload, nil
 }
 
-func (p sshFxpNamePacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpNamePacket) MarshalBinary() ([]byte, error) {
 	header, payload, err := p.marshalPacket()
 	return append(header, payload...), err
 }
@@ -565,9 +565,9 @@ type sshFxpOpenPacket struct {
 	Flags  uint32 // ignored
 }
 
-func (p sshFxpOpenPacket) id() uint32 { return p.ID }
+func (p *sshFxpOpenPacket) id() uint32 { return p.ID }
 
-func (p sshFxpOpenPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpOpenPacket) MarshalBinary() ([]byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Path) +
 		4 + 4
@@ -603,9 +603,9 @@ type sshFxpReadPacket struct {
 	Handle string
 }
 
-func (p sshFxpReadPacket) id() uint32 { return p.ID }
+func (p *sshFxpReadPacket) id() uint32 { return p.ID }
 
-func (p sshFxpReadPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpReadPacket) MarshalBinary() ([]byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Handle) +
 		8 + 4 // uint64 + uint32
@@ -655,9 +655,9 @@ type sshFxpRenamePacket struct {
 	Newpath string
 }
 
-func (p sshFxpRenamePacket) id() uint32 { return p.ID }
+func (p *sshFxpRenamePacket) id() uint32 { return p.ID }
 
-func (p sshFxpRenamePacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpRenamePacket) MarshalBinary() ([]byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Oldpath) +
 		4 + len(p.Newpath)
@@ -689,9 +689,9 @@ type sshFxpPosixRenamePacket struct {
 	Newpath string
 }
 
-func (p sshFxpPosixRenamePacket) id() uint32 { return p.ID }
+func (p *sshFxpPosixRenamePacket) id() uint32 { return p.ID }
 
-func (p sshFxpPosixRenamePacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpPosixRenamePacket) MarshalBinary() ([]byte, error) {
 	const ext = "posix-rename@openssh.com"
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(ext) +
@@ -716,9 +716,9 @@ type sshFxpWritePacket struct {
 	Data   []byte
 }
 
-func (p sshFxpWritePacket) id() uint32 { return p.ID }
+func (p *sshFxpWritePacket) id() uint32 { return p.ID }
 
-func (p sshFxpWritePacket) marshalPacket() ([]byte, []byte, error) {
+func (p *sshFxpWritePacket) marshalPacket() ([]byte, []byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Handle) +
 		8 + // uint64
@@ -734,7 +734,7 @@ func (p sshFxpWritePacket) marshalPacket() ([]byte, []byte, error) {
 	return b, p.Data, nil
 }
 
-func (p sshFxpWritePacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpWritePacket) MarshalBinary() ([]byte, error) {
 	header, payload, err := p.marshalPacket()
 	return append(header, payload...), err
 }
@@ -763,9 +763,9 @@ type sshFxpMkdirPacket struct {
 	Path  string
 }
 
-func (p sshFxpMkdirPacket) id() uint32 { return p.ID }
+func (p *sshFxpMkdirPacket) id() uint32 { return p.ID }
 
-func (p sshFxpMkdirPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpMkdirPacket) MarshalBinary() ([]byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Path) +
 		4 // uint32
@@ -805,10 +805,10 @@ type sshFxpFsetstatPacket struct {
 	Attrs  interface{}
 }
 
-func (p sshFxpSetstatPacket) id() uint32  { return p.ID }
-func (p sshFxpFsetstatPacket) id() uint32 { return p.ID }
+func (p *sshFxpSetstatPacket) id() uint32  { return p.ID }
+func (p *sshFxpFsetstatPacket) id() uint32 { return p.ID }
 
-func (p sshFxpSetstatPacket) marshalPacket() ([]byte, []byte, error) {
+func (p *sshFxpSetstatPacket) marshalPacket() ([]byte, []byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Path) +
 		4 // uint32
@@ -824,12 +824,12 @@ func (p sshFxpSetstatPacket) marshalPacket() ([]byte, []byte, error) {
 	return b, payload, nil
 }
 
-func (p sshFxpSetstatPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpSetstatPacket) MarshalBinary() ([]byte, error) {
 	header, payload, err := p.marshalPacket()
 	return append(header, payload...), err
 }
 
-func (p sshFxpFsetstatPacket) marshalPacket() ([]byte, []byte, error) {
+func (p *sshFxpFsetstatPacket) marshalPacket() ([]byte, []byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Handle) +
 		4 // uint32
@@ -845,7 +845,7 @@ func (p sshFxpFsetstatPacket) marshalPacket() ([]byte, []byte, error) {
 	return b, payload, nil
 }
 
-func (p sshFxpFsetstatPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpFsetstatPacket) MarshalBinary() ([]byte, error) {
 	header, payload, err := p.marshalPacket()
 	return append(header, payload...), err
 }
@@ -881,7 +881,7 @@ type sshFxpHandlePacket struct {
 	Handle string
 }
 
-func (p sshFxpHandlePacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpHandlePacket) MarshalBinary() ([]byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Handle)
 
@@ -898,7 +898,7 @@ type sshFxpStatusPacket struct {
 	StatusError
 }
 
-func (p sshFxpStatusPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpStatusPacket) MarshalBinary() ([]byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 +
 		4 + len(p.StatusError.msg) +
@@ -918,7 +918,7 @@ type sshFxpDataPacket struct {
 	Data   []byte
 }
 
-func (p sshFxpDataPacket) marshalPacket() ([]byte, []byte, error) {
+func (p *sshFxpDataPacket) marshalPacket() ([]byte, []byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4
 
@@ -935,7 +935,7 @@ func (p sshFxpDataPacket) marshalPacket() ([]byte, []byte, error) {
 //
 // This is hand-coded rather than just append(header, payload...),
 // in order to try and reuse the r.Data backing store in the packet.
-func (p sshFxpDataPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpDataPacket) MarshalBinary() ([]byte, error) {
 	b := append(p.Data, make([]byte, dataHeaderLen)...)
 	copy(b[dataHeaderLen:], p.Data[:p.Length])
 	// b[0:4] will be overwritten with the length in sendPacket
@@ -964,9 +964,9 @@ type sshFxpStatvfsPacket struct {
 	Path string
 }
 
-func (p sshFxpStatvfsPacket) id() uint32 { return p.ID }
+func (p *sshFxpStatvfsPacket) id() uint32 { return p.ID }
 
-func (p sshFxpStatvfsPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpStatvfsPacket) MarshalBinary() ([]byte, error) {
 	const ext = "statvfs@openssh.com"
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(ext) +
@@ -1027,9 +1027,9 @@ type sshFxpFsyncPacket struct {
 	Handle string
 }
 
-func (p sshFxpFsyncPacket) id() uint32 { return p.ID }
+func (p *sshFxpFsyncPacket) id() uint32 { return p.ID }
 
-func (p sshFxpFsyncPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpFsyncPacket) MarshalBinary() ([]byte, error) {
 	const ext = "fsync@openssh.com"
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(ext) +
@@ -1053,17 +1053,17 @@ type sshFxpExtendedPacket struct {
 	}
 }
 
-func (p sshFxpExtendedPacket) id() uint32 { return p.ID }
-func (p sshFxpExtendedPacket) readonly() bool {
+func (p *sshFxpExtendedPacket) id() uint32 { return p.ID }
+func (p *sshFxpExtendedPacket) readonly() bool {
 	if p.SpecificPacket == nil {
 		return true
 	}
 	return p.SpecificPacket.readonly()
 }
 
-func (p sshFxpExtendedPacket) respond(svr *Server) responsePacket {
+func (p *sshFxpExtendedPacket) respond(svr *Server) responsePacket {
 	if p.SpecificPacket == nil {
-		return statusFromError(p, nil)
+		return statusFromError(p.ID, nil)
 	}
 	return p.SpecificPacket.respond(svr)
 }
@@ -1098,8 +1098,8 @@ type sshFxpExtendedPacketStatVFS struct {
 	Path            string
 }
 
-func (p sshFxpExtendedPacketStatVFS) id() uint32     { return p.ID }
-func (p sshFxpExtendedPacketStatVFS) readonly() bool { return true }
+func (p *sshFxpExtendedPacketStatVFS) id() uint32     { return p.ID }
+func (p *sshFxpExtendedPacketStatVFS) readonly() bool { return true }
 func (p *sshFxpExtendedPacketStatVFS) UnmarshalBinary(b []byte) error {
 	var err error
 	if p.ID, b, err = unmarshalUint32Safe(b); err != nil {
@@ -1119,8 +1119,8 @@ type sshFxpExtendedPacketPosixRename struct {
 	Newpath         string
 }
 
-func (p sshFxpExtendedPacketPosixRename) id() uint32     { return p.ID }
-func (p sshFxpExtendedPacketPosixRename) readonly() bool { return false }
+func (p *sshFxpExtendedPacketPosixRename) id() uint32     { return p.ID }
+func (p *sshFxpExtendedPacketPosixRename) readonly() bool { return false }
 func (p *sshFxpExtendedPacketPosixRename) UnmarshalBinary(b []byte) error {
 	var err error
 	if p.ID, b, err = unmarshalUint32Safe(b); err != nil {
@@ -1135,9 +1135,9 @@ func (p *sshFxpExtendedPacketPosixRename) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-func (p sshFxpExtendedPacketPosixRename) respond(s *Server) responsePacket {
+func (p *sshFxpExtendedPacketPosixRename) respond(s *Server) responsePacket {
 	err := os.Rename(p.Oldpath, p.Newpath)
-	return statusFromError(p, err)
+	return statusFromError(p.ID, err)
 }
 
 type sshFxpExtendedPacketHardlink struct {
@@ -1148,8 +1148,8 @@ type sshFxpExtendedPacketHardlink struct {
 }
 
 // https://github.com/openssh/openssh-portable/blob/master/PROTOCOL
-func (p sshFxpExtendedPacketHardlink) id() uint32     { return p.ID }
-func (p sshFxpExtendedPacketHardlink) readonly() bool { return true }
+func (p *sshFxpExtendedPacketHardlink) id() uint32     { return p.ID }
+func (p *sshFxpExtendedPacketHardlink) readonly() bool { return true }
 func (p *sshFxpExtendedPacketHardlink) UnmarshalBinary(b []byte) error {
 	var err error
 	if p.ID, b, err = unmarshalUint32Safe(b); err != nil {
@@ -1164,7 +1164,7 @@ func (p *sshFxpExtendedPacketHardlink) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-func (p sshFxpExtendedPacketHardlink) respond(s *Server) responsePacket {
+func (p *sshFxpExtendedPacketHardlink) respond(s *Server) responsePacket {
 	err := os.Link(p.Oldpath, p.Newpath)
-	return statusFromError(p, err)
+	return statusFromError(p.ID, err)
 }

--- a/packet_test.go
+++ b/packet_test.go
@@ -142,20 +142,20 @@ var sendPacketTests = []struct {
 	p    encoding.BinaryMarshaler
 	want []byte
 }{
-	{sshFxInitPacket{
+	{&sshFxInitPacket{
 		Version: 3,
 		Extensions: []extensionPair{
 			{"posix-rename@openssh.com", "1"},
 		},
 	}, []byte{0x0, 0x0, 0x0, 0x26, 0x1, 0x0, 0x0, 0x0, 0x3, 0x0, 0x0, 0x0, 0x18, 0x70, 0x6f, 0x73, 0x69, 0x78, 0x2d, 0x72, 0x65, 0x6e, 0x61, 0x6d, 0x65, 0x40, 0x6f, 0x70, 0x65, 0x6e, 0x73, 0x73, 0x68, 0x2e, 0x63, 0x6f, 0x6d, 0x0, 0x0, 0x0, 0x1, 0x31}},
 
-	{sshFxpOpenPacket{
+	{&sshFxpOpenPacket{
 		ID:     1,
 		Path:   "/foo",
 		Pflags: flags(os.O_RDONLY),
 	}, []byte{0x0, 0x0, 0x0, 0x15, 0x3, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x4, 0x2f, 0x66, 0x6f, 0x6f, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0}},
 
-	{sshFxpWritePacket{
+	{&sshFxpWritePacket{
 		ID:     124,
 		Handle: "foo",
 		Offset: 13,
@@ -163,7 +163,7 @@ var sendPacketTests = []struct {
 		Data:   []byte("bar"),
 	}, []byte{0x0, 0x0, 0x0, 0x1b, 0x6, 0x0, 0x0, 0x0, 0x7c, 0x0, 0x0, 0x0, 0x3, 0x66, 0x6f, 0x6f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xd, 0x0, 0x0, 0x0, 0x3, 0x62, 0x61, 0x72}},
 
-	{sshFxpSetstatPacket{
+	{&sshFxpSetstatPacket{
 		ID:    31,
 		Path:  "/bar",
 		Flags: flags(os.O_WRONLY),
@@ -195,7 +195,7 @@ var recvPacketTests = []struct {
 	want uint8
 	rest []byte
 }{
-	{sp(sshFxInitPacket{
+	{sp(&sshFxInitPacket{
 		Version: 3,
 		Extensions: []extensionPair{
 			{"posix-rename@openssh.com", "1"},
@@ -299,7 +299,7 @@ func TestSSHFxpOpenPackethasPflags(t *testing.T) {
 
 func BenchmarkMarshalInit(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		sp(sshFxInitPacket{
+		sp(&sshFxInitPacket{
 			Version: 3,
 			Extensions: []extensionPair{
 				{"posix-rename@openssh.com", "1"},
@@ -310,7 +310,7 @@ func BenchmarkMarshalInit(b *testing.B) {
 
 func BenchmarkMarshalOpen(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		sp(sshFxpOpenPacket{
+		sp(&sshFxpOpenPacket{
 			ID:     1,
 			Path:   "/home/test/some/random/path",
 			Pflags: flags(os.O_RDONLY),
@@ -321,7 +321,7 @@ func BenchmarkMarshalOpen(b *testing.B) {
 func BenchmarkMarshalWriteWorstCase(b *testing.B) {
 	data := make([]byte, 32*1024)
 	for i := 0; i < b.N; i++ {
-		sp(sshFxpWritePacket{
+		sp(&sshFxpWritePacket{
 			ID:     1,
 			Handle: "someopaquehandle",
 			Offset: 0,
@@ -334,7 +334,7 @@ func BenchmarkMarshalWriteWorstCase(b *testing.B) {
 func BenchmarkMarshalWrite1k(b *testing.B) {
 	data := make([]byte, 1024)
 	for i := 0; i < b.N; i++ {
-		sp(sshFxpWritePacket{
+		sp(&sshFxpWritePacket{
 			ID:     1,
 			Handle: "someopaquehandle",
 			Offset: 0,

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -69,7 +69,7 @@ func clientRequestServerPair(t *testing.T) *csPair {
 	require.NoError(t, err)
 	client, err := NewClientPipe(c, c)
 	if err != nil {
-		t.Fatalf("%+v\n", err)
+		t.Fatalf("unexpected error: %+v", err)
 	}
 	pair.svr = server
 	pair.cli = client

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -147,11 +147,12 @@ func TestRequestCacheState(t *testing.T) {
 
 func putTestFile(cli *Client, path, content string) (int, error) {
 	w, err := cli.Create(path)
-	if err == nil {
-		defer w.Close()
-		return w.Write([]byte(content))
+	if err != nil {
+		return 0, err
 	}
-	return 0, err
+	defer w.Close()
+
+	return w.Write([]byte(content))
 }
 
 func getTestFile(cli *Client, path string) ([]byte, error) {

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -39,11 +39,14 @@ const sock = "/tmp/rstest.sock"
 func clientRequestServerPair(t *testing.T) *csPair {
 	skipIfWindows(t)
 	skipIfPlan9(t)
-	ready := make(chan bool)
+
+	ready := make(chan struct{})
+	canReturn := make(chan struct{})
 	os.Remove(sock) // either this or signal handling
 	pair := &csPair{
 		svrResult: make(chan error, 1),
 	}
+
 	var server *RequestServer
 	go func() {
 		l, err := net.Listen("unix", sock)
@@ -51,26 +54,37 @@ func clientRequestServerPair(t *testing.T) *csPair {
 			// neither assert nor t.Fatal reliably exit before Accept errors
 			panic(err)
 		}
-		ready <- true
+
+		close(ready)
+
 		fd, err := l.Accept()
 		require.NoError(t, err)
+
 		handlers := InMemHandler()
 		var options []RequestServerOption
 		if *testAllocator {
 			options = append(options, WithRSAllocator())
 		}
+
 		server = NewRequestServer(fd, handlers, options...)
+		close(canReturn)
+
 		err = server.Serve()
 		pair.svrResult <- err
 	}()
+
 	<-ready
 	defer os.Remove(sock)
+
 	c, err := net.Dial("unix", sock)
 	require.NoError(t, err)
+
 	client, err := NewClientPipe(c, c)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
+
+	<-canReturn
 	pair.svr = server
 	pair.cli = client
 	return pair

--- a/request_test.go
+++ b/request_test.go
@@ -118,11 +118,11 @@ func (h *Handlers) returnError(err error) {
 }
 
 func getStatusMsg(p interface{}) string {
-	pkt := p.(sshFxpStatusPacket)
+	pkt := p.(*sshFxpStatusPacket)
 	return pkt.StatusError.msg
 }
 func checkOkStatus(t *testing.T, p interface{}) {
-	pkt := p.(sshFxpStatusPacket)
+	pkt := p.(*sshFxpStatusPacket)
 	assert.Equal(t, pkt.StatusError.Code, uint32(sshFxOk),
 		"sshFxpStatusPacket not OK\n", pkt.StatusError.msg)
 }
@@ -166,7 +166,7 @@ func TestRequestCustomError(t *testing.T) {
 	cmdErr := errors.New("stat not supported")
 	handlers.returnError(cmdErr)
 	rpkt := request.call(handlers, pkt, nil, 0)
-	assert.Equal(t, rpkt, statusFromError(rpkt, cmdErr))
+	assert.Equal(t, rpkt, statusFromError(pkt.myid, cmdErr))
 }
 
 // XXX can't just set method to Get, need to use Open to setup Get/Put
@@ -194,7 +194,7 @@ func TestRequestCmdr(t *testing.T) {
 
 	handlers.returnError(errTest)
 	rpkt = request.call(handlers, pkt, nil, 0)
-	assert.Equal(t, rpkt, statusFromError(rpkt, errTest))
+	assert.Equal(t, rpkt, statusFromError(pkt.myid, errTest))
 }
 
 func TestRequestInfoStat(t *testing.T) {
@@ -227,7 +227,7 @@ func TestRequestInfoReadlink(t *testing.T) {
 	rpkt := request.call(handlers, pkt, nil, 0)
 	npkt, ok := rpkt.(*sshFxpNamePacket)
 	if assert.True(t, ok) {
-		assert.IsType(t, sshFxpNameAttr{}, npkt.NameAttrs[0])
+		assert.IsType(t, &sshFxpNameAttr{}, npkt.NameAttrs[0])
 		assert.Equal(t, npkt.NameAttrs[0].Name, "request_test.go")
 	}
 }

--- a/server.go
+++ b/server.go
@@ -152,7 +152,7 @@ func (svr *Server) sftpServerWorker(pktChan chan orderedRequest) error {
 		// return permission denied
 		if !readonly && svr.readOnly {
 			svr.pktMgr.readyPacket(
-				svr.pktMgr.newOrderedResponse(statusFromError(pkt, syscall.EPERM), pkt.orderID()),
+				svr.pktMgr.newOrderedResponse(statusFromError(pkt.id(), syscall.EPERM), pkt.orderID()),
 			)
 			continue
 		}
@@ -169,29 +169,29 @@ func handlePacket(s *Server, p orderedRequest) error {
 	orderID := p.orderID()
 	switch p := p.requestPacket.(type) {
 	case *sshFxInitPacket:
-		rpkt = sshFxVersionPacket{
+		rpkt = &sshFxVersionPacket{
 			Version:    sftpProtocolVersion,
 			Extensions: sftpExtensions,
 		}
 	case *sshFxpStatPacket:
 		// stat the requested file
 		info, err := os.Stat(p.Path)
-		rpkt = sshFxpStatResponse{
+		rpkt = &sshFxpStatResponse{
 			ID:   p.ID,
 			info: info,
 		}
 		if err != nil {
-			rpkt = statusFromError(p, err)
+			rpkt = statusFromError(p.ID, err)
 		}
 	case *sshFxpLstatPacket:
 		// stat the requested file
 		info, err := os.Lstat(p.Path)
-		rpkt = sshFxpStatResponse{
+		rpkt = &sshFxpStatResponse{
 			ID:   p.ID,
 			info: info,
 		}
 		if err != nil {
-			rpkt = statusFromError(p, err)
+			rpkt = statusFromError(p.ID, err)
 		}
 	case *sshFxpFstatPacket:
 		f, ok := s.getHandle(p.Handle)
@@ -199,71 +199,75 @@ func handlePacket(s *Server, p orderedRequest) error {
 		var info os.FileInfo
 		if ok {
 			info, err = f.Stat()
-			rpkt = sshFxpStatResponse{
+			rpkt = &sshFxpStatResponse{
 				ID:   p.ID,
 				info: info,
 			}
 		}
 		if err != nil {
-			rpkt = statusFromError(p, err)
+			rpkt = statusFromError(p.ID, err)
 		}
 	case *sshFxpMkdirPacket:
 		// TODO FIXME: ignore flags field
 		err := os.Mkdir(p.Path, 0755)
-		rpkt = statusFromError(p, err)
+		rpkt = statusFromError(p.ID, err)
 	case *sshFxpRmdirPacket:
 		err := os.Remove(p.Path)
-		rpkt = statusFromError(p, err)
+		rpkt = statusFromError(p.ID, err)
 	case *sshFxpRemovePacket:
 		err := os.Remove(p.Filename)
-		rpkt = statusFromError(p, err)
+		rpkt = statusFromError(p.ID, err)
 	case *sshFxpRenamePacket:
 		err := os.Rename(p.Oldpath, p.Newpath)
-		rpkt = statusFromError(p, err)
+		rpkt = statusFromError(p.ID, err)
 	case *sshFxpSymlinkPacket:
 		err := os.Symlink(p.Targetpath, p.Linkpath)
-		rpkt = statusFromError(p, err)
+		rpkt = statusFromError(p.ID, err)
 	case *sshFxpClosePacket:
-		rpkt = statusFromError(p, s.closeHandle(p.Handle))
+		rpkt = statusFromError(p.ID, s.closeHandle(p.Handle))
 	case *sshFxpReadlinkPacket:
 		f, err := os.Readlink(p.Path)
-		rpkt = sshFxpNamePacket{
+		rpkt = &sshFxpNamePacket{
 			ID: p.ID,
-			NameAttrs: []sshFxpNameAttr{{
-				Name:     f,
-				LongName: f,
-				Attrs:    emptyFileStat,
-			}},
+			NameAttrs: []*sshFxpNameAttr{
+				&sshFxpNameAttr{
+					Name:     f,
+					LongName: f,
+					Attrs:    emptyFileStat,
+				},
+			},
 		}
 		if err != nil {
-			rpkt = statusFromError(p, err)
+			rpkt = statusFromError(p.ID, err)
 		}
 	case *sshFxpRealpathPacket:
 		f, err := filepath.Abs(p.Path)
 		f = cleanPath(f)
-		rpkt = sshFxpNamePacket{
+		rpkt = &sshFxpNamePacket{
 			ID: p.ID,
-			NameAttrs: []sshFxpNameAttr{{
-				Name:     f,
-				LongName: f,
-				Attrs:    emptyFileStat,
-			}},
+			NameAttrs: []*sshFxpNameAttr{
+				&sshFxpNameAttr{
+					Name:     f,
+					LongName: f,
+					Attrs:    emptyFileStat,
+				},
+			},
 		}
 		if err != nil {
-			rpkt = statusFromError(p, err)
+			rpkt = statusFromError(p.ID, err)
 		}
 	case *sshFxpOpendirPacket:
 		if stat, err := os.Stat(p.Path); err != nil {
-			rpkt = statusFromError(p, err)
+			rpkt = statusFromError(p.ID, err)
 		} else if !stat.IsDir() {
-			rpkt = statusFromError(p, &os.PathError{
+			rpkt = statusFromError(p.ID, &os.PathError{
 				Path: p.Path, Err: syscall.ENOTDIR})
 		} else {
-			rpkt = sshFxpOpenPacket{
+			rpkt = (&sshFxpOpenPacket{
 				ID:     p.ID,
 				Path:   p.Path,
 				Pflags: sshFxfRead,
-			}.respond(s)
+			}).respond(s)
 		}
 	case *sshFxpReadPacket:
 		var err error = EBADF
@@ -275,7 +279,7 @@ func handlePacket(s *Server, p orderedRequest) error {
 			if _err != nil && (_err != io.EOF || n == 0) {
 				err = _err
 			}
-			rpkt = sshFxpDataPacket{
+			rpkt = &sshFxpDataPacket{
 				ID:     p.ID,
 				Length: uint32(n),
 				Data:   data[:n],
@@ -283,7 +287,7 @@ func handlePacket(s *Server, p orderedRequest) error {
 			}
 		}
 		if err != nil {
-			rpkt = statusFromError(p, err)
+			rpkt = statusFromError(p.ID, err)
 		}
 
 	case *sshFxpWritePacket:
@@ -292,10 +296,10 @@ func handlePacket(s *Server, p orderedRequest) error {
 		if ok {
 			_, err = f.WriteAt(p.Data, int64(p.Offset))
 		}
-		rpkt = statusFromError(p, err)
+		rpkt = statusFromError(p.ID, err)
 	case *sshFxpExtendedPacket:
 		if p.SpecificPacket == nil {
-			rpkt = statusFromError(p, ErrSSHFxOpUnsupported)
+			rpkt = statusFromError(p.ID, ErrSSHFxOpUnsupported)
 		} else {
 			rpkt = p.respond(s)
 		}
@@ -375,14 +379,14 @@ type ider interface {
 }
 
 // The init packet has no ID, so we just return a zero-value ID
-func (p sshFxInitPacket) id() uint32 { return 0 }
+func (p *sshFxInitPacket) id() uint32 { return 0 }
 
 type sshFxpStatResponse struct {
 	ID   uint32
 	info os.FileInfo
 }
 
-func (p sshFxpStatResponse) marshalPacket() ([]byte, []byte, error) {
+func (p *sshFxpStatResponse) marshalPacket() ([]byte, []byte, error) {
 	l := 4 + 1 + 4 // uint32(length) + byte(type) + uint32(id)
 
 	b := make([]byte, 4, l)
@@ -395,18 +399,18 @@ func (p sshFxpStatResponse) marshalPacket() ([]byte, []byte, error) {
 	return b, payload, nil
 }
 
-func (p sshFxpStatResponse) MarshalBinary() ([]byte, error) {
+func (p *sshFxpStatResponse) MarshalBinary() ([]byte, error) {
 	header, payload, err := p.marshalPacket()
 	return append(header, payload...), err
 }
 
 var emptyFileStat = []interface{}{uint32(0)}
 
-func (p sshFxpOpenPacket) readonly() bool {
+func (p *sshFxpOpenPacket) readonly() bool {
 	return !p.hasPflags(sshFxfWrite)
 }
 
-func (p sshFxpOpenPacket) hasPflags(flags ...uint32) bool {
+func (p *sshFxpOpenPacket) hasPflags(flags ...uint32) bool {
 	for _, f := range flags {
 		if p.Pflags&f == 0 {
 			return false
@@ -415,7 +419,7 @@ func (p sshFxpOpenPacket) hasPflags(flags ...uint32) bool {
 	return true
 }
 
-func (p sshFxpOpenPacket) respond(svr *Server) responsePacket {
+func (p *sshFxpOpenPacket) respond(svr *Server) responsePacket {
 	var osFlags int
 	if p.hasPflags(sshFxfRead, sshFxfWrite) {
 		osFlags |= os.O_RDWR
@@ -425,7 +429,7 @@ func (p sshFxpOpenPacket) respond(svr *Server) responsePacket {
 		osFlags |= os.O_RDONLY
 	} else {
 		// how are they opening?
-		return statusFromError(p, syscall.EINVAL)
+		return statusFromError(p.ID, syscall.EINVAL)
 	}
 
 	// Don't use O_APPEND flag as it conflicts with WriteAt.
@@ -443,28 +447,28 @@ func (p sshFxpOpenPacket) respond(svr *Server) responsePacket {
 
 	f, err := os.OpenFile(p.Path, osFlags, 0644)
 	if err != nil {
-		return statusFromError(p, err)
+		return statusFromError(p.ID, err)
 	}
 
 	handle := svr.nextHandle(f)
-	return sshFxpHandlePacket{ID: p.id(), Handle: handle}
+	return &sshFxpHandlePacket{ID: p.ID, Handle: handle}
 }
 
-func (p sshFxpReaddirPacket) respond(svr *Server) responsePacket {
+func (p *sshFxpReaddirPacket) respond(svr *Server) responsePacket {
 	f, ok := svr.getHandle(p.Handle)
 	if !ok {
-		return statusFromError(p, EBADF)
+		return statusFromError(p.ID, EBADF)
 	}
 
 	dirname := f.Name()
 	dirents, err := f.Readdir(128)
 	if err != nil {
-		return statusFromError(p, err)
+		return statusFromError(p.ID, err)
 	}
 
-	ret := sshFxpNamePacket{ID: p.ID}
+	ret := &sshFxpNamePacket{ID: p.ID}
 	for _, dirent := range dirents {
-		ret.NameAttrs = append(ret.NameAttrs, sshFxpNameAttr{
+		ret.NameAttrs = append(ret.NameAttrs, &sshFxpNameAttr{
 			Name:     dirent.Name(),
 			LongName: runLs(dirname, dirent),
 			Attrs:    []interface{}{dirent},
@@ -473,7 +477,7 @@ func (p sshFxpReaddirPacket) respond(svr *Server) responsePacket {
 	return ret
 }
 
-func (p sshFxpSetstatPacket) respond(svr *Server) responsePacket {
+func (p *sshFxpSetstatPacket) respond(svr *Server) responsePacket {
 	// additional unmarshalling is required for each possibility here
 	b := p.Attrs.([]byte)
 	var err error
@@ -512,13 +516,13 @@ func (p sshFxpSetstatPacket) respond(svr *Server) responsePacket {
 		}
 	}
 
-	return statusFromError(p, err)
+	return statusFromError(p.ID, err)
 }
 
-func (p sshFxpFsetstatPacket) respond(svr *Server) responsePacket {
+func (p *sshFxpFsetstatPacket) respond(svr *Server) responsePacket {
 	f, ok := svr.getHandle(p.Handle)
 	if !ok {
-		return statusFromError(p, EBADF)
+		return statusFromError(p.ID, EBADF)
 	}
 
 	// additional unmarshalling is required for each possibility here
@@ -559,12 +563,12 @@ func (p sshFxpFsetstatPacket) respond(svr *Server) responsePacket {
 		}
 	}
 
-	return statusFromError(p, err)
+	return statusFromError(p.ID, err)
 }
 
-func statusFromError(p ider, err error) sshFxpStatusPacket {
-	ret := sshFxpStatusPacket{
-		ID: p.id(),
+func statusFromError(id uint32, err error) *sshFxpStatusPacket {
+	ret := &sshFxpStatusPacket{
+		ID: id,
 		StatusError: StatusError{
 			// sshFXOk               = 0
 			// sshFXEOF              = 1

--- a/server_statvfs_impl.go
+++ b/server_statvfs_impl.go
@@ -9,21 +9,20 @@ import (
 	"syscall"
 )
 
-func (p sshFxpExtendedPacketStatVFS) respond(svr *Server) responsePacket {
+func (p *sshFxpExtendedPacketStatVFS) respond(svr *Server) responsePacket {
 	retPkt, err := getStatVFSForPath(p.Path)
 	if err != nil {
-		return statusFromError(p, err)
+		return statusFromError(p.ID, err)
 	}
-	retPkt.ID = p.ID
 
 	return retPkt
 }
 
 func getStatVFSForPath(name string) (*StatVFS, error) {
-	stat := &syscall.Statfs_t{}
-	if err := syscall.Statfs(name, stat); err != nil {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(name, &stat); err != nil {
 		return nil, err
 	}
 
-	return statvfsFromStatfst(stat)
+	return statvfsFromStatfst(&stat)
 }

--- a/server_statvfs_plan9.go
+++ b/server_statvfs_plan9.go
@@ -4,8 +4,8 @@ import (
 	"syscall"
 )
 
-func (p sshFxpExtendedPacketStatVFS) respond(svr *Server) responsePacket {
-	return statusFromError(p, syscall.EPLAN9)
+func (p *sshFxpExtendedPacketStatVFS) respond(svr *Server) responsePacket {
+	return statusFromError(p.ID, syscall.EPLAN9)
 }
 
 func getStatVFSForPath(name string) (*StatVFS, error) {

--- a/server_statvfs_stubs.go
+++ b/server_statvfs_stubs.go
@@ -6,8 +6,8 @@ import (
 	"syscall"
 )
 
-func (p sshFxpExtendedPacketStatVFS) respond(svr *Server) responsePacket {
-	return statusFromError(p, syscall.ENOTSUP)
+func (p *sshFxpExtendedPacketStatVFS) respond(svr *Server) responsePacket {
+	return statusFromError(p.ID, syscall.ENOTSUP)
 }
 
 func getStatVFSForPath(name string) (*StatVFS, error) {

--- a/server_test.go
+++ b/server_test.go
@@ -344,7 +344,7 @@ func TestOpenStatRace(t *testing.T) {
 			err := normaliseError(unmarshalStatus(id, r.data))
 			assert.NoError(t, err, "race hit, stat before open")
 		default:
-			assert.Fail(t, "Unexpected type")
+			t.Fatal("unexpected type:", r.typ)
 		}
 	}
 	testreply(id1, ch)

--- a/server_test.go
+++ b/server_test.go
@@ -337,7 +337,7 @@ func TestOpenStatRace(t *testing.T) {
 		ID:   id2,
 		Path: tmppath,
 	})
-	testreply := func(id uint32, ch chan result) {
+	testreply := func(id uint32) {
 		r := <-ch
 		switch r.typ {
 		case sshFxpAttrs, sshFxpHandle: // ignore
@@ -348,8 +348,8 @@ func TestOpenStatRace(t *testing.T) {
 			t.Fatal("unexpected type:", r.typ)
 		}
 	}
-	testreply(id1, ch)
-	testreply(id2, ch)
+	testreply(id1)
+	testreply(id2)
 	os.Remove(tmppath)
 	checkServerAllocator(t, server)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -193,15 +193,16 @@ type sshFxpTestBadExtendedPacket struct {
 func (p sshFxpTestBadExtendedPacket) id() uint32 { return p.ID }
 
 func (p sshFxpTestBadExtendedPacket) MarshalBinary() ([]byte, error) {
-	l := 1 + 4 + 4 + // type(byte) + uint32 + uint32
-		len(p.Extension) +
-		len(p.Data)
+	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
+		4 + len(p.Extension) +
+		4 + len(p.Data)
 
-	b := make([]byte, 0, l)
+	b := make([]byte, 4, l)
 	b = append(b, sshFxpExtended)
 	b = marshalUint32(b, p.ID)
 	b = marshalString(b, p.Extension)
 	b = marshalString(b, p.Data)
+
 	return b, nil
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -223,7 +223,7 @@ func TestInvalidExtendedPacket(t *testing.T) {
 	defer server.Close()
 
 	badPacket := sshFxpTestBadExtendedPacket{client.nextID(), "thisDoesn'tExist", "foobar"}
-	typ, data, err := client.clientConn.sendPacket(badPacket)
+	typ, data, err := client.clientConn.sendPacket(nil, badPacket)
 	if err != nil {
 		t.Fatalf("unexpected error from sendPacket: %s", err)
 	}

--- a/sftp_test.go
+++ b/sftp_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestErrFxCode(t *testing.T) {
-	ider := sshFxpStatusPacket{ID: 1}
 	table := []struct {
 		err error
 		fx  fxerr
@@ -22,7 +21,7 @@ func TestErrFxCode(t *testing.T) {
 		{err: io.EOF, fx: ErrSSHFxEOF},
 	}
 	for _, tt := range table {
-		statusErr := statusFromError(ider, tt.err).StatusError
+		statusErr := statusFromError(1, tt.err).StatusError
 		assert.Equal(t, statusErr.FxCode(), tt.fx)
 	}
 }


### PR DESCRIPTION
* `MarshalBinary` for packets must now include 4 empty bytes at the start for filling in the length of the packet.
* Packets may now implement `marshalPacket` that can return both the packet and payload as separate byte-slices, allowing the payload to be written separately without having to copy it into a separate marshaled packet slice first.
* rigorously define behavior of `chan result` in sending packets to the server to guarantee at-most-once delivery on each channel, meaning we can halve the space overhead from allocating a buffered channel (happens nearly every request).
* fix a write-read race condition in `request-server_test.go`
* fix a bunch of edge-cases in `client_integration_test.go` that were causing integration tests to lock up, be flaky or just not work.
* implement `WriterAt`
* new concurrency model of Map→Worker→Reduce for better high-latency concurrency in: `ReadAt`, `WriteAt`, `ReadFrom`.
* if a `ReadAt` or `WriteAt` can be done in one request, short-circuit concurrency and just do the request straight
* try and guess if a `ReadFrom` can be done in one request, and short-circuit to a synchronous loop (this is to be absolutely sure the `io.Reader` is read to `io.EOF`, even though it’s strongly likely that it will only ever run one loop.)
* TODO: currently pondering how best to do `WriteTo` efficiently with the Map→Worker→Reduce paradigm. For sure though, it won’t end up as similar as the other three are to each other.