### PR TITLE
A simpler bytes buffer pool

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,29 @@
+package sftp
+
+type bufPool struct {
+	ch   chan []byte
+	blen int
+}
+
+func newBufPool(depth, bufLen int) *bufPool {
+	return &bufPool{
+		ch:   make(chan []byte, depth),
+		blen: bufLen,
+	}
+}
+
+func (p *bufPool) Get() []byte {
+	select {
+	case b := <-p.ch:
+		return b
+	default:
+		return make([]byte, p.blen)
+	}
+}
+
+func (p *bufPool) Put(b []byte) {
+	select {
+	case p.ch <- b:
+	default:
+	}
+}


### PR DESCRIPTION
Building on https://github.com/pkg/sftp/pull/415 I did a bit of poking. I found:
* Using this `sync.Pool` of `[]byte` buffers was causing _more_ allocations than just allocating all new buffers every time.
* We don’t really need the whole overhead of a `sync.Pool` at all, especially since this is not long-lived.
* Using a more-drop-in compatible `bufPool` means very little code change necessary to the `client.go` code.
* This less code change is better because now `readFromConcurrent` can easily be fixed to use the less-overhead version as well.