### PR TITLE
honor executable flag in Create file request

### DIFF
--- a/server.go
+++ b/server.go
@@ -446,7 +446,7 @@ func (p *sshFxpOpenPacket) respond(svr *Server) responsePacket {
 		osFlags |= os.O_EXCL
 	}
 
-	f, err := os.OpenFile(toLocalPath(p.Path), osFlags, 0644)
+	f, err := os.OpenFile(toLocalPath(p.Path), osFlags, p.Perms)
 	if err != nil {
 		return statusFromError(p.ID, err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -78,7 +78,7 @@ func runLsTestHelper(t *testing.T, result, expectedType, path string) {
 
 	// permissions (len 10, "drwxr-xr-x")
 	got := result[0:10]
-	if ok, err := regexp.MatchString("^"+expectedType+"[rwx-]{9}$", got); !ok {
+	if ok, err := regexp.MatchString("^"+expectedType+"[rwxs-]{9}$", got); !ok {
 		t.Errorf("runLs(%#v, *FileInfo): permission field mismatch, expected dir, got: %#v, err: %#v", path, got, err)
 	}
 


### PR DESCRIPTION
The following C program illustrates the problem:

```c
int main() {
  open("/mnt/sshfs/executable", O_CREAT | O_EXCL | O_WRONLY, 0755);
}
```

Before this change, the file would be created using mode 0644, despite the
caller requesting mode 0755.