### PR TITLE
Missing ID passthru on statfs

### DIFF
--- a/server_statvfs_impl.go
+++ b/server_statvfs_impl.go
@@ -14,6 +14,7 @@ func (p *sshFxpExtendedPacketStatVFS) respond(svr *Server) responsePacket {
 	if err != nil {
 		return statusFromError(p.ID, err)
 	}
+	retPkt.ID = p.ID
 
 	return retPkt
 }


### PR DESCRIPTION
Issue https://github.com/pkg/sftp/issues/466 raised an issue of a lockup that was ascribed to `statfs` hanging, however, the problem is that `Server` was responding with `ID = 0` as it wasn’t being populated. It looked like the issue was `statfs` because it was the last thing that happened before the combination of binaries started sleeping, but it had actually returned.

This error caused `sshfs` to freakout, because it had not sent a request with `ID = 0` (which is technically an invalid ID anyways) and print `request 0 not found`. But as `sshfs` was still waiting for the response it just threw out, everything desynced and started waiting forever.