### PR TITLE
[Bugfix] WriteTo write work channel should never be closed…

### DIFF
--- a/client.go
+++ b/client.go
@@ -1284,7 +1284,7 @@ func (f *File) WriteTo(w io.Writer) (written int64, err error) {
 	for {
 		packet, ok := <-cur
 		if !ok {
-			return written, nil
+			return written, errors.New("sftp.File.WriteTo: unexpectedly closed channel")
 		}
 
 		// Because writes are serialized, this will always be the last successfully read byte.


### PR DESCRIPTION
An earlier draft of this had the channel close signal a valid EOF, but since, the code has changed so that this closed channel read should never happen. As such, if it does, we should be returning an `err != nil` not an `EOF`.