### PR TITLE
Fix panic when connection dropped in the middle of the sid

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -84,7 +84,10 @@ func (c *clientConn) recv() error {
 		if err != nil {
 			return err
 		}
-		sid, _ := unmarshalUint32(data)
+		sid, _, err := unmarshalUint32Safe(data)
+		if err != nil {
+			return err
+		}
 
 		ch, ok := c.getChannel(sid)
 		if !ok {


### PR DESCRIPTION
Fixes #418. Includes a unit test that exhibits the panic.

Q: is errors.Is(err, ErrSSHFxConnectionLost) the right check in the test?