### PR TITLE
Support os.Mode{Setuid,Setgid,Sticky} in Chmod

### DIFF
--- a/stat_plan9.go
+++ b/stat_plan9.go
@@ -94,3 +94,11 @@ func fromFileMode(mode os.FileMode) uint32 {
 
 	return ret
 }
+
+// Plan 9 doesn't have setuid, setgid or sticky, but a Plan 9 client should
+// be able to send these bits to a POSIX server.
+const (
+	s_ISUID = 04000
+	s_ISGID = 02000
+	S_ISVTX = 01000
+)

--- a/stat_posix.go
+++ b/stat_posix.go
@@ -114,3 +114,9 @@ func fromFileMode(mode os.FileMode) uint32 {
 
 	return ret
 }
+
+const (
+	s_ISUID = syscall.S_ISUID
+	s_ISGID = syscall.S_ISGID
+	s_ISVTX = syscall.S_ISVTX
+)


### PR DESCRIPTION
Previously, these bits were ignored by Chmod, which sent the numerical value of the mode argument as-is to the server. As a result, callers had to supply POSIX values for setuid, setgid and sticky to Chmod.

The new version supports both the POSIX values and the Go values, at the expense of some code duplication.

Also added a note to the docs to clarify that the umask is not subtracted from the mode, and why that is. The only portable way to get the umask is to set it, then reset it, but that's racy. On Linux, we could parse /proc/self/status, but that doesn't work portably and will fail where /proc is not available (some Docker containers, notably). Ref #335.