### PR TITLE
Pre-Merge filexfer Bugfixes

### DIFF
--- a/internal/encoding/ssh/filexfer/attrs_test.go
+++ b/internal/encoding/ssh/filexfer/attrs_test.go
@@ -113,48 +113,50 @@ func TestAttributes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			attr.Flags = tt.flags
 
-			buf := new(Buffer)
-			attr.MarshalInto(buf)
+			buf, err := attr.MarshalBinary()
+			if err != nil {
+				t.Fatal("unexpected error:", err)
+			}
 
-			if got, want := buf.Bytes(), tt.encoded; !bytes.Equal(got, want) {
-				t.Fatalf("MarshalInto() = %X, but wanted %X", got, want)
+			if !bytes.Equal(buf, tt.encoded) {
+				t.Fatalf("MarshalBinary() = %X, but wanted %X", buf, tt.encoded)
 			}
 
 			attr = Attributes{}
 
-			if err := attr.UnmarshalFrom(buf); err != nil {
+			if err := attr.UnmarshalBinary(buf); err != nil {
 				t.Fatal("unexpected error:", err)
 			}
 
 			if attr.Flags != tt.flags {
-				t.Errorf("UnmarshalFrom(): Flags was %x, but wanted %x", attr.Flags, tt.flags)
+				t.Errorf("UnmarshalBinary(): Flags was %x, but wanted %x", attr.Flags, tt.flags)
 			}
 
 			if attr.Flags&AttrSize != 0 && attr.Size != size {
-				t.Errorf("UnmarshalFrom(): Size was %x, but wanted %x", attr.Size, size)
+				t.Errorf("UnmarshalBinary(): Size was %x, but wanted %x", attr.Size, size)
 			}
 
 			if attr.Flags&AttrUIDGID != 0 {
 				if attr.UID != uid {
-					t.Errorf("UnmarshalFrom(): UID was %x, but wanted %x", attr.UID, uid)
+					t.Errorf("UnmarshalBinary(): UID was %x, but wanted %x", attr.UID, uid)
 				}
 
 				if attr.GID != gid {
-					t.Errorf("UnmarshalFrom(): GID was %x, but wanted %x", attr.GID, gid)
+					t.Errorf("UnmarshalBinary(): GID was %x, but wanted %x", attr.GID, gid)
 				}
 			}
 
 			if attr.Flags&AttrPermissions != 0 && attr.Permissions != perms {
-				t.Errorf("UnmarshalFrom(): Permissions was %#v, but wanted %#v", attr.Permissions, perms)
+				t.Errorf("UnmarshalBinary(): Permissions was %#v, but wanted %#v", attr.Permissions, perms)
 			}
 
 			if attr.Flags&AttrACModTime != 0 {
 				if attr.ATime != atime {
-					t.Errorf("UnmarshalFrom(): ATime was %x, but wanted %x", attr.ATime, atime)
+					t.Errorf("UnmarshalBinary(): ATime was %x, but wanted %x", attr.ATime, atime)
 				}
 
 				if attr.MTime != mtime {
-					t.Errorf("UnmarshalFrom(): MTime was %x, but wanted %x", attr.MTime, mtime)
+					t.Errorf("UnmarshalBinary(): MTime was %x, but wanted %x", attr.MTime, mtime)
 				}
 			}
 
@@ -162,11 +164,11 @@ func TestAttributes(t *testing.T) {
 				extAttrs := attr.ExtendedAttributes
 
 				if count := len(extAttrs); count != 1 {
-					t.Fatalf("UnmarshalFrom(): len(ExtendedAttributes) was %d, but wanted %d", count, 1)
+					t.Fatalf("UnmarshalBinary(): len(ExtendedAttributes) was %d, but wanted %d", count, 1)
 				}
 
 				if got := extAttrs[0]; got != extAttr {
-					t.Errorf("UnmarshalFrom(): ExtendedAttributes[0] was %#v, but wanted %#v", got, extAttr)
+					t.Errorf("UnmarshalBinary(): ExtendedAttributes[0] was %#v, but wanted %#v", got, extAttr)
 				}
 			}
 		})
@@ -189,8 +191,10 @@ func TestNameEntry(t *testing.T) {
 		},
 	}
 
