### PR TITLE
Check for two more errors in tests

### DIFF
--- a/request-server_test.go
+++ b/request-server_test.go
@@ -490,6 +490,7 @@ func TestRequestFsetstat(t *testing.T) {
 	fp, err := p.cli.OpenFile("/foo", os.O_WRONLY)
 	require.NoError(t, err)
 	err = fp.Truncate(2)
+	require.NoError(t, err)
 	fi, err := fp.Stat()
 	require.NoError(t, err)
 	assert.Equal(t, fi.Name(), "foo")

--- a/sftp_test.go
+++ b/sftp_test.go
@@ -70,5 +70,6 @@ func TestExtensions(t *testing.T) {
 	assert.Equal(t, expectedSFTPExtensions, sftpExtensions)
 
 	err = SetSFTPExtensions(supportedExtensions...)
+	assert.NoError(t, err)
 	assert.Equal(t, supportedSFTPExtensions, sftpExtensions)
 }


### PR DESCRIPTION
I saw at https://goreportcard.com/report/github.com/pkg/sftp#ineffassign, that those `err` variables weren't used in those two places.