### PR TITLE
client fix potential crash if we receive a short packet

### DIFF
--- a/client.go
+++ b/client.go
@@ -273,7 +273,10 @@ func (c *Client) recvVersion() error {
 		return &unexpectedPacketErr{sshFxpVersion, typ}
 	}
 
-	version, data := unmarshalUint32(data)
+	version, data, err := unmarshalUint32Safe(data)
+	if err != nil {
+		return err
+	}
 	if version != sftpProtocolVersion {
 		return &unexpectedVersionErr{sftpProtocolVersion, version}
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -228,3 +228,14 @@ func TestClientZeroLengthPacket(t *testing.T) {
 		c.Close()
 	}
 }
+
+func TestClientShortPacket(t *testing.T) {
+	// init packet too short.
+	packet := []byte{0, 0, 0, 1, 2}
+
+	r := bytes.NewReader(packet)
+	_, err := NewClientPipe(r, &sink{})
+	if !errors.Is(err, errShortPacket) {
+		t.Fatalf("expected error: %v, got: %v", errShortPacket, err)
+	}
+}


### PR DESCRIPTION
This was discovered using  continuous fuzzing, see [here](https://github.com/google/oss-fuzz/pull/5324)