-	buf := new(Buffer)
-	e.MarshalInto(buf)
+	buf, err := e.MarshalBinary()
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
 
 	want := []byte{
 		0x00, 0x00, 0x00, 0x03, 'f', 'o', 'o',
@@ -199,13 +203,13 @@ func TestNameEntry(t *testing.T) {
 		0x87, 0x65, 0x43, 0x21,
 	}
 
-	if got := buf.Bytes(); !bytes.Equal(got, want) {
-		t.Fatalf("MarshalInto() = %X, but wanted %X", got, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalBinary() = %X, but wanted %X", buf, want)
 	}
 
 	*e = NameEntry{}
 
-	if err := e.UnmarshalFrom(buf); err != nil {
+	if err := e.UnmarshalBinary(buf); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 

--- a/internal/encoding/ssh/filexfer/extended_packets.go
+++ b/internal/encoding/ssh/filexfer/extended_packets.go
@@ -51,6 +51,11 @@ type ExtendedPacket struct {
 	Data ExtendedData
 }
 
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *ExtendedPacket) Type() PacketType {
+	return PacketTypeExtended
+}
+
 // MarshalPacket returns p as a two-part binary encoding of p.
 //
 // The Data is marshaled into binary, and returned as the payload.
@@ -95,6 +100,11 @@ func (p *ExtendedPacket) UnmarshalPacketBody(buf *Buffer) (err error) {
 // ExtendedReplyPacket defines the SSH_FXP_CLOSE packet.
 type ExtendedReplyPacket struct {
 	Data ExtendedData
+}
+
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *ExtendedReplyPacket) Type() PacketType {
+	return PacketTypeExtendedReply
 }
 
 // MarshalPacket returns p as a two-part binary encoding of p.

--- a/internal/encoding/ssh/filexfer/extended_packets_test.go
+++ b/internal/encoding/ssh/filexfer/extended_packets_test.go
@@ -42,7 +42,7 @@ func TestExtendedPacketNoData(t *testing.T) {
 		ExtendedRequest: extendedRequest,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -54,14 +54,14 @@ func TestExtendedPacketNoData(t *testing.T) {
 		0x00, 0x00, 0x00, 11, 'f', 'o', 'o', '@', 'e', 'x', 'a', 'm', 'p', 'l', 'e',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = ExtendedPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -86,7 +86,7 @@ func TestExtendedPacketTestData(t *testing.T) {
 		},
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -99,8 +99,8 @@ func TestExtendedPacketTestData(t *testing.T) {
 		0x27,
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = ExtendedPacket{
@@ -108,7 +108,7 @@ func TestExtendedPacketTestData(t *testing.T) {
 	}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -116,17 +116,17 @@ func TestExtendedPacketTestData(t *testing.T) {
 		t.Errorf("UnmarshalPacketBody(): ExtendedRequest was %q, but expected %q", p.ExtendedRequest, extendedRequest)
 	}
 
-	if data, ok := p.Data.(*testExtendedData); !ok {
-		t.Errorf("UnmarshalPacketBody(): Data was type %T, but expected %T", p.Data, data)
+	if buf, ok := p.Data.(*testExtendedData); !ok {
+		t.Errorf("UnmarshalPacketBody(): Data was type %T, but expected %T", p.Data, buf)
 
-	} else if data.value != value {
-		t.Errorf("UnmarshalPacketBody(): Data.value was %#x, but expected %#x", data.value, value)
+	} else if buf.value != value {
+		t.Errorf("UnmarshalPacketBody(): Data.value was %#x, but expected %#x", buf.value, value)
 	}
 
 	*p = ExtendedPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -136,11 +136,11 @@ func TestExtendedPacketTestData(t *testing.T) {
 
 	wantBuffer := []byte{0x27}
 
-	if data, ok := p.Data.(*Buffer); !ok {
-		t.Errorf("UnmarshalPacketBody(): Data was type %T, but expected %T", p.Data, data)
+	if buf, ok := p.Data.(*Buffer); !ok {
+		t.Errorf("UnmarshalPacketBody(): Data was type %T, but expected %T", p.Data, buf)
 
-	} else if !bytes.Equal(data.b, wantBuffer) {
-		t.Errorf("UnmarshalPacketBody(): Data was %X, but expected %X", data.b, wantBuffer)
+	} else if !bytes.Equal(buf.b, wantBuffer) {
+		t.Errorf("UnmarshalPacketBody(): Data was %X, but expected %X", buf.b, wantBuffer)
 	}
 }
 
@@ -153,7 +153,7 @@ func TestExtendedReplyNoData(t *testing.T) {
 
 	p := &ExtendedReplyPacket{}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -164,14 +164,14 @@ func TestExtendedReplyNoData(t *testing.T) {
 		0x00, 0x00, 0x00, 42,
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = ExtendedReplyPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 }
@@ -190,7 +190,7 @@ func TestExtendedReplyPacketTestData(t *testing.T) {
 		},
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -202,8 +202,8 @@ func TestExtendedReplyPacketTestData(t *testing.T) {
 		0x27,
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = ExtendedReplyPacket{
@@ -211,30 +211,30 @@ func TestExtendedReplyPacketTestData(t *testing.T) {
 	}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
-	if data, ok := p.Data.(*testExtendedData); !ok {
-		t.Errorf("UnmarshalPacketBody(): Data was type %T, but expected %T", p.Data, data)
+	if buf, ok := p.Data.(*testExtendedData); !ok {
+		t.Errorf("UnmarshalPacketBody(): Data was type %T, but expected %T", p.Data, buf)
 
-	} else if data.value != value {
-		t.Errorf("UnmarshalPacketBody(): Data.value was %#x, but expected %#x", data.value, value)
+	} else if buf.value != value {
+		t.Errorf("UnmarshalPacketBody(): Data.value was %#x, but expected %#x", buf.value, value)
 	}
 
 	*p = ExtendedReplyPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
 	wantBuffer := []byte{0x27}
 
-	if data, ok := p.Data.(*Buffer); !ok {
-		t.Errorf("UnmarshalPacketBody(): Data was type %T, but expected %T", p.Data, data)
+	if buf, ok := p.Data.(*Buffer); !ok {
+		t.Errorf("UnmarshalPacketBody(): Data was type %T, but expected %T", p.Data, buf)
 
-	} else if !bytes.Equal(data.b, wantBuffer) {
-		t.Errorf("UnmarshalPacketBody(): Data was %X, but expected %X", data.b, wantBuffer)
+	} else if !bytes.Equal(buf.b, wantBuffer) {
+		t.Errorf("UnmarshalPacketBody(): Data was %X, but expected %X", buf.b, wantBuffer)
 	}
 }

--- a/internal/encoding/ssh/filexfer/extensions.go
+++ b/internal/encoding/ssh/filexfer/extensions.go
@@ -22,7 +22,7 @@ func (e *ExtensionPair) MarshalInto(buf *Buffer) {
 
 // MarshalBinary returns e as the binary encoding of e.
 func (e *ExtensionPair) MarshalBinary() ([]byte, error) {
-	buf := NewBuffer(make([]byte, e.Len()))
+	buf := NewBuffer(make([]byte, 0, e.Len()))
 	e.MarshalInto(buf)
 	return buf.Bytes(), nil
 }

--- a/internal/encoding/ssh/filexfer/extensions_test.go
+++ b/internal/encoding/ssh/filexfer/extensions_test.go
@@ -16,9 +16,10 @@ func TestExtensionPair(t *testing.T) {
 		Data: data,
 	}
 
-	buf := new(Buffer)
-
-	pair.MarshalInto(buf)
+	buf, err := pair.MarshalBinary()
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
 
 	want := []byte{
 		0x00, 0x00, 0x00, 3,
@@ -27,18 +28,18 @@ func TestExtensionPair(t *testing.T) {
 		'1',
 	}
 
-	if got := buf.Bytes(); !bytes.Equal(got, want) {
-		t.Errorf("ExtensionPair.MarshalInto() = %X, but wanted %X", got, want)
+	if !bytes.Equal(buf, want) {
+		t.Errorf("ExtensionPair.MarshalBinary() = %X, but wanted %X", buf, want)
 	}
 
 	*pair = ExtensionPair{}
 
-	if err := pair.UnmarshalFrom(buf); err != nil {
+	if err := pair.UnmarshalBinary(buf); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
 	if pair.Name != name {
-		t.Errorf("ExtensionPair.UnmarshalFrom(): Name was %q, but expected %q", pair.Name, name)
+		t.Errorf("ExtensionPair.UnmarshalBinary(): Name was %q, but expected %q", pair.Name, name)
 	}
 
 	if pair.Data != data {

--- a/internal/encoding/ssh/filexfer/fx.go
+++ b/internal/encoding/ssh/filexfer/fx.go
@@ -61,12 +61,22 @@ const (
 	StatusV6NoMatchingByteRangeLock
 )
 
-func (f Status) Error() string {
-	return f.String()
+func (s Status) Error() string {
+	return s.String()
 }
 
-func (f Status) String() string {
-	switch f {
+// Is returns true if the target is the same Status code,
+// or target is a StatusPacket with the same Status code.
+func (s Status) Is(target error) bool {
+	if target, ok := target.(*StatusPacket); ok {
+		return target.StatusCode == s
+	}
+
+	return s == target
+}
+
+func (s Status) String() string {
+	switch s {
 	case StatusOK:
 		return "SSH_FX_OK"
 	case StatusEOF:
@@ -132,6 +142,6 @@ func (f Status) String() string {
 	case StatusV6NoMatchingByteRangeLock:
 		return "SSH_FX_NO_MATCHING_BYTE_RANGE_LOCK"
 	default:
-		return fmt.Sprintf("SSH_FX_UNKNOWN(%d)", f)
+		return fmt.Sprintf("SSH_FX_UNKNOWN(%d)", s)
 	}
 }

--- a/internal/encoding/ssh/filexfer/fx_test.go
+++ b/internal/encoding/ssh/filexfer/fx_test.go
@@ -2,6 +2,7 @@ package filexfer
 
 import (
 	"bufio"
+	"errors"
 	"regexp"
 	"strconv"
 	"strings"
@@ -80,5 +81,22 @@ func TestFxNames(t *testing.T) {
 
 	if err := scan.Err(); err != nil {
 		t.Fatal("unexpected error:", err)
+	}
+}
+
+func TestStatusIs(t *testing.T) {
+	status := StatusFailure
+
+	if !errors.Is(status, StatusFailure) {
+		t.Error("errors.Is(StatusFailure, StatusFailure) != true")
+	}
+	if !errors.Is(status, &StatusPacket{StatusCode: StatusFailure}) {
+		t.Error("errors.Is(StatusFailure, StatusPacket{StatusFailure}) != true")
+	}
+	if errors.Is(status, StatusOK) {
+		t.Error("errors.Is(StatusFailure, StatusFailure) == true")
+	}
+	if errors.Is(status, &StatusPacket{StatusCode: StatusOK}) {
+		t.Error("errors.Is(StatusFailure, StatusPacket{StatusFailure}) == true")
 	}
 }

--- a/internal/encoding/ssh/filexfer/handle_packets_test.go
+++ b/internal/encoding/ssh/filexfer/handle_packets_test.go
@@ -17,7 +17,7 @@ func TestClosePacket(t *testing.T) {
 		Handle: "somehandle",
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -29,14 +29,14 @@ func TestClosePacket(t *testing.T) {
 		0x00, 0x00, 0x00, 10, 's', 'o', 'm', 'e', 'h', 'a', 'n', 'd', 'l', 'e',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = ClosePacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -61,7 +61,7 @@ func TestReadPacket(t *testing.T) {
 		Len:    length,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -75,14 +75,14 @@ func TestReadPacket(t *testing.T) {
 		0xFE, 0xDC, 0xBA, 0x98,
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = ReadPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -116,7 +116,7 @@ func TestWritePacket(t *testing.T) {
 		Data:   payload,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -130,14 +130,14 @@ func TestWritePacket(t *testing.T) {
 		0x00, 0x00, 0x00, 0x06, 'f', 'o', 'o', 'b', 'a', 'r',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = WritePacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -166,7 +166,7 @@ func TestFStatPacket(t *testing.T) {
 		Handle: "somehandle",
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -178,14 +178,14 @@ func TestFStatPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 10, 's', 'o', 'm', 'e', 'h', 'a', 'n', 'd', 'l', 'e',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = FStatPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -211,7 +211,7 @@ func TestFSetstatPacket(t *testing.T) {
 		},
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -225,14 +225,14 @@ func TestFSetstatPacket(t *testing.T) {
 		0x87, 0x65, 0x43, 0x21,
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = FSetstatPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -253,7 +253,7 @@ func TestReadDirPacket(t *testing.T) {
 		Handle: "somehandle",
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -265,14 +265,14 @@ func TestReadDirPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 10, 's', 'o', 'm', 'e', 'h', 'a', 'n', 'd', 'l', 'e',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = ReadDirPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 

--- a/internal/encoding/ssh/filexfer/init_packets.go
+++ b/internal/encoding/ssh/filexfer/init_packets.go
@@ -64,7 +64,7 @@ func (p *VersionPacket) MarshalBinary() ([]byte, error) {
 	}
 
 	b := NewBuffer(make([]byte, 4, 4+size))
-	b.AppendUint8(uint8(PacketTypeInit))
+	b.AppendUint8(uint8(PacketTypeVersion))
 	b.AppendUint32(p.Version)
 
 	for _, ext := range p.Extensions {

--- a/internal/encoding/ssh/filexfer/init_packets_test.go
+++ b/internal/encoding/ssh/filexfer/init_packets_test.go
@@ -18,7 +18,7 @@ func TestInitPacket(t *testing.T) {
 		},
 	}
 
-	data, err := p.MarshalBinary()
+	buf, err := p.MarshalBinary()
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -31,14 +31,14 @@ func TestInitPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 1, '1',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalBinary() = %X, but wanted %X", buf, want)
 	}
 
 	*p = InitPacket{}
 
 	// UnmarshalBinary assumes the uint32(length) + uint8(type) have already been consumed.
-	if err := p.UnmarshalBinary(data[5:]); err != nil {
+	if err := p.UnmarshalBinary(buf[5:]); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -72,27 +72,27 @@ func TestVersionPacket(t *testing.T) {
 		},
 	}
 
-	data, err := p.MarshalBinary()
+	buf, err := p.MarshalBinary()
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
 	want := []byte{
 		0x00, 0x00, 0x00, 17,
-		1,
+		2,
 		0x00, 0x00, 0x00, version,
 		0x00, 0x00, 0x00, 3, 'f', 'o', 'o',
 		0x00, 0x00, 0x00, 1, '1',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalBinary() = %X, but wanted %X", buf, want)
 	}
 
 	*p = VersionPacket{}
 
 	// UnmarshalBinary assumes the uint32(length) + uint8(type) have already been consumed.
-	if err := p.UnmarshalBinary(data[5:]); err != nil {
+	if err := p.UnmarshalBinary(buf[5:]); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 

--- a/internal/encoding/ssh/filexfer/open_packets.go
+++ b/internal/encoding/ssh/filexfer/open_packets.go
@@ -17,6 +17,11 @@ type OpenPacket struct {
 	Attrs    Attributes
 }
 
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *OpenPacket) Type() PacketType {
+	return PacketTypeOpen
+}
+
 // MarshalPacket returns p as a two-part binary encoding of p.
 func (p *OpenPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	buf := NewBuffer(b)
@@ -52,6 +57,11 @@ func (p *OpenPacket) UnmarshalPacketBody(buf *Buffer) (err error) {
 // OpenDirPacket defines the SSH_FXP_OPENDIR packet.
 type OpenDirPacket struct {
 	Path string
+}
+
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *OpenDirPacket) Type() PacketType {
+	return PacketTypeOpenDir
 }
 
 // MarshalPacket returns p as a two-part binary encoding of p.

--- a/internal/encoding/ssh/filexfer/open_packets_test.go
+++ b/internal/encoding/ssh/filexfer/open_packets_test.go
@@ -23,7 +23,7 @@ func TestOpenPacket(t *testing.T) {
 		},
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -38,14 +38,14 @@ func TestOpenPacket(t *testing.T) {
 		0x87, 0x65, 0x43, 0x21,
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = OpenPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -78,7 +78,7 @@ func TestOpenDirPacket(t *testing.T) {
 		Path: path,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -90,14 +90,14 @@ func TestOpenDirPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = OpenDirPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 

--- a/internal/encoding/ssh/filexfer/openssh/fsync.go
+++ b/internal/encoding/ssh/filexfer/openssh/fsync.go
@@ -1,0 +1,73 @@
+package openssh
+
+import (
+	sshfx "github.com/pkg/sftp/internal/encoding/ssh/filexfer"
+)
+
+const extensionFSync = "fsync@openssh.com"
+
+// RegisterExtensionFSync registers the "fsync@openssh.com" extended packet with the encoding/ssh/filexfer package.
+func RegisterExtensionFSync() {
+	sshfx.RegisterExtendedPacketType(extensionFSync, func() sshfx.ExtendedData {
+		return new(FSyncExtendedPacket)
+	})
+}
+
+// ExtensionFSync returns an ExtensionPair suitable to append into an sshfx.InitPacket or sshfx.VersionPacket.
+func ExtensionFSync() *sshfx.ExtensionPair {
+	return &sshfx.ExtensionPair{
+		Name: extensionFSync,
+		Data: "1",
+	}
+}
+
+// FSyncExtendedPacket defines the fsync@openssh.com extend packet.
+type FSyncExtendedPacket struct {
+	Handle string
+}
+
+// Type returns the SSH_FXP_EXTENDED packet type.
+func (ep *FSyncExtendedPacket) Type() sshfx.PacketType {
+	return sshfx.PacketTypeExtended
+}
+
+// MarshalPacket returns ep as a two-part binary encoding of the full extended packet.
+func (ep *FSyncExtendedPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
+	p := &sshfx.ExtendedPacket{
+		ExtendedRequest: extensionFSync,
+
+		Data: ep,
+	}
+	return p.MarshalPacket(reqid, b)
+}
+
+// MarshalInto encodes ep into the binary encoding of the fsync@openssh.com extended packet-specific data.
+func (ep *FSyncExtendedPacket) MarshalInto(buf *sshfx.Buffer) {
+	buf.AppendString(ep.Handle)
+}
+
+// MarshalBinary encodes ep into the binary encoding of the fsync@openssh.com extended packet-specific data.
+//
+// NOTE: This _only_ encodes the packet-specific data, it does not encode the full extended packet.
+func (ep *FSyncExtendedPacket) MarshalBinary() ([]byte, error) {
+	// string(handle)
+	size := 4 + len(ep.Handle)
+
+	buf := sshfx.NewBuffer(make([]byte, 0, size))
+	ep.MarshalInto(buf)
+	return buf.Bytes(), nil
+}
+
+// UnmarshalFrom decodes the fsync@openssh.com extended packet-specific data from buf.
+func (ep *FSyncExtendedPacket) UnmarshalFrom(buf *sshfx.Buffer) (err error) {
+	if ep.Handle, err = buf.ConsumeString(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalBinary decodes the fsync@openssh.com extended packet-specific data into ep.
+func (ep *FSyncExtendedPacket) UnmarshalBinary(data []byte) (err error) {
+	return ep.UnmarshalFrom(sshfx.NewBuffer(data))
+}

--- a/internal/encoding/ssh/filexfer/openssh/fsync_test.go
+++ b/internal/encoding/ssh/filexfer/openssh/fsync_test.go
@@ -1,0 +1,62 @@
+package openssh
+
+import (
+	"bytes"
+	"testing"
+
+	sshfx "github.com/pkg/sftp/internal/encoding/ssh/filexfer"
+)
+
+var _ sshfx.PacketMarshaller = &FSyncExtendedPacket{}
+
+func init() {
+	RegisterExtensionFSync()
+}
+
+func TestFSyncExtendedPacket(t *testing.T) {
+	const (
+		id     = 42
+		handle = "somehandle"
+	)
+
+	ep := &FSyncExtendedPacket{
+		Handle: handle,
+	}
+
+	data, err := sshfx.ComposePacket(ep.MarshalPacket(id, nil))
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	want := []byte{
+		0x00, 0x00, 0x00, 40,
+		200,
+		0x00, 0x00, 0x00, 42,
+		0x00, 0x00, 0x00, 17, 'f', 's', 'y', 'n', 'c', '@', 'o', 'p', 'e', 'n', 's', 's', 'h', '.', 'c', 'o', 'm',
+		0x00, 0x00, 0x00, 10, 's', 'o', 'm', 'e', 'h', 'a', 'n', 'd', 'l', 'e',
+	}
+
+	if !bytes.Equal(data, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", data, want)
+	}
+
+	var p sshfx.ExtendedPacket
+
+	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
+	if err := p.UnmarshalPacketBody(sshfx.NewBuffer(data[9:])); err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	if p.ExtendedRequest != extensionFSync {
+		t.Errorf("UnmarshalPacketBody(): ExtendedRequest was %q, but expected %q", p.ExtendedRequest, extensionFSync)
+	}
+
+	ep, ok := p.Data.(*FSyncExtendedPacket)
+	if !ok {
+		t.Fatalf("UnmarshaledPacketBody(): Data was type %T, but expected *FSyncExtendedPacket", p.Data)
+	}
+
+	if ep.Handle != handle {
+		t.Errorf("UnmarshalPacketBody(): Handle was %q, but expected %q", ep.Handle, handle)
+	}
+}

--- a/internal/encoding/ssh/filexfer/openssh/hardlink.go
+++ b/internal/encoding/ssh/filexfer/openssh/hardlink.go
@@ -27,6 +27,11 @@ type HardlinkExtendedPacket struct {
 	NewPath string
 }
 
+// Type returns the SSH_FXP_EXTENDED packet type.
+func (ep *HardlinkExtendedPacket) Type() sshfx.PacketType {
+	return sshfx.PacketTypeExtended
+}
+
 // MarshalPacket returns ep as a two-part binary encoding of the full extended packet.
 func (ep *HardlinkExtendedPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	p := &sshfx.ExtendedPacket{
@@ -50,7 +55,7 @@ func (ep *HardlinkExtendedPacket) MarshalBinary() ([]byte, error) {
 	// string(oldpath) + string(newpath)
 	size := 4 + len(ep.OldPath) + 4 + len(ep.NewPath)
 
-	buf := sshfx.NewBuffer(make([]byte, size))
+	buf := sshfx.NewBuffer(make([]byte, 0, size))
 	ep.MarshalInto(buf)
 	return buf.Bytes(), nil
 }

--- a/internal/encoding/ssh/filexfer/openssh/hardlink_test.go
+++ b/internal/encoding/ssh/filexfer/openssh/hardlink_test.go
@@ -1,0 +1,69 @@
+package openssh
+
+import (
+	"bytes"
+	"testing"
+
+	sshfx "github.com/pkg/sftp/internal/encoding/ssh/filexfer"
+)
+
+var _ sshfx.PacketMarshaller = &HardlinkExtendedPacket{}
+
+func init() {
+	RegisterExtensionHardlink()
+}
+
+func TestHardlinkExtendedPacket(t *testing.T) {
+	const (
+		id      = 42
+		oldpath = "/foo"
+		newpath = "/bar"
+	)
+
+	ep := &HardlinkExtendedPacket{
+		OldPath: oldpath,
+		NewPath: newpath,
+	}
+
+	data, err := sshfx.ComposePacket(ep.MarshalPacket(id, nil))
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	want := []byte{
+		0x00, 0x00, 0x00, 45,
+		200,
+		0x00, 0x00, 0x00, 42,
+		0x00, 0x00, 0x00, 20, 'h', 'a', 'r', 'd', 'l', 'i', 'n', 'k', '@', 'o', 'p', 'e', 'n', 's', 's', 'h', '.', 'c', 'o', 'm',
+		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
+		0x00, 0x00, 0x00, 4, '/', 'b', 'a', 'r',
+	}
+
+	if !bytes.Equal(data, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", data, want)
+	}
+
+	var p sshfx.ExtendedPacket
+
+	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
+	if err := p.UnmarshalPacketBody(sshfx.NewBuffer(data[9:])); err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	if p.ExtendedRequest != extensionHardlink {
+		t.Errorf("UnmarshalPacketBody(): ExtendedRequest was %q, but expected %q", p.ExtendedRequest, extensionHardlink)
+	}
+
+	ep, ok := p.Data.(*HardlinkExtendedPacket)
+	if !ok {
+		t.Fatalf("UnmarshaledPacketBody(): Data was type %T, but expected *HardlinkExtendedPacket", p.Data)
+	}
+
+	if ep.OldPath != oldpath {
+		t.Errorf("UnmarshalPacketBody(): OldPath was %q, but expected %q", ep.OldPath, oldpath)
+	}
+
+	if ep.NewPath != newpath {
+		t.Errorf("UnmarshalPacketBody(): NewPath was %q, but expected %q", ep.NewPath, newpath)
+	}
+}

--- a/internal/encoding/ssh/filexfer/openssh/posix-rename.go
+++ b/internal/encoding/ssh/filexfer/openssh/posix-rename.go
@@ -27,6 +27,11 @@ type PosixRenameExtendedPacket struct {
 	NewPath string
 }
 
+// Type returns the SSH_FXP_EXTENDED packet type.
+func (ep *PosixRenameExtendedPacket) Type() sshfx.PacketType {
+	return sshfx.PacketTypeExtended
+}
+
 // MarshalPacket returns ep as a two-part binary encoding of the full extended packet.
 func (ep *PosixRenameExtendedPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	p := &sshfx.ExtendedPacket{
@@ -50,7 +55,7 @@ func (ep *PosixRenameExtendedPacket) MarshalBinary() ([]byte, error) {
 	// string(oldpath) + string(newpath)
 	size := 4 + len(ep.OldPath) + 4 + len(ep.NewPath)
 
-	buf := sshfx.NewBuffer(make([]byte, size))
+	buf := sshfx.NewBuffer(make([]byte, 0, size))
 	ep.MarshalInto(buf)
 	return buf.Bytes(), nil
 }

--- a/internal/encoding/ssh/filexfer/openssh/posix-rename_test.go
+++ b/internal/encoding/ssh/filexfer/openssh/posix-rename_test.go
@@ -1,0 +1,69 @@
+package openssh
+
+import (
+	"bytes"
+	"testing"
+
+	sshfx "github.com/pkg/sftp/internal/encoding/ssh/filexfer"
+)
+
+var _ sshfx.PacketMarshaller = &PosixRenameExtendedPacket{}
+
+func init() {
+	RegisterExtensionPosixRename()
+}
+
+func TestPosixRenameExtendedPacket(t *testing.T) {
+	const (
+		id      = 42
+		oldpath = "/foo"
+		newpath = "/bar"
+	)
+
+	ep := &PosixRenameExtendedPacket{
+		OldPath: oldpath,
+		NewPath: newpath,
+	}
+
+	data, err := sshfx.ComposePacket(ep.MarshalPacket(id, nil))
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	want := []byte{
+		0x00, 0x00, 0x00, 49,
+		200,
+		0x00, 0x00, 0x00, 42,
+		0x00, 0x00, 0x00, 24, 'p', 'o', 's', 'i', 'x', '-', 'r', 'e', 'n', 'a', 'm', 'e', '@', 'o', 'p', 'e', 'n', 's', 's', 'h', '.', 'c', 'o', 'm',
+		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
+		0x00, 0x00, 0x00, 4, '/', 'b', 'a', 'r',
+	}
+
+	if !bytes.Equal(data, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", data, want)
+	}
+
+	var p sshfx.ExtendedPacket
+
+	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
+	if err := p.UnmarshalPacketBody(sshfx.NewBuffer(data[9:])); err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	if p.ExtendedRequest != extensionPosixRename {
+		t.Errorf("UnmarshalPacketBody(): ExtendedRequest was %q, but expected %q", p.ExtendedRequest, extensionPosixRename)
+	}
+
+	ep, ok := p.Data.(*PosixRenameExtendedPacket)
+	if !ok {
+		t.Fatalf("UnmarshaledPacketBody(): Data was type %T, but expected *PosixRenameExtendedPacket", p.Data)
+	}
+
+	if ep.OldPath != oldpath {
+		t.Errorf("UnmarshalPacketBody(): OldPath was %q, but expected %q", ep.OldPath, oldpath)
+	}
+
+	if ep.NewPath != newpath {
+		t.Errorf("UnmarshalPacketBody(): NewPath was %q, but expected %q", ep.NewPath, newpath)
+	}
+}

--- a/internal/encoding/ssh/filexfer/openssh/statvfs.go
+++ b/internal/encoding/ssh/filexfer/openssh/statvfs.go
@@ -26,6 +26,11 @@ type StatVFSExtendedPacket struct {
 	Path string
 }
 
+// Type returns the SSH_FXP_EXTENDED packet type.
+func (ep *StatVFSExtendedPacket) Type() sshfx.PacketType {
+	return sshfx.PacketTypeExtended
+}
+
 // MarshalPacket returns ep as a two-part binary encoding of the full extended packet.
 func (ep *StatVFSExtendedPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	p := &sshfx.ExtendedPacket{
@@ -47,7 +52,7 @@ func (ep *StatVFSExtendedPacket) MarshalInto(buf *sshfx.Buffer) {
 func (ep *StatVFSExtendedPacket) MarshalBinary() ([]byte, error) {
 	size := 4 + len(ep.Path) // string(path)
 
-	buf := sshfx.NewBuffer(make([]byte, size))
+	buf := sshfx.NewBuffer(make([]byte, 0, size))
 
 	ep.MarshalInto(buf)
 
@@ -90,6 +95,11 @@ type FStatVFSExtendedPacket struct {
 	Path string
 }
 
+// Type returns the SSH_FXP_EXTENDED packet type.
+func (ep *FStatVFSExtendedPacket) Type() sshfx.PacketType {
+	return sshfx.PacketTypeExtended
+}
+
 // MarshalPacket returns ep as a two-part binary encoding of the full extended packet.
 func (ep *FStatVFSExtendedPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	p := &sshfx.ExtendedPacket{
@@ -111,7 +121,7 @@ func (ep *FStatVFSExtendedPacket) MarshalInto(buf *sshfx.Buffer) {
 func (ep *FStatVFSExtendedPacket) MarshalBinary() ([]byte, error) {
 	size := 4 + len(ep.Path) // string(path)
 
-	buf := sshfx.NewBuffer(make([]byte, size))
+	buf := sshfx.NewBuffer(make([]byte, 0, size))
 
 	ep.MarshalInto(buf)
 
@@ -154,12 +164,25 @@ type StatVFSExtendedReplyPacket struct {
 	MaxNameLength uint64 /* f_namemax: maximum filename length */
 }
 
+// Type returns the SSH_FXP_EXTENDED_REPLY packet type.
+func (ep *StatVFSExtendedReplyPacket) Type() sshfx.PacketType {
+	return sshfx.PacketTypeExtendedReply
+}
+
 // MarshalPacket returns ep as a two-part binary encoding of the full extended reply packet.
 func (ep *StatVFSExtendedReplyPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	p := &sshfx.ExtendedReplyPacket{
 		Data: ep,
 	}
 	return p.MarshalPacket(reqid, b)
+}
+
+// UnmarshalPacketBody returns ep as a two-part binary encoding of the full extended reply packet.
+func (ep *StatVFSExtendedReplyPacket) UnmarshalPacketBody(buf *sshfx.Buffer) (err error) {
+	p := &sshfx.ExtendedReplyPacket{
+		Data: ep,
+	}
+	return p.UnmarshalPacketBody(buf)
 }
 
 // MarshalInto encodes ep into the binary encoding of the (f)statvfs@openssh.com extended reply packet-specific data.
@@ -183,7 +206,7 @@ func (ep *StatVFSExtendedReplyPacket) MarshalInto(buf *sshfx.Buffer) {
 func (ep *StatVFSExtendedReplyPacket) MarshalBinary() ([]byte, error) {
 	size := 11 * 8 // 11 × uint64(various)
 
-	b := sshfx.NewBuffer(make([]byte, size))
+	b := sshfx.NewBuffer(make([]byte, 0, size))
 	ep.MarshalInto(b)
 	return b.Bytes(), nil
 }

--- a/internal/encoding/ssh/filexfer/openssh/statvfs_test.go
+++ b/internal/encoding/ssh/filexfer/openssh/statvfs_test.go
@@ -1,0 +1,239 @@
+package openssh
+
+import (
+	"bytes"
+	"testing"
+
+	sshfx "github.com/pkg/sftp/internal/encoding/ssh/filexfer"
+)
+
+var _ sshfx.PacketMarshaller = &StatVFSExtendedPacket{}
+
+func init() {
+	RegisterExtensionStatVFS()
+}
+
+func TestStatVFSExtendedPacket(t *testing.T) {
+	const (
+		id   = 42
+		path = "/foo"
+	)
+
+	ep := &StatVFSExtendedPacket{
+		Path: path,
+	}
+
+	data, err := sshfx.ComposePacket(ep.MarshalPacket(id, nil))
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	want := []byte{
+		0x00, 0x00, 0x00, 36,
+		200,
+		0x00, 0x00, 0x00, 42,
+		0x00, 0x00, 0x00, 19, 's', 't', 'a', 't', 'v', 'f', 's', '@', 'o', 'p', 'e', 'n', 's', 's', 'h', '.', 'c', 'o', 'm',
+		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
+	}
+
+	if !bytes.Equal(data, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", data, want)
+	}
+
+	var p sshfx.ExtendedPacket
+
+	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
+	if err := p.UnmarshalPacketBody(sshfx.NewBuffer(data[9:])); err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	if p.ExtendedRequest != extensionStatVFS {
+		t.Errorf("UnmarshalPacketBody(): ExtendedRequest was %q, but expected %q", p.ExtendedRequest, extensionStatVFS)
+	}
+
+	ep, ok := p.Data.(*StatVFSExtendedPacket)
+	if !ok {
+		t.Fatalf("UnmarshaledPacketBody(): Data was type %T, but expected *StatVFSExtendedPacket", p.Data)
+	}
+
+	if ep.Path != path {
+		t.Errorf("UnmarshalPacketBody(): Path was %q, but expected %q", ep.Path, path)
+	}
+}
+
+var _ sshfx.PacketMarshaller = &FStatVFSExtendedPacket{}
+
+func init() {
+	RegisterExtensionFStatVFS()
+}
+
+func TestFStatVFSExtendedPacket(t *testing.T) {
+	const (
+		id   = 42
+		path = "/foo"
+	)
+
+	ep := &FStatVFSExtendedPacket{
+		Path: path,
+	}
+
+	data, err := sshfx.ComposePacket(ep.MarshalPacket(id, nil))
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	want := []byte{
+		0x00, 0x00, 0x00, 37,
+		200,
+		0x00, 0x00, 0x00, 42,
+		0x00, 0x00, 0x00, 20, 'f', 's', 't', 'a', 't', 'v', 'f', 's', '@', 'o', 'p', 'e', 'n', 's', 's', 'h', '.', 'c', 'o', 'm',
+		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
+	}
+
+	if !bytes.Equal(data, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", data, want)
+	}
+
+	var p sshfx.ExtendedPacket
+
+	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
+	if err := p.UnmarshalPacketBody(sshfx.NewBuffer(data[9:])); err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	if p.ExtendedRequest != extensionFStatVFS {
+		t.Errorf("UnmarshalPacketBody(): ExtendedRequest was %q, but expected %q", p.ExtendedRequest, extensionFStatVFS)
+	}
+
+	ep, ok := p.Data.(*FStatVFSExtendedPacket)
+	if !ok {
+		t.Fatalf("UnmarshaledPacketBody(): Data was type %T, but expected *FStatVFSExtendedPacket", p.Data)
+	}
+
+	if ep.Path != path {
+		t.Errorf("UnmarshalPacketBody(): Path was %q, but expected %q", ep.Path, path)
+	}
+}
+
+var _ sshfx.Packet = &StatVFSExtendedReplyPacket{}
+
+func TestStatVFSExtendedReplyPacket(t *testing.T) {
+	const (
+		id   = 42
+		path = "/foo"
+	)
+
+	const (
+		BlockSize = uint64(iota + 13)
+		FragmentSize
+		Blocks
+		BlocksFree
+		BlocksAvail
+		Files
+		FilesFree
+		FilesAvail
+		FilesystemID
+		MountFlags
+		MaxNameLength
+	)
+
+	ep := &StatVFSExtendedReplyPacket{
+		BlockSize:     BlockSize,
+		FragmentSize:  FragmentSize,
+		Blocks:        Blocks,
+		BlocksFree:    BlocksFree,
+		BlocksAvail:   BlocksAvail,
+		Files:         Files,
+		FilesFree:     FilesFree,
+		FilesAvail:    FilesAvail,
+		FilesystemID:  FilesystemID,
+		MountFlags:    MountFlags,
+		MaxNameLength: MaxNameLength,
+	}
+
+	data, err := sshfx.ComposePacket(ep.MarshalPacket(id, nil))
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	want := []byte{
+		0x00, 0x00, 0x00, 93,
+		201,
+		0x00, 0x00, 0x00, 42,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 13,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 14,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 15,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 16,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 17,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 18,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 19,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 20,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 21,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 22,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 23,
+	}
+
+	if !bytes.Equal(data, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", data, want)
+	}
+
+	*ep = StatVFSExtendedReplyPacket{}
+
+	p := sshfx.ExtendedReplyPacket{
+		Data: ep,
+	}
+
+	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
+	if err := p.UnmarshalPacketBody(sshfx.NewBuffer(data[9:])); err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	ep, ok := p.Data.(*StatVFSExtendedReplyPacket)
+	if !ok {
+		t.Fatalf("UnmarshaledPacketBody(): Data was type %T, but expected *StatVFSExtendedReplyPacket", p.Data)
+	}
+
+	if ep.BlockSize != BlockSize {
+		t.Errorf("UnmarshalPacketBody(): BlockSize was %d, but expected %d", ep.BlockSize, BlockSize)
+	}
+
+	if ep.FragmentSize != FragmentSize {
+		t.Errorf("UnmarshalPacketBody(): FragmentSize was %d, but expected %d", ep.FragmentSize, FragmentSize)
+	}
+
+	if ep.Blocks != Blocks {
+		t.Errorf("UnmarshalPacketBody(): Blocks was %d, but expected %d", ep.Blocks, Blocks)
+	}
+
+	if ep.BlocksFree != BlocksFree {
+		t.Errorf("UnmarshalPacketBody(): BlocksFree was %d, but expected %d", ep.BlocksFree, BlocksFree)
+	}
+
+	if ep.BlocksAvail != BlocksAvail {
+		t.Errorf("UnmarshalPacketBody(): BlocksAvail was %d, but expected %d", ep.BlocksAvail, BlocksAvail)
+	}
+
+	if ep.Files != Files {
+		t.Errorf("UnmarshalPacketBody(): Files was %d, but expected %d", ep.Files, Files)
+	}
+
+	if ep.FilesFree != FilesFree {
+		t.Errorf("UnmarshalPacketBody(): FilesFree was %d, but expected %d", ep.FilesFree, FilesFree)
+	}
+
+	if ep.FilesAvail != FilesAvail {
+		t.Errorf("UnmarshalPacketBody(): FilesAvail was %d, but expected %d", ep.FilesAvail, FilesAvail)
+	}
+
+	if ep.FilesystemID != FilesystemID {
+		t.Errorf("UnmarshalPacketBody(): FilesystemID was %d, but expected %d", ep.FilesystemID, FilesystemID)
+	}
+
+	if ep.MountFlags != MountFlags {
+		t.Errorf("UnmarshalPacketBody(): MountFlags was %d, but expected %d", ep.MountFlags, MountFlags)
+	}
+
+	if ep.MaxNameLength != MaxNameLength {
+		t.Errorf("UnmarshalPacketBody(): MaxNameLength was %d, but expected %d", ep.MaxNameLength, MaxNameLength)
+	}
+}

--- a/internal/encoding/ssh/filexfer/packets.go
+++ b/internal/encoding/ssh/filexfer/packets.go
@@ -65,10 +65,15 @@ func newPacketFromType(typ PacketType) (Packet, error) {
 //
 // Defined in https://tools.ietf.org/html/draft-ietf-secsh-filexfer-02#section-3
 type RawPacket struct {
-	Type      PacketType
-	RequestID uint32
+	PacketType PacketType
+	RequestID  uint32
 
 	Data Buffer
+}
+
+// Type returns the Type field defining the SSH_FXP_xy type for this packet.
+func (p *RawPacket) Type() PacketType {
+	return p.PacketType
 }
 
 // Reset clears the pointers and reference-semantic variables of RawPacket,
@@ -87,7 +92,7 @@ func (p *RawPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byt
 		buf = NewMarshalBuffer(0)
 	}
 
-	buf.StartPacket(p.Type, reqid)
+	buf.StartPacket(p.PacketType, reqid)
 
 	return buf.Packet(p.Data.Bytes())
 }
@@ -110,7 +115,7 @@ func (p *RawPacket) UnmarshalFrom(buf *Buffer) error {
 		return err
 	}
 
-	p.Type = PacketType(typ)
+	p.PacketType = PacketType(typ)
 
 	if p.RequestID, err = buf.ConsumeUint32(); err != nil {
 		return err
@@ -225,6 +230,11 @@ type RequestPacket struct {
 	RequestID uint32
 
 	Request Packet
+}
+
+// Type returns the SSH_FXP_xy value associated with the underlying packet.
+func (p *RequestPacket) Type() PacketType {
+	return p.Request.Type()
 }
 
 // Reset clears the pointers and reference-semantic variables in RequestPacket,

--- a/internal/encoding/ssh/filexfer/packets_test.go
+++ b/internal/encoding/ssh/filexfer/packets_test.go
@@ -13,8 +13,8 @@ func TestRawPacket(t *testing.T) {
 	)
 
 	p := &RawPacket{
-		Type:      PacketTypeStatus,
-		RequestID: id,
+		PacketType: PacketTypeStatus,
+		RequestID:  id,
 		Data: Buffer{
 			b: []byte{
 				0x00, 0x00, 0x00, 0x01,
@@ -24,7 +24,7 @@ func TestRawPacket(t *testing.T) {
 		},
 	}
 
-	data, err := p.MarshalBinary()
+	buf, err := p.MarshalBinary()
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -38,18 +38,18 @@ func TestRawPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 2, 'e', 'n',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Errorf("RawPacket.Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Errorf("RawPacket.MarshalBinary() = %X, but wanted %X", buf, want)
 	}
 
 	*p = RawPacket{}
 
-	if err := p.ReadFrom(bytes.NewReader(data), nil, DefaultMaxPacketLength); err != nil {
+	if err := p.ReadFrom(bytes.NewReader(buf), nil, DefaultMaxPacketLength); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
-	if p.Type != PacketTypeStatus {
-		t.Errorf("RawPacket.UnmarshalBinary(): Type was %v, but expected %v", p.Type, PacketTypeStat)
+	if p.PacketType != PacketTypeStatus {
+		t.Errorf("RawPacket.UnmarshalBinary(): Type was %v, but expected %v", p.PacketType, PacketTypeStat)
 	}
 
 	if p.RequestID != uint32(id) {
@@ -70,15 +70,15 @@ func TestRawPacket(t *testing.T) {
 	resp.UnmarshalPacketBody(&p.Data)
 
 	if resp.StatusCode != StatusEOF {
-		t.Errorf("UnmarshalPacketBody(RawPacket.Data): StatusCode was %v, but expected %v", resp.StatusCode, StatusEOF)
+		t.Errorf("UnmarshalPacketBody(): StatusCode was %v, but expected %v", resp.StatusCode, StatusEOF)
 	}
 
 	if resp.ErrorMessage != errMsg {
-		t.Errorf("UnmarshalPacketBody(RawPacket.Data): ErrorMessage was %q, but expected %q", resp.ErrorMessage, errMsg)
+		t.Errorf("UnmarshalPacketBody(): ErrorMessage was %q, but expected %q", resp.ErrorMessage, errMsg)
 	}
 
 	if resp.LanguageTag != langTag {
-		t.Errorf("UnmarshalPacketBody(RawPacket.Data): LanguageTag was %q, but expected %q", resp.LanguageTag, langTag)
+		t.Errorf("UnmarshalPacketBody(): LanguageTag was %q, but expected %q", resp.LanguageTag, langTag)
 	}
 }
 
@@ -95,7 +95,7 @@ func TestRequestPacket(t *testing.T) {
 		},
 	}
 
-	data, err := p.MarshalBinary()
+	buf, err := p.MarshalBinary()
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -107,13 +107,13 @@ func TestRequestPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 3, 'f', 'o', 'o',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Errorf("RequestPacket.Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Errorf("RequestPacket.MarshalBinary() = %X, but wanted %X", buf, want)
 	}
 
 	*p = RequestPacket{}
 
-	if err := p.ReadFrom(bytes.NewReader(data), nil, DefaultMaxPacketLength); err != nil {
+	if err := p.ReadFrom(bytes.NewReader(buf), nil, DefaultMaxPacketLength); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 

--- a/internal/encoding/ssh/filexfer/path_packets.go
+++ b/internal/encoding/ssh/filexfer/path_packets.go
@@ -5,6 +5,11 @@ type LStatPacket struct {
 	Path string
 }
 
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *LStatPacket) Type() PacketType {
+	return PacketTypeLStat
+}
+
 // MarshalPacket returns p as a two-part binary encoding of p.
 func (p *LStatPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	buf := NewBuffer(b)
@@ -33,6 +38,11 @@ func (p *LStatPacket) UnmarshalPacketBody(buf *Buffer) (err error) {
 type SetstatPacket struct {
 	Path  string
 	Attrs Attributes
+}
+
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *SetstatPacket) Type() PacketType {
+	return PacketTypeSetstat
 }
 
 // MarshalPacket returns p as a two-part binary encoding of p.
@@ -66,6 +76,11 @@ type RemovePacket struct {
 	Path string
 }
 
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *RemovePacket) Type() PacketType {
+	return PacketTypeRemove
+}
+
 // MarshalPacket returns p as a two-part binary encoding of p.
 func (p *RemovePacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	buf := NewBuffer(b)
@@ -94,6 +109,11 @@ func (p *RemovePacket) UnmarshalPacketBody(buf *Buffer) (err error) {
 type MkdirPacket struct {
 	Path  string
 	Attrs Attributes
+}
+
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *MkdirPacket) Type() PacketType {
+	return PacketTypeMkdir
 }
 
 // MarshalPacket returns p as a two-part binary encoding of p.
@@ -127,6 +147,11 @@ type RmdirPacket struct {
 	Path string
 }
 
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *RmdirPacket) Type() PacketType {
+	return PacketTypeRmdir
+}
+
 // MarshalPacket returns p as a two-part binary encoding of p.
 func (p *RmdirPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	buf := NewBuffer(b)
@@ -154,6 +179,11 @@ func (p *RmdirPacket) UnmarshalPacketBody(buf *Buffer) (err error) {
 // RealPathPacket defines the SSH_FXP_REALPATH packet.
 type RealPathPacket struct {
 	Path string
+}
+
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *RealPathPacket) Type() PacketType {
+	return PacketTypeRealPath
 }
 
 // MarshalPacket returns p as a two-part binary encoding of p.
@@ -185,6 +215,11 @@ type StatPacket struct {
 	Path string
 }
 
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *StatPacket) Type() PacketType {
+	return PacketTypeStat
+}
+
 // MarshalPacket returns p as a two-part binary encoding of p.
 func (p *StatPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	buf := NewBuffer(b)
@@ -213,6 +248,11 @@ func (p *StatPacket) UnmarshalPacketBody(buf *Buffer) (err error) {
 type RenamePacket struct {
 	OldPath string
 	NewPath string
+}
+
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *RenamePacket) Type() PacketType {
+	return PacketTypeRename
 }
 
 // MarshalPacket returns p as a two-part binary encoding of p.
@@ -250,6 +290,11 @@ type ReadLinkPacket struct {
 	Path string
 }
 
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *ReadLinkPacket) Type() PacketType {
+	return PacketTypeReadLink
+}
+
 // MarshalPacket returns p as a two-part binary encoding of p.
 func (p *ReadLinkPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	buf := NewBuffer(b)
@@ -282,6 +327,11 @@ func (p *ReadLinkPacket) UnmarshalPacketBody(buf *Buffer) (err error) {
 type SymlinkPacket struct {
 	LinkPath   string
 	TargetPath string
+}
+
+// Type returns the SSH_FXP_xy value associated with this packet type.
+func (p *SymlinkPacket) Type() PacketType {
+	return PacketTypeSymlink
 }
 
 // MarshalPacket returns p as a two-part binary encoding of p.

--- a/internal/encoding/ssh/filexfer/path_packets_test.go
+++ b/internal/encoding/ssh/filexfer/path_packets_test.go
@@ -17,7 +17,7 @@ func TestLStatPacket(t *testing.T) {
 		Path: path,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -29,14 +29,14 @@ func TestLStatPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = LStatPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -62,7 +62,7 @@ func TestSetstatPacket(t *testing.T) {
 		},
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -76,14 +76,14 @@ func TestSetstatPacket(t *testing.T) {
 		0x87, 0x65, 0x43, 0x21,
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = SetstatPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -112,7 +112,7 @@ func TestRemovePacket(t *testing.T) {
 		Path: path,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -124,14 +124,14 @@ func TestRemovePacket(t *testing.T) {
 		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = RemovePacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -157,7 +157,7 @@ func TestMkdirPacket(t *testing.T) {
 		},
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -171,14 +171,14 @@ func TestMkdirPacket(t *testing.T) {
 		0x87, 0x65, 0x43, 0x21,
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = MkdirPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -207,7 +207,7 @@ func TestRmdirPacket(t *testing.T) {
 		Path: path,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -219,14 +219,14 @@ func TestRmdirPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = RmdirPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -247,7 +247,7 @@ func TestRealPathPacket(t *testing.T) {
 		Path: path,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -259,14 +259,14 @@ func TestRealPathPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = RealPathPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -287,7 +287,7 @@ func TestStatPacket(t *testing.T) {
 		Path: path,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -299,14 +299,14 @@ func TestStatPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = StatPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -329,7 +329,7 @@ func TestRenamePacket(t *testing.T) {
 		NewPath: newpath,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -342,14 +342,14 @@ func TestRenamePacket(t *testing.T) {
 		0x00, 0x00, 0x00, 4, '/', 'b', 'a', 'r',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = RenamePacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -374,7 +374,7 @@ func TestReadLinkPacket(t *testing.T) {
 		Path: path,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -386,14 +386,14 @@ func TestReadLinkPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = ReadLinkPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -416,7 +416,7 @@ func TestSymlinkPacket(t *testing.T) {
 		TargetPath: targetpath,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -429,14 +429,14 @@ func TestSymlinkPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 4, '/', 'f', 'o', 'o',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = SymlinkPacket{}
 
 	// UnmarshalPacketBody assumes the (length, type, request-id) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 

--- a/internal/encoding/ssh/filexfer/permissions.go
+++ b/internal/encoding/ssh/filexfer/permissions.go
@@ -86,5 +86,29 @@ func (m FileMode) String() string {
 		}
 	}
 
+	if m&ModeSetUID != 0 {
+		if buf[3] == 'x' {
+			buf[3] = 's'
+		} else {
+			buf[3] = 'S'
+		}
+	}
+
+	if m&ModeSetGID != 0 {
+		if buf[6] == 'x' {
+			buf[6] = 's'
+		} else {
+			buf[6] = 'S'
+		}
+	}
+
+	if m&ModeSticky != 0 {
+		if buf[9] == 'x' {
+			buf[9] = 't'
+		} else {
+			buf[9] = 'T'
+		}
+	}
+
 	return string(buf[:])
 }

--- a/internal/encoding/ssh/filexfer/response_packets_test.go
+++ b/internal/encoding/ssh/filexfer/response_packets_test.go
@@ -2,8 +2,30 @@ package filexfer
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
+
+func TestStatusPacketIs(t *testing.T) {
+	status := &StatusPacket{
+		StatusCode:   StatusFailure,
+		ErrorMessage: "error message",
+		LanguageTag:  "language tag",
+	}
+
+	if !errors.Is(status, StatusFailure) {
+		t.Error("errors.Is(StatusFailure, StatusFailure) != true")
+	}
+	if !errors.Is(status, &StatusPacket{StatusCode: StatusFailure}) {
+		t.Error("errors.Is(StatusFailure, StatusPacket{StatusFailure}) != true")
+	}
+	if errors.Is(status, StatusOK) {
+		t.Error("errors.Is(StatusFailure, StatusFailure) == true")
+	}
+	if errors.Is(status, &StatusPacket{StatusCode: StatusOK}) {
+		t.Error("errors.Is(StatusFailure, StatusPacket{StatusFailure}) == true")
+	}
+}
 
 var _ Packet = &StatusPacket{}
 
@@ -21,7 +43,7 @@ func TestStatusPacket(t *testing.T) {
 		LanguageTag:  languageTag,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -35,14 +57,14 @@ func TestStatusPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 9, 'x', '-', 'e', 'x', 'a', 'm', 'p', 'l', 'e',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = StatusPacket{}
 
 	// UnmarshalBinary assumes the uint32(length) + uint8(type) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -71,7 +93,7 @@ func TestHandlePacket(t *testing.T) {
 		Handle: "somehandle",
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -83,14 +105,14 @@ func TestHandlePacket(t *testing.T) {
 		0x00, 0x00, 0x00, 10, 's', 'o', 'm', 'e', 'h', 'a', 'n', 'd', 'l', 'e',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = HandlePacket{}
 
 	// UnmarshalBinary assumes the uint32(length) + uint8(type) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -112,7 +134,7 @@ func TestDataPacket(t *testing.T) {
 		Data: payload,
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -124,14 +146,14 @@ func TestDataPacket(t *testing.T) {
 		0x00, 0x00, 0x00, 6, 'f', 'o', 'o', 'b', 'a', 'r',
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = DataPacket{}
 
 	// UnmarshalBinary assumes the uint32(length) + uint8(type) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -171,7 +193,7 @@ func TestNamePacket(t *testing.T) {
 		},
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -191,14 +213,14 @@ func TestNamePacket(t *testing.T) {
 		0x87, 0x65, 0x43, 0x02,
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = NamePacket{}
 
 	// UnmarshalBinary assumes the uint32(length) + uint8(type) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
@@ -240,7 +262,7 @@ func TestAttrsPacket(t *testing.T) {
 		},
 	}
 
-	data, err := ComposePacket(p.MarshalPacket(id, nil))
+	buf, err := ComposePacket(p.MarshalPacket(id, nil))
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -253,14 +275,14 @@ func TestAttrsPacket(t *testing.T) {
 		0x87, 0x65, 0x43, 0x21,
 	}
 
-	if !bytes.Equal(data, want) {
-		t.Fatalf("Marshal() = %X, but wanted %X", data, want)
+	if !bytes.Equal(buf, want) {
+		t.Fatalf("MarshalPacket() = %X, but wanted %X", buf, want)
 	}
 
 	*p = AttrsPacket{}
 
 	// UnmarshalBinary assumes the uint32(length) + uint8(type) have already been consumed.
-	if err := p.UnmarshalPacketBody(NewBuffer(data[9:])); err != nil {
+	if err := p.UnmarshalPacketBody(NewBuffer(buf[9:])); err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 


### PR DESCRIPTION
As part of rolling out a client implementation with `filexfer` a number of bugs were found in the `filexfer` and `filexfer/openssh` sub-packages. Although they are right now `internal/` packages, so cannot be imported by any other go packages, I would rather we not cut a release that has significant bugs in it.

A few other feature improvements are carried over as well, since it’s easier to just import the whole of the `filexfer` from the other branch rather than piecemeal copying (which would also cause significant merge conflicts).