### PR TITLE
[bugfix] Sequentially issue read requests, process results concurrently

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -1,5 +1,7 @@
 package sftp
 
+// bufPool provides a pool of byte-slices to be reused in various parts of the package.
+// It is safe to use concurrently through a pointer.
 type bufPool struct {
 	ch   chan []byte
 	blen int
@@ -13,17 +15,66 @@ func newBufPool(depth, bufLen int) *bufPool {
 }
 
 func (p *bufPool) Get() []byte {
-	select {
-	case b := <-p.ch:
-		return b
-	default:
+	if p == nil {
+		// functional default: no reuse.
 		return make([]byte, p.blen)
+	}
+
+	for {
+		select {
+		case b := <-p.ch:
+			if cap(b) < p.blen {
+				// just in case: throw away any buffer with insufficient capacity.
+				continue
+			}
+
+			return b[:p.blen]
+
+		default:
+			return make([]byte, p.blen)
+		}
 	}
 }
 
 func (p *bufPool) Put(b []byte) {
+	if p == nil {
+		// functional default: no reuse.
+		return
+	}
+
+	if cap(b) < p.blen || cap(b) > p.blen*2 {
+		// DO NOT reuse buffers with insufficient capacity.
+		// This could cause panics when resizing to p.blen.
+
+		// DO NOT reuse buffers with excessive capacity.
+		// This could cause memory leaks.
+		return
+	}
+
 	select {
 	case p.ch <- b:
+	default:
+	}
+}
+
+type resChanPool chan chan result
+
+func newResChanPool(depth int) resChanPool {
+	return make(chan chan result, depth)
+}
+
+func (p resChanPool) Get() chan result {
+	select {
+	case ch := <-p:
+		return ch
+	default:
+		return make(chan result, 1)
+	}
+}
+
+func (p resChanPool) Put(ch chan result) {
+	select {
+	case p <- ch:
 	default:
 	}
 }

--- a/stat_plan9.go
+++ b/stat_plan9.go
@@ -41,6 +41,11 @@ func translateSyscallError(err error) (uint32, bool) {
 	return 0, false
 }
 
+// isRegular returns true if the mode describes a regular file.
+func isRegular(mode uint32) bool {
+	return mode&S_IFMT == syscall.S_IFREG
+}
+
 // toFileMode converts sftp filemode bits to the os.FileMode specification
 func toFileMode(mode uint32) os.FileMode {
 	var fm = os.FileMode(mode & 0777)

--- a/stat_posix.go
+++ b/stat_posix.go
@@ -43,6 +43,11 @@ func translateSyscallError(err error) (uint32, bool) {
 	return 0, false
 }
 
+// isRegular returns true if the mode describes a regular file.
+func isRegular(mode uint32) bool {
+	return mode&S_IFMT == syscall.S_IFREG
+}
+
 // toFileMode converts sftp filemode bits to the os.FileMode specification
 func toFileMode(mode uint32) os.FileMode {
 	var fm = os.FileMode(mode & 0777)


### PR DESCRIPTION
Originally, it was assumed that we could issue read requests in any arbitrary order, and it would execute the same way. This holds for many cases, but fails for cases where the server might reset the file once an `io.EOF` has been sent back to the client.

So, this takes care to issue requests sequentially, and then handle the results as the results come back. There is a bit of a change as well, since we can no longer just read in a chunk until it is completely read, we are stuck having to assume that each chunk read will be read to completion, exclusive from returning a short read and an EOF at the following read. This is only guaranteed per the standard for a regular file. Fortunately, we’re already stating the remote file to get the file length, so we just additionally check the permissions to make sure it’s a regular file.

I brought in the `pool.go` changes from the `filexfer` implementation PR, so that I have `resChanPool` as this was useful for this PR.