### PR TITLE
Translate EACCES to PERMISSION_DENIED.

### DIFF
--- a/stat_posix.go
+++ b/stat_posix.go
@@ -1,3 +1,4 @@
+//go:build !plan9
 // +build !plan9
 
 package sftp
@@ -23,7 +24,7 @@ func translateErrno(errno syscall.Errno) uint32 {
 		return sshFxOk
 	case syscall.ENOENT:
 		return sshFxNoSuchFile
-	case syscall.EPERM:
+	case syscall.EACCES, syscall.EPERM:
 		return sshFxPermissionDenied
 	}
 


### PR DESCRIPTION
This is returned by (POSIX) open(2) if there is a permission issue,
e.g. opening a read-only file for writing.