### PR TITLE
Guard against accidental io.EOFs

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -142,6 +142,13 @@ func (c *clientConn) sendPacket(ch chan result, p idmarshaler) (byte, []byte, er
 
 	c.dispatchRequest(ch, p)
 	s := <-ch
+
+	if errors.Is(s.err, io.EOF) {
+		// This function should never return io.EOF.
+		// Proper client EOFs are always from SSH_FX_EOF packets.
+		return s.typ, s.data, ErrSSHFxConnectionLost
+	}
+
 	return s.typ, s.data, s.err
 }
 


### PR DESCRIPTION
There are a number of situations where we should really be able to _know_ that the code path doesn’t contain an `io.EOF`. As a precaution, we put a guard statement in each of these paths that should prevent an unintentional `io.EOF` from falling through.

Instead, we return `ErrSSHFxConnectionLost` instead. I’m not sure this is precisely the correct return value we want to use instead of an `io.EOF`, but I cannot think of what other kind of an error we should return.