### PR TITLE
Improve benchmarks and errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ server_standalone/server_standalone
 
 examples/*/id_rsa
 examples/*/id_rsa.pub
+
+memprofile.out
+memprofile.svg

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,8 @@ COUNT ?= 1
 BENCHMARK_PATTERN ?= "."
 
 benchmark:
-	go test -integration -run=NONE -bench=$(BENCHMARK_PATTERN) -benchmem -memprofile memprofile.out -count=$(COUNT)
+	go test -integration -run=NONE -bench=$(BENCHMARK_PATTERN) -benchmem -count=$(COUNT)
+
+benchmark_w_memprofile:
+	go test -integration -run=NONE -bench=$(BENCHMARK_PATTERN) -benchmem -count=$(COUNT) -memprofile memprofile.out
 	go tool pprof -svg -output=memprofile.svg memprofile.out

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: integration integration_w_race benchmark
+
 integration:
 	go test -integration -v ./...
 	go test -testserver -v ./...
@@ -14,4 +16,9 @@ integration_w_race:
 	go test -race -testserver -allocator -v ./...
 	go test -race -integration -allocator -testserver -v ./...
 
+COUNT ?= 1
+BENCHMARK_PATTERN ?= "."
 
+benchmark:
+	go test -integration -run=NONE -bench=$(BENCHMARK_PATTERN) -benchmem -memprofile memprofile.out -count=$(COUNT)
+	go tool pprof -svg -output=memprofile.svg memprofile.out

