### PR TITLE
[bugfix] Sequentially issue read requests in ReadAt the same as WriteTo

### DIFF
--- a/client.go
+++ b/client.go
@@ -1112,6 +1112,13 @@ func (f *File) ReadAt(b []byte, off int64) (int, error) {
 						} else {
 							l, data := unmarshalUint32(data)
 							n = copy(packet.b, data[:l])
+
+							// For normal disk files, it is guaranteed that this will read
+							// the specified number of bytes, or up to end of file.
+							// This implies, if we have a short read, that means EOF.
+							if n < len(packet.b) {
+								err = io.EOF
+							}
 						}
 
 					default:

--- a/client.go
+++ b/client.go
@@ -1028,7 +1028,17 @@ func (f *File) ReadAt(b []byte, off int64) (int, error) {
 
 	cancel := make(chan struct{})
 
+	concurrency := len(b)/f.c.maxPacket + 1
+	if concurrency > f.c.maxConcurrentRequests || concurrency < 1 {
+		concurrency = f.c.maxConcurrentRequests
+	}
+
+	resPool := newResChanPool(concurrency)
+
 	type work struct {
+		id  uint32
+		res chan result
+
 		b   []byte
 		off int64
 	}
@@ -1048,8 +1058,18 @@ func (f *File) ReadAt(b []byte, off int64) (int, error) {
 				rb = rb[:chunkSize]
 			}
 
+			id := f.c.nextID()
+			res := resPool.Get()
+
+			f.c.dispatchRequest(res, &sshFxpReadPacket{
+				ID:     id,
+				Handle: f.handle,
+				Offset: uint64(offset),
+				Len:    uint32(chunkSize),
+			})
+
 			select {
-			case workCh <- work{rb, offset}:
+			case workCh <- work{id, res, rb, offset}:
 			case <-cancel:
 				return
 			}
@@ -1065,11 +1085,6 @@ func (f *File) ReadAt(b []byte, off int64) (int, error) {
 	}
 	errCh := make(chan rErr)
 
-	concurrency := len(b)/f.c.maxPacket + 1
-	if concurrency > f.c.maxConcurrentRequests || concurrency < 1 {
-		concurrency = f.c.maxConcurrentRequests
-	}
-
 	var wg sync.WaitGroup
 	wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {
@@ -1077,10 +1092,33 @@ func (f *File) ReadAt(b []byte, off int64) (int, error) {
 		go func() {
 			defer wg.Done()
 
-			ch := make(chan result, 1) // reusable channel per mapper.
-
 			for packet := range workCh {
-				n, err := f.readChunkAt(ch, packet.b, packet.off)
+				var n int
+
+				s := <-packet.res
+				resPool.Put(packet.res)
+
+				err := s.err
+				if err == nil {
+					switch s.typ {
+					case sshFxpStatus:
+						err = normaliseError(unmarshalStatus(packet.id, s.data))
+
+					case sshFxpData:
+						sid, data := unmarshalUint32(s.data)
+						if packet.id != sid {
+							err = &unexpectedIDErr{packet.id, sid}
+
+						} else {
+							l, data := unmarshalUint32(data)
+							n = copy(packet.b, data[:l])
+						}
+
+					default:
+						err = unimplementedPacketErr(s.typ)
+					}
+				}
+
 				if err != nil {
 					// return the offset as the start + how much we read before the error.
 					errCh <- rErr{packet.off + int64(n), err}


### PR DESCRIPTION
Copy in the sequential read functionality for `WriteTo` into `ReadAt`.

```
name                    old time/op    new time/op    delta
Read1k-8                  47.4ms ± 1%    47.4ms ± 0%    ~     (p=1.000 n=10+10)
Read16k-8                 9.94ms ± 3%    9.86ms ± 3%    ~     (p=0.393 n=10+10)
Read32k-8                 7.51ms ± 1%    7.46ms ± 2%    ~     (p=0.280 n=10+10)
Read128k-8                4.87ms ± 1%    4.78ms ± 2%  -1.76%  (p=0.000 n=9+9)
Read512k-8                3.95ms ± 2%    3.86ms ± 2%  -2.44%  (p=0.000 n=9+10)
Read1MiB-8                4.01ms ± 1%    3.92ms ± 1%  -2.28%  (p=0.000 n=9+9)
Read4MiB-8                4.43ms ± 1%    4.36ms ± 0%  -1.74%  (p=0.000 n=10+7)
Read4MiBDelay10Msec-8     69.6ms ± 1%    69.5ms ± 0%    ~     (p=0.739 n=10+10)
Read4MiBDelay50Msec-8      311ms ± 0%     311ms ± 0%    ~     (p=0.739 n=10+10)
Read4MiBDelay150Msec-8     912ms ± 0%     912ms ± 0%    ~     (p=0.796 n=10+10)

name                    old speed      new speed      delta
Read1k-8                 221MB/s ± 1%   221MB/s ± 0%    ~     (p=1.000 n=10+10)
Read16k-8               1.06GB/s ± 3%  1.06GB/s ± 3%    ~     (p=0.393 n=10+10)
Read32k-8               1.40GB/s ± 1%  1.41GB/s ± 2%    ~     (p=0.280 n=10+10)
Read128k-8              2.16GB/s ± 1%  2.19GB/s ± 2%  +1.80%  (p=0.000 n=9+9)
Read512k-8              2.65GB/s ± 2%  2.72GB/s ± 2%  +2.50%  (p=0.000 n=9+10)
Read1MiB-8              2.62GB/s ± 1%  2.68GB/s ± 1%  +2.34%  (p=0.000 n=9+9)
Read4MiB-8              2.36GB/s ± 1%  2.41GB/s ± 0%  +1.77%  (p=0.000 n=10+7)
Read4MiBDelay10Msec-8    151MB/s ± 1%   151MB/s ± 0%    ~     (p=0.671 n=10+10)
Read4MiBDelay50Msec-8   33.7MB/s ± 0%  33.7MB/s ± 0%    ~     (p=0.842 n=10+10)
Read4MiBDelay150Msec-8  11.5MB/s ± 0%  11.5MB/s ± 0%    ~     (p=1.000 n=10+10)

name                    old alloc/op   new alloc/op   delta
Read1k-8                  6.99MB ± 0%    6.99MB ± 0%    ~     (p=0.328 n=9+9)
Read16k-8                 5.99MB ± 0%    5.99MB ± 0%    ~     (p=0.929 n=10+10)
Read32k-8                 6.63MB ± 0%    6.63MB ± 0%    ~     (p=0.439 n=10+10)
Read128k-8                6.77MB ± 0%    6.77MB ± 0%  +0.00%  (p=0.022 n=10+10)
Read512k-8                7.25MB ± 0%    7.25MB ± 0%  +0.02%  (p=0.000 n=10+10)
Read1MiB-8                7.91MB ± 0%    7.91MB ± 0%  +0.01%  (p=0.000 n=10+10)
Read4MiB-8                10.5MB ± 0%    10.5MB ± 0%  +0.01%  (p=0.000 n=9+10)
Read4MiBDelay10Msec-8     10.5MB ± 0%    10.5MB ± 0%  +0.02%  (p=0.000 n=10+10)
Read4MiBDelay50Msec-8     10.5MB ± 0%    10.5MB ± 0%  +0.01%  (p=0.005 n=10+10)
Read4MiBDelay150Msec-8    10.5MB ± 0%    10.5MB ± 0%  +0.02%  (p=0.000 n=10+9)

name                    old allocs/op  new allocs/op  delta
Read1k-8                   30.7k ± 0%     30.7k ± 0%    ~     (all equal)
Read16k-8                  1.94k ± 0%     1.94k ± 0%    ~     (all equal)
Read32k-8                    982 ± 0%       982 ± 0%    ~     (all equal)
Read128k-8                 1.25k ± 0%     1.25k ± 0%  +0.04%  (p=0.015 n=9+10)
Read512k-8                 1.14k ± 0%     1.14k ± 0%  +0.06%  (p=0.019 n=10+10)
Read1MiB-8                 1.22k ± 0%     1.21k ± 0%  -0.53%  (p=0.000 n=10+10)
Read4MiB-8                 1.32k ± 0%     1.32k ± 0%  +0.55%  (p=0.000 n=9+9)
Read4MiBDelay10Msec-8      1.57k ± 1%     1.58k ± 0%  +0.66%  (p=0.000 n=10+10)
Read4MiBDelay50Msec-8      1.58k ± 1%     1.58k ± 1%    ~     (p=0.066 n=10+10)
Read4MiBDelay150Msec-8     1.58k ± 1%     1.59k ± 1%  +1.15%  (p=0.002 n=10+9)
```