### PR TITLE
[bugfix] a nil-pointer safeguard has itself a nil-pointer deref

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -15,6 +15,10 @@ func newBufPool(depth, bufLen int) *bufPool {
 }
 
 func (p *bufPool) Get() []byte {
+	if p.blen <= 0 {
+		panic("bufPool: new buffer creation length must be greater than zero")
+	}
+
 	for {
 		select {
 		case b := <-p.ch:

--- a/pool.go
+++ b/pool.go
@@ -15,11 +15,6 @@ func newBufPool(depth, bufLen int) *bufPool {
 }
 
 func (p *bufPool) Get() []byte {
-	if p == nil {
-		// functional default: no reuse.
-		return make([]byte, p.blen)
-	}
-
 	for {
 		select {
 		case b := <-p.ch:


### PR DESCRIPTION
Since the code is thus not fit for purpose, and we cannot just return an empty/nil slice, as the slices returned need to have an actual length to them to be properly used for reads; the code needs to just be removed.

Thinking about it while composing this PR description, a safeguard to ensure `p.blen > 0` is  a better choice. We will nil-pointer deref at that line if given a nil-pointer, but the panic message on the condition should serve a dual purpose of explaining why that nil-pointer deref can’t just be fixed with returning an empty slice.

Sure, “Don’t Panic” but this code should never panic, except under misuse within our own library, and should panic in the tests anyways, which should do the job of protecting code quality.