--- a/client.go
+++ b/client.go
@@ -43,10 +43,10 @@ type ClientOption func(*Client) error
 func MaxPacketChecked(size int) ClientOption {
 	return func(c *Client) error {
 		if size < 1 {
-			return errors.Errorf("size must be greater or equal to 1")
+			return errors.New("size must be greater or equal to 1")
 		}
 		if size > 32768 {
-			return errors.Errorf("sizes larger than 32KB might not work with all servers")
+			return errors.New("sizes larger than 32KB might not work with all servers")
 		}
 		c.maxPacket = size
 		return nil
@@ -65,7 +65,7 @@ func MaxPacketChecked(size int) ClientOption {
 func MaxPacketUnchecked(size int) ClientOption {
 	return func(c *Client) error {
 		if size < 1 {
-			return errors.Errorf("size must be greater or equal to 1")
+			return errors.New("size must be greater or equal to 1")
 		}
 		c.maxPacket = size
 		return nil
@@ -90,7 +90,7 @@ func MaxPacket(size int) ClientOption {
 func MaxConcurrentRequestsPerFile(n int) ClientOption {
 	return func(c *Client) error {
 		if n < 1 {
-			return errors.Errorf("n must be greater or equal to 1")
+			return errors.New("n must be greater or equal to 1")
 		}
 		c.maxConcurrentRequests = n
 		return nil

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -1569,7 +1569,7 @@ func clientWriteDeadlock(t *testing.T, N int, badfunc func(*File)) {
 
 // Read/WriteTo has this issue as well
 func TestClientReadDeadlock(t *testing.T) {
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 3; i++ {
 		clientReadDeadlock(t, i, func(f *File) {
 			b := make([]byte, 32768*4)
 
@@ -1582,7 +1582,7 @@ func TestClientReadDeadlock(t *testing.T) {
 }
 
 func TestClientWriteToDeadlock(t *testing.T) {
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 3; i++ {
 		clientReadDeadlock(t, i, func(f *File) {
 			b := make([]byte, 32768*4)
 
@@ -2495,12 +2495,12 @@ func benchmarkWriteTo(b *testing.B, bufsize int, delay time.Duration) {
 	f.Write(data)
 	f.Close()
 
-	b.ResetTimer()
-	b.SetBytes(int64(size))
-
 	buf := &writeToBuffer{
 		b: make([]byte, 0, size),
 	}
+
+	b.ResetTimer()
+	b.SetBytes(int64(size))
 
 	for i := 0; i < b.N; i++ {
 		buf.Reset()

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -2473,7 +2473,7 @@ func benchmarkWriteTo(b *testing.B, bufsize int, delay time.Duration) {
 	f.Write(data)
 	f.Close()
 
-	buf := new(bytes.Buffer)
+	buf := bytes.NewBuffer(make([]byte, 0, size))
 
 	b.ResetTimer()
 	b.SetBytes(int64(size))

--- a/conn.go
+++ b/conn.go
@@ -16,8 +16,6 @@ type conn struct {
 	// this is the same allocator used in packet manager
 	alloc      *allocator
 	sync.Mutex // used to serialise writes to sendPacket
-	// sendPacketTest is needed to replicate packet issues in testing
-	sendPacketTest func(w io.Writer, m encoding.BinaryMarshaler) error
 }
 
 // the orderID is used in server mode if the allocator is enabled.
@@ -29,9 +27,7 @@ func (c *conn) recvPacket(orderID uint32) (uint8, []byte, error) {
 func (c *conn) sendPacket(m encoding.BinaryMarshaler) error {
 	c.Lock()
 	defer c.Unlock()
-	if c.sendPacketTest != nil {
-		return c.sendPacketTest(c, m)
-	}
+
 	return sendPacket(c, m)
 }
 
@@ -91,7 +87,7 @@ func (c *clientConn) recv() error {
 			// This is an unexpected occurrence. Send the error
 			// back to all listeners so that they terminate
 			// gracefully.
-			return errors.Errorf("sid not found: %v", sid)
+			return errors.Errorf("sid not found: %d", sid)
 		}
 
 		ch <- result{typ: typ, data: data}

--- a/example_test.go
+++ b/example_test.go
@@ -131,7 +131,7 @@ func ExampleClient_Mkdir_parents() {
 					fi, err = client.Stat(parents)
 					if err == nil {
 						if !fi.IsDir() {
-							return fmt.Errorf("File exists: %s", parents)
+							return fmt.Errorf("file exists: %s", parents)
 						}
 					}
 				}

--- a/go.sum
+++ b/go.sum
@@ -15,9 +15,12 @@ golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/packet.go
+++ b/packet.go
@@ -133,7 +133,7 @@ func marshalPacket(m encoding.BinaryMarshaler) (header, payload []byte, err erro
 func sendPacket(w io.Writer, m encoding.BinaryMarshaler) error {
 	header, payload, err := marshalPacket(m)
 	if err != nil {
-		return errors.Errorf("binary marshaller failed: %v", err)
+		return errors.Wrap(err, "binary marshaller failed")
 	}
 
 	length := len(header) + len(payload) - 4 // subtract the uint32(length) from the start
@@ -146,12 +146,12 @@ func sendPacket(w io.Writer, m encoding.BinaryMarshaler) error {
 	binary.BigEndian.PutUint32(header[:4], uint32(length))
 
 	if _, err := w.Write(header); err != nil {
-		return errors.Errorf("failed to send packet: %v", err)
+		return errors.Wrap(err, "failed to send packet")
 	}
 
 	if len(payload) > 0 {
 		if _, err := w.Write(payload); err != nil {
-			return errors.Errorf("failed to send packet payload: %v", err)
+			return errors.Wrap(err, "failed to send packet payload")
 		}
 	}
 

--- a/packet_test.go
+++ b/packet_test.go
@@ -217,14 +217,6 @@ func TestUnmarshalString(t *testing.T) {
 	}
 }
 
-type nopCloserBuffer struct {
-	bytes.Buffer
-}
-
-func (*nopCloserBuffer) Close() error {
-	return nil
-}
-
 func TestSendPacket(t *testing.T) {
 	var tests = []struct {
 		packet encoding.BinaryMarshaler
@@ -349,6 +341,12 @@ func TestRecvPacket(t *testing.T) {
 			},
 			wantErr: errShortPacket,
 		},
+		{
+			b: []byte{
+				0xff, 0xff, 0xff, 0xff,
+			},
+			wantErr: errLongPacket,
+		},
 	}
 
 	for _, tt := range recvPacketTests {
@@ -460,6 +458,8 @@ func TestSSHFxpOpenPackethasPflags(t *testing.T) {
 }
 
 func benchMarshal(b *testing.B, packet encoding.BinaryMarshaler) {
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		sendPacket(ioutil.Discard, packet)
 	}

--- a/sftp.go
+++ b/sftp.go
@@ -239,7 +239,7 @@ func getSupportedExtensionByName(extensionName string) (sshExtensionPair, error)
 			return supportedExtension, nil
 		}
 	}
-	return sshExtensionPair{}, fmt.Errorf("unsupported extension: %s", extensionName)
+	return sshExtensionPair{}, errors.Errorf("unsupported extension: %s", extensionName)
 }
 
 // SetSFTPExtensions allows to customize the supported server extensions.

--- a/sftp.go
+++ b/sftp.go
@@ -200,15 +200,15 @@ func unimplementedPacketErr(u uint8) error {
 type unexpectedIDErr struct{ want, got uint32 }
 
 func (u *unexpectedIDErr) Error() string {
-	return fmt.Sprintf("sftp: unexpected id: want %v, got %v", u.want, u.got)
+	return fmt.Sprintf("sftp: unexpected id: want %d, got %d", u.want, u.got)
 }
 
 func unimplementedSeekWhence(whence int) error {
-	return errors.Errorf("sftp: unimplemented seek whence %v", whence)
+	return errors.Errorf("sftp: unimplemented seek whence %d", whence)
 }
 
 func unexpectedCount(want, got uint32) error {
-	return errors.Errorf("sftp: unexpected count: want %v, got %v", want, got)
+	return errors.Errorf("sftp: unexpected count: want %d, got %d", want, got)
 }
 
 type unexpectedVersionErr struct{ want, got uint32 }
@@ -239,7 +239,7 @@ func getSupportedExtensionByName(extensionName string) (sshExtensionPair, error)
 			return supportedExtension, nil
 		}
 	}
-	return sshExtensionPair{}, fmt.Errorf("Unsupported extension: %v", extensionName)
+	return sshExtensionPair{}, fmt.Errorf("unsupported extension: %s", extensionName)
 }
 
 // SetSFTPExtensions allows to customize the supported server extensions.


### PR DESCRIPTION
Ahead of some other improvements, I wanted to narrow the benchmarks to only relevant code, and this allow necessitated fixing some tests to go along with it.

Fixes:
* `errors.Errorf("constant string")` have been replaced with `errors.New("constant string")`
* `errors.Errorf("constant string: %v", err)` have been replaced with `errors.Wrap(err, "constant string")`
* `sftp.clientConn.conn.sendPacketTest` has been replaced with a `timeBombWriter`, this removes unnecessary test code from `conn`
* all `err != errFakeNet` have been replaced with `!errors.Is(err, errFakeNet)`, this works because we are now properly wrapping errors.
* Error messages starting with a capital letter have been fixed to use a lower-case character.
* `%v` formatting codes that can be more type-safe have been made to be more type specific.
* errors from `runSftpClient`’s `cmd.Wait` have been put into  an `execErr` type that wraps the underlying error.

`packet_test.go` has a lot of changes:
* test tables have been moved into their individual functions, rather than globals
* more marshaling and unmarshaling tests have been added to verify full byte ordering
* where a byte value in a byte-slice is semantically an ASCII character, use `'c'` to make the value clear.
* marshal/unmarshal string can contain NUL bytes, which can always be a sticky point, so add some tests for that
* byte-slices that are marshaled output have semantic line-breaks on each field to make the semantics of the binary data clearer
* `TestRecvPacket` now tests a the short-packet behavior, and the long-packet behavior.
* benchmarks on marshaling now marshal to `ioutil.Discard` as we do not want to benchmark `bytes.Buffer`, we want to benchmark our marshaling code.