### PR TITLE
Use go errors instead of github.com/pkg/errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package sftp
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"io"
 	"math"
 	"os"
@@ -13,7 +14,6 @@ import (
 	"time"
 
 	"github.com/kr/fs"
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )
 

--- a/conn.go
+++ b/conn.go
@@ -2,10 +2,9 @@ package sftp
 
 import (
 	"encoding"
+	"fmt"
 	"io"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 // conn implements a bidirectional channel on which client and server
@@ -90,7 +89,7 @@ func (c *clientConn) recv() error {
 			// This is an unexpected occurrence. Send the error
 			// back to all listeners so that they terminate
 			// gracefully.
-			return errors.Errorf("sid not found: %d", sid)
+			return fmt.Errorf("sid not found: %d", sid)
 		}
 
 		ch <- result{typ: typ, data: data}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/kr/fs v0.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/packet-typing.go
+++ b/packet-typing.go
@@ -2,8 +2,7 @@ package sftp
 
 import (
 	"encoding"
-
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 // all incoming packets
@@ -125,7 +124,7 @@ func makePacket(p rxPacket) (requestPacket, error) {
 	case sshFxpExtended:
 		pkt = &sshFxpExtendedPacket{}
 	default:
-		return nil, errors.Errorf("unhandled packet type: %s", p.pktType)
+		return nil, fmt.Errorf("unhandled packet type: %s", p.pktType)
 	}
 	if err := pkt.UnmarshalBinary(p.pktBytes); err != nil {
 		// Return partially unpacked packet to allow callers to return

--- a/request-server.go
+++ b/request-server.go
@@ -2,13 +2,12 @@ package sftp
 
 import (
 	"context"
+	"errors"
 	"io"
 	"path"
 	"path/filepath"
 	"strconv"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 var maxTxPacket uint32 = 1 << 15
@@ -122,8 +121,8 @@ func (rs *RequestServer) serveLoop(pktChan chan<- orderedRequest) error {
 
 		pkt, err = makePacket(rxPacket{fxp(pktType), pktBytes})
 		if err != nil {
-			switch errors.Cause(err) {
-			case errUnknownExtendedPacket:
+			switch {
+			case errors.Is(err, errUnknownExtendedPacket):
 				// do nothing
 			default:
 				debug("makePacket err: %v", err)

--- a/request.go
+++ b/request.go
@@ -2,6 +2,8 @@ package sftp
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -9,8 +11,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-
-	"github.com/pkg/errors"
 )
 
 // MaxFilelist is the max number of files to return in a readdir batch.
@@ -220,7 +220,7 @@ func (r *Request) call(handlers Handlers, pkt requestPacket, alloc *allocator, o
 		return filestat(handlers.FileList, r, pkt)
 	default:
 		return statusFromError(pkt.id(),
-			errors.Errorf("unexpected method: %s", r.Method))
+			fmt.Errorf("unexpected method: %s", r.Method))
 	}
 }
 
@@ -422,7 +422,7 @@ func filelist(h FileLister, r *Request, pkt requestPacket) responsePacket {
 		}
 		return ret
 	default:
-		err = errors.Errorf("unexpected method: %s", r.Method)
+		err = fmt.Errorf("unexpected method: %s", r.Method)
 		return statusFromError(pkt.id(), err)
 	}
 }
@@ -484,7 +484,7 @@ func filestat(h FileLister, r *Request, pkt requestPacket) responsePacket {
 			},
 		}
 	default:
-		err = errors.Errorf("unexpected method: %s", r.Method)
+		err = fmt.Errorf("unexpected method: %s", r.Method)
 		return statusFromError(pkt.id(), err)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ package sftp
 
 import (
 	"encoding"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,8 +14,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -306,7 +305,7 @@ func handlePacket(s *Server, p orderedRequest) error {
 	case serverRespondablePacket:
 		rpkt = p.respond(s)
 	default:
-		return errors.Errorf("unexpected packet type %T", p)
+		return fmt.Errorf("unexpected packet type %T", p)
 	}
 
 	s.pktMgr.readyPacket(s.pktMgr.newOrderedResponse(rpkt, orderID))
@@ -346,8 +345,8 @@ func (svr *Server) Serve() error {
 
 		pkt, err = makePacket(rxPacket{fxp(pktType), pktBytes})
 		if err != nil {
-			switch errors.Cause(err) {
-			case errUnknownExtendedPacket:
+			switch {
+			case errors.Is(err, errUnknownExtendedPacket):
 				//if err := svr.serverConn.sendError(pkt, ErrSshFxOpUnsupported); err != nil {
 				//	debug("failed to send err packet: %v", err)
 				//	svr.conn.Close() // shuts down recvPacket

--- a/server_test.go
+++ b/server_test.go
@@ -2,6 +2,7 @@ package sftp
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -12,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/sftp.go
+++ b/sftp.go
@@ -4,8 +4,6 @@ package sftp
 
 import (
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -194,7 +192,7 @@ func (u *unexpectedPacketErr) Error() string {
 }
 
 func unimplementedPacketErr(u uint8) error {
-	return errors.Errorf("sftp: unimplemented packet type: got %v", fxp(u))
+	return fmt.Errorf("sftp: unimplemented packet type: got %v", fxp(u))
 }
 
 type unexpectedIDErr struct{ want, got uint32 }
@@ -204,11 +202,11 @@ func (u *unexpectedIDErr) Error() string {
 }
 
 func unimplementedSeekWhence(whence int) error {
-	return errors.Errorf("sftp: unimplemented seek whence %d", whence)
+	return fmt.Errorf("sftp: unimplemented seek whence %d", whence)
 }
 
 func unexpectedCount(want, got uint32) error {
-	return errors.Errorf("sftp: unexpected count: want %d, got %d", want, got)
+	return fmt.Errorf("sftp: unexpected count: want %d, got %d", want, got)
 }
 
 type unexpectedVersionErr struct{ want, got uint32 }
@@ -239,7 +237,7 @@ func getSupportedExtensionByName(extensionName string) (sshExtensionPair, error)
 			return supportedExtension, nil
 		}
 	}
-	return sshExtensionPair{}, errors.Errorf("unsupported extension: %s", extensionName)
+	return sshExtensionPair{}, fmt.Errorf("unsupported extension: %s", extensionName)
 }
 
 // SetSFTPExtensions allows to customize the supported server extensions.

--- a/sftp_test.go
+++ b/sftp_test.go
@@ -1,11 +1,11 @@
 package sftp
 
 import (
+	"errors"
 	"io"
 	"syscall"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This PR is a proposal to remove the github.com/pkg/errors and replace it with the standard "errors" package.

1. go 1.13 and above support the same or equivalent functionality compared to github.com/pkg/errors
1. github.com/pkg/errors is now under maintenance

