### PR TITLE
request server: add an optional RealpathFileLister interface

### DIFF
--- a/request-example.go
+++ b/request-example.go
@@ -469,7 +469,7 @@ func (fs *root) Realpath(p string) string {
 	if fs.startDirectory == "" || fs.startDirectory == "/" {
 		return cleanPath(p)
 	}
-	return cleanPathWithBase(p, fs.startDirectory)
+	return cleanPathWithBase(fs.startDirectory, p)
 }
 
 // In memory file-system-y thing that the Hanlders live on

--- a/request-example.go
+++ b/request-example.go
@@ -464,10 +464,19 @@ func (fs *root) Lstat(r *Request) (ListerAt, error) {
 	return listerat{file}, nil
 }
 
+// implements RealpathFileLister interface
+func (fs *root) Realpath(p string) string {
+	if fs.startDirectory == "" || fs.startDirectory == "/" {
+		return cleanPath(p)
+	}
+	return cleanPathWithBase(p, fs.startDirectory)
+}
+
 // In memory file-system-y thing that the Hanlders live on
 type root struct {
-	rootFile *memFile
-	mockErr  error
+	rootFile       *memFile
+	mockErr        error
+	startDirectory string
 
 	mu    sync.Mutex
 	files map[string]*memFile

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -86,13 +86,13 @@ type LstatFileLister interface {
 	Lstat(*Request) (ListerAt, error)
 }
 
-// RealpathFileLister is a FileLister that implements the Realpath method.
+// RealPathFileLister is a FileLister that implements the Realpath method.
 // We use "/" as start directory for relative paths, implementing this
 // interface you can customize the start directory.
 // You have to return an absolute POSIX path.
-type RealpathFileLister interface {
+type RealPathFileLister interface {
 	FileLister
-	Realpath(string) string
+	RealPath(string) string
 }
 
 // ListerAt does for file lists what io.ReaderAt does for files.

--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -86,6 +86,15 @@ type LstatFileLister interface {
 	Lstat(*Request) (ListerAt, error)
 }
 
+// RealpathFileLister is a FileLister that implements the Realpath method.
+// We use "/" as start directory for relative paths, implementing this
+// interface you can customize the start directory.
+// You have to return an absolute POSIX path.
+type RealpathFileLister interface {
+	FileLister
+	Realpath(string) string
+}
+
 // ListerAt does for file lists what io.ReaderAt does for files.
 // ListAt should return the number of entries copied and an io.EOF
 // error if at end of list. This is testable by comparing how many you

--- a/request-server.go
+++ b/request-server.go
@@ -198,7 +198,13 @@ func (rs *RequestServer) packetWorker(
 			handle := pkt.getHandle()
 			rpkt = statusFromError(pkt.ID, rs.closeRequest(handle))
 		case *sshFxpRealpathPacket:
-			rpkt = cleanPacketPath(pkt)
+			var realPath string
+			if realPather, ok := rs.Handlers.FileList.(RealpathFileLister); ok {
+				realPath = realPather.Realpath(pkt.getPath())
+			} else {
+				realPath = cleanPath(pkt.getPath())
+			}
+			rpkt = cleanPacketPath(pkt, realPath)
 		case *sshFxpOpendirPacket:
 			request := requestFromPacket(ctx, pkt)
 			handle := rs.nextRequest(request)
@@ -263,14 +269,13 @@ func (rs *RequestServer) packetWorker(
 }
 
 // clean and return name packet for file
-func cleanPacketPath(pkt *sshFxpRealpathPacket) responsePacket {
-	path := cleanPath(pkt.getPath())
+func cleanPacketPath(pkt *sshFxpRealpathPacket, realPath string) responsePacket {
 	return &sshFxpNamePacket{
 		ID: pkt.id(),
 		NameAttrs: []*sshFxpNameAttr{
 			{
-				Name:     path,
-				LongName: path,
+				Name:     realPath,
+				LongName: realPath,
 				Attrs:    emptyFileStat,
 			},
 		},
@@ -279,9 +284,13 @@ func cleanPacketPath(pkt *sshFxpRealpathPacket) responsePacket {
 
 // Makes sure we have a clean POSIX (/) absolute path to work with
 func cleanPath(p string) string {
+	return cleanPathWithBase(p, "/")
+}
+
+func cleanPathWithBase(p, base string) string {
 	p = filepath.ToSlash(p)
 	if !path.IsAbs(p) {
-		p = "/" + p
+		return path.Join(base, p)
 	}
 	return path.Clean(p)
 }

--- a/request-server.go
+++ b/request-server.go
@@ -199,8 +199,8 @@ func (rs *RequestServer) packetWorker(
 			rpkt = statusFromError(pkt.ID, rs.closeRequest(handle))
 		case *sshFxpRealpathPacket:
 			var realPath string
-			if realPather, ok := rs.Handlers.FileList.(RealpathFileLister); ok {
-				realPath = realPather.Realpath(pkt.getPath())
+			if realPather, ok := rs.Handlers.FileList.(RealPathFileLister); ok {
+				realPath = realPather.RealPath(pkt.getPath())
 			} else {
 				realPath = cleanPath(pkt.getPath())
 			}
@@ -284,10 +284,10 @@ func cleanPacketPath(pkt *sshFxpRealpathPacket, realPath string) responsePacket 
 
 // Makes sure we have a clean POSIX (/) absolute path to work with
 func cleanPath(p string) string {
-	return cleanPathWithBase(p, "/")
+	return cleanPathWithBase("/", p)
 }
 
-func cleanPathWithBase(p, base string) string {
+func cleanPathWithBase(base, p string) string {
 	p = filepath.ToSlash(p)
 	if !path.IsAbs(p) {
 		return path.Join(base, p)

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"runtime"
 	"testing"
 	"time"
@@ -805,6 +806,25 @@ func TestUncleanDisconnect(t *testing.T) {
 	err = <-p.svrResult
 	require.EqualError(t, err, io.ErrUnexpectedEOF.Error())
 	checkRequestServerAllocator(t, p)
+}
+
+func TestRealPath(t *testing.T) {
+	root := &root{
+		rootFile:       &memFile{name: "/", modtime: time.Now(), isdir: true},
+		files:          make(map[string]*memFile),
+		startDirectory: "/apath",
+	}
+
+	p := root.Realpath(".")
+	require.Equal(t, root.startDirectory, p)
+	p = root.Realpath("/")
+	require.Equal(t, "/", p)
+	p = root.Realpath("..")
+	require.Equal(t, "/", p)
+	p = root.Realpath("../../..")
+	require.Equal(t, "/", p)
+	p = root.Realpath("relpath")
+	require.Equal(t, path.Join(root.startDirectory, "relpath"), p)
 }
 
 func TestCleanPath(t *testing.T) {

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -816,15 +816,15 @@ func TestRealPath(t *testing.T) {
 	}
 
 	p := root.Realpath(".")
-	require.Equal(t, root.startDirectory, p)
+	assert.Equal(t, root.startDirectory, p)
 	p = root.Realpath("/")
-	require.Equal(t, "/", p)
+	assert.Equal(t, "/", p)
 	p = root.Realpath("..")
-	require.Equal(t, "/", p)
+	assert.Equal(t, "/", p)
 	p = root.Realpath("../../..")
-	require.Equal(t, "/", p)
+	assert.Equal(t, "/", p)
 	p = root.Realpath("relpath")
-	require.Equal(t, path.Join(root.startDirectory, "relpath"), p)
+	assert.Equal(t, path.Join(root.startDirectory, "relpath"), p)
 }
 
 func TestCleanPath(t *testing.T) {


### PR DESCRIPTION
This allow to customize the responses for SSH_FXP_REALPATH requests
and so implementing features like a start directory.

I'm not sure if this is the best way to add this feature, maybe we could consider a server option too