### PR TITLE
bugfix: int64 math overflows possible on 32-bit architectures

### DIFF
--- a/client.go
+++ b/client.go
@@ -1058,7 +1058,7 @@ func (f *File) ReadAt(b []byte, off int64) (int, error) {
 	errCh := make(chan rErr)
 
 	concurrency := len(b)/f.c.maxPacket + 1
-	if concurrency > f.c.maxConcurrentRequests {
+	if concurrency > f.c.maxConcurrentRequests || concurrency < 1 {
 		concurrency = f.c.maxConcurrentRequests
 	}
 
@@ -1181,7 +1181,7 @@ func (f *File) WriteTo(w io.Writer) (written int64, err error) {
 	}
 
 	concurrency := int(fileSize/uint64(f.c.maxPacket) + 1) // a bad guess, but better than no guess
-	if concurrency > f.c.maxConcurrentRequests {
+	if concurrency > f.c.maxConcurrentRequests || concurrency < 1 {
 		concurrency = f.c.maxConcurrentRequests
 	}
 
@@ -1410,7 +1410,7 @@ func (f *File) writeAtConcurrent(b []byte, off int64) (int, error) {
 	errCh := make(chan wErr)
 
 	concurrency := len(b)/f.c.maxPacket + 1
-	if concurrency > f.c.maxConcurrentRequests {
+	if concurrency > f.c.maxConcurrentRequests || concurrency < 1 {
 		concurrency = f.c.maxConcurrentRequests
 	}
 
@@ -1520,7 +1520,7 @@ func (f *File) readFromConcurrent(r io.Reader, remain int64) (read int64, err er
 	errCh := make(chan rwErr)
 
 	concurrency := int(remain/int64(f.c.maxPacket) + 1) // a bad guess, but better than no guess
-	if concurrency > f.c.maxConcurrentRequests {
+	if concurrency > f.c.maxConcurrentRequests || concurrency < 1 {
 		concurrency = f.c.maxConcurrentRequests
 	}
 
@@ -1648,6 +1648,10 @@ func (f *File) ReadFrom(r io.Reader) (int64, error) {
 			if err == nil {
 				remain = info.Size()
 			}
+		}
+
+		if remain < 0 {
+			remain = math.MaxInt64
 		}
 
 		if remain > int64(f.c.maxPacket) {

--- a/client.go
+++ b/client.go
@@ -1180,10 +1180,11 @@ func (f *File) WriteTo(w io.Writer) (written int64, err error) {
 		return f.writeToSequential(w)
 	}
 
-	concurrency := int(fileSize/uint64(f.c.maxPacket) + 1) // a bad guess, but better than no guess
-	if concurrency > f.c.maxConcurrentRequests || concurrency < 1 {
-		concurrency = f.c.maxConcurrentRequests
+	concurrency64 := fileSize/uint64(f.c.maxPacket) + 1 // a bad guess, but better than no guess
+	if concurrency64 > uint64(f.c.maxConcurrentRequests) || concurrency64 < 1 {
+		concurrency64 = uint64(f.c.maxConcurrentRequests)
 	}
+	concurrency := int(concurrency64)
 
 	cancel := make(chan struct{})
 	var wg sync.WaitGroup
@@ -1519,10 +1520,11 @@ func (f *File) readFromConcurrent(r io.Reader, remain int64) (read int64, err er
 	}
 	errCh := make(chan rwErr)
 
-	concurrency := int(remain/int64(f.c.maxPacket) + 1) // a bad guess, but better than no guess
-	if concurrency > f.c.maxConcurrentRequests || concurrency < 1 {
-		concurrency = f.c.maxConcurrentRequests
+	concurrency64 := remain/int64(f.c.maxPacket) + 1 // a bad guess, but better than no guess
+	if concurrency64 > int64(f.c.maxConcurrentRequests) || concurrency64 < 1 {
+		concurrency64 = int64(f.c.maxConcurrentRequests)
 	}
+	concurrency := int(concurrency64)
 
 	pool := newBufPool(concurrency, f.c.maxPacket)
 

--- a/client.go
+++ b/client.go
@@ -1184,6 +1184,7 @@ func (f *File) WriteTo(w io.Writer) (written int64, err error) {
 	if concurrency64 > uint64(f.c.maxConcurrentRequests) || concurrency64 < 1 {
 		concurrency64 = uint64(f.c.maxConcurrentRequests)
 	}
+	// Now that concurrency64 is saturated to an int value, we know this assignment cannot possibly overflow.
 	concurrency := int(concurrency64)
 
 	cancel := make(chan struct{})
@@ -1524,6 +1525,7 @@ func (f *File) readFromConcurrent(r io.Reader, remain int64) (read int64, err er
 	if concurrency64 > int64(f.c.maxConcurrentRequests) || concurrency64 < 1 {
 		concurrency64 = int64(f.c.maxConcurrentRequests)
 	}
+	// Now that concurrency64 is saturated to an int value, we know this assignment cannot possibly overflow.
 	concurrency := int(concurrency64)
 
 	pool := newBufPool(concurrency, f.c.maxPacket)


### PR DESCRIPTION
Investigating #433 I tracked it down to a situation where an overflow in 32-bit architectures can result in a calculation of `concurrency = 0`. With zero concurrency… the `wg.Wait()` returns immediately and no work is done.

The solution is to check if concurrency is less than one, and if it is, then use max concurrency, as we overflowed an int32, so it should use max concurrency.