### PR TITLE
Need to type constants that overflow `int` on 32-bit archs

### DIFF
--- a/internal/encoding/ssh/filexfer/attrs_test.go
+++ b/internal/encoding/ssh/filexfer/attrs_test.go
@@ -7,12 +7,12 @@ import (
 
 func TestAttributes(t *testing.T) {
 	const (
-		size  = 0x123456789ABCDEF0
-		uid   = 1000
-		gid   = 100
-		perms = 0x87654321
-		atime = 0x2A2B2C2D
-		mtime = 0x42434445
+		size  uint64   = 0x123456789ABCDEF0
+		uid            = 1000
+		gid            = 100
+		perms FileMode = 0x87654321
+		atime          = 0x2A2B2C2D
+		mtime          = 0x42434445
 	)
 
 	extAttr := ExtendedAttribute{
@@ -177,9 +177,9 @@ func TestAttributes(t *testing.T) {
 
 func TestNameEntry(t *testing.T) {
 	const (
-		filename = "foo"
-		longname = "bar"
-		perms    = 0x87654321
+		filename          = "foo"
+		longname          = "bar"
+		perms    FileMode = 0x87654321
 	)
 
 	e := &NameEntry{

--- a/internal/encoding/ssh/filexfer/handle_packets_test.go
+++ b/internal/encoding/ssh/filexfer/handle_packets_test.go
@@ -49,10 +49,10 @@ var _ Packet = &ReadPacket{}
 
 func TestReadPacket(t *testing.T) {
 	const (
-		id     = 42
-		handle = "somehandle"
-		offset = 0x123456789ABCDEF0
-		length = 0xFEDCBA98
+		id            = 42
+		handle        = "somehandle"
+		offset uint64 = 0x123456789ABCDEF0
+		length uint32 = 0xFEDCBA98
 	)
 
 	p := &ReadPacket{
@@ -103,9 +103,9 @@ var _ Packet = &WritePacket{}
 
 func TestWritePacket(t *testing.T) {
 	const (
-		id     = 42
-		handle = "somehandle"
-		offset = 0x123456789ABCDEF0
+		id            = 42
+		handle        = "somehandle"
+		offset uint64 = 0x123456789ABCDEF0
 	)
 
 	var payload = []byte(`foobar`)

--- a/internal/encoding/ssh/filexfer/open_packets_test.go
+++ b/internal/encoding/ssh/filexfer/open_packets_test.go
@@ -9,9 +9,9 @@ var _ Packet = &OpenPacket{}
 
 func TestOpenPacket(t *testing.T) {
 	const (
-		id       = 42
-		filename = "/foo"
-		perms    = 0x87654321
+		id                = 42
+		filename          = "/foo"
+		perms    FileMode = 0x87654321
 	)
 
 	p := &OpenPacket{

--- a/internal/encoding/ssh/filexfer/path_packets_test.go
+++ b/internal/encoding/ssh/filexfer/path_packets_test.go
@@ -49,9 +49,9 @@ var _ Packet = &SetstatPacket{}
 
 func TestSetstatPacket(t *testing.T) {
 	const (
-		id    = 42
-		path  = "/foo"
-		perms = 0x87654321
+		id             = 42
+		path           = "/foo"
+		perms FileMode = 0x87654321
 	)
 
 	p := &SetstatPacket{
@@ -144,9 +144,9 @@ var _ Packet = &MkdirPacket{}
 
 func TestMkdirPacket(t *testing.T) {
 	const (
-		id    = 42
-		path  = "/foo"
-		perms = 0x87654321
+		id             = 42
+		path           = "/foo"
+		perms FileMode = 0x87654321
 	)
 
 	p := &MkdirPacket{

--- a/internal/encoding/ssh/filexfer/response_packets_test.go
+++ b/internal/encoding/ssh/filexfer/response_packets_test.go
@@ -166,10 +166,10 @@ var _ Packet = &NamePacket{}
 
 func TestNamePacket(t *testing.T) {
 	const (
-		id       = 42
-		filename = "foo"
-		longname = "bar"
-		perms    = 0x87654300
+		id                = 42
+		filename          = "foo"
+		longname          = "bar"
+		perms    FileMode = 0x87654300
 	)
 
 	p := &NamePacket{
@@ -241,7 +241,7 @@ func TestNamePacket(t *testing.T) {
 			t.Errorf("UnmarshalBinary(): Entries[%d].Attrs.Flags was %#x, but expected %#x", i, got, want)
 		}
 
-		if got, want := e.Attrs.Permissions, FileMode(perms|(i+1)); got != want {
+		if got, want := e.Attrs.Permissions, perms|FileMode(i+1); got != want {
 			t.Errorf("UnmarshalBinary(): Entries[%d].Attrs.Permissions was %#v, but expected %#v", i, got, want)
 		}
 	}
@@ -251,8 +251,8 @@ var _ Packet = &AttrsPacket{}
 
 func TestAttrsPacket(t *testing.T) {
 	const (
-		id    = 42
-		perms = 0x87654321
+		id             = 42
+		perms FileMode = 0x87654321
 	)
 
 	p := &AttrsPacket{


### PR DESCRIPTION
Fixes issue #469 

For 32-bit architectures, some of the constants being used in `filexfer` package are overflowing the implicit `int` type when passed into `fmt.Errorf(…)` lines.