### PR TITLE
Add Client.OpenFileWithMode

### DIFF
--- a/client.go
+++ b/client.go
@@ -239,16 +239,17 @@ func NewClientPipe(rd io.Reader, wr io.WriteCloser, opts ...ClientOption) (*Clie
 	return sftp, nil
 }
 
-// Create creates the named file mode 0666 (before umask), truncating it if it
-// already exists. If successful, methods on the returned File can be used for
-// I/O; the associated file descriptor has mode O_RDWR. If you need more
-// control over the flags/mode used to open the file see client.OpenFile.
+// Create creates the named file mode 0666 (before remote umask), truncating it
+// if it already exists. If successful, methods on the returned File can be used
+// for I/O; the associated file descriptor has mode O_RDWR. If you need more
+// control over the flags/mode used to open the file, see
+// client.OpenFileWithMode.
 //
 // Note that some SFTP servers (eg. AWS Transfer) do not support opening files
 // read/write at the same time. For those services you will need to use
 // `client.OpenFile(os.O_WRONLY|os.O_CREATE|os.O_TRUNC)`.
 func (c *Client) Create(path string) (*File, error) {
-	return c.open(path, flags(os.O_RDWR|os.O_CREATE|os.O_TRUNC))
+	return c.open(path, flags(os.O_RDWR|os.O_CREATE|os.O_TRUNC), 0, 0)
 }
 
 const sftpProtocolVersion = 3 // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-02
@@ -567,22 +568,36 @@ func (c *Client) Truncate(path string, size int64) error {
 // returned file can be used for reading; the associated file descriptor
 // has mode O_RDONLY.
 func (c *Client) Open(path string) (*File, error) {
-	return c.open(path, flags(os.O_RDONLY))
+	return c.open(path, flags(os.O_RDONLY), 0, 0)
 }
 
-// OpenFile is the generalized open call; most users will use Open or
-// Create instead. It opens the named file with specified flag (O_RDONLY
-// etc.). If successful, methods on the returned File can be used for I/O.
+// OpenFile is equivalent to OpenFileWithMode, but with file permissions for
+// newly created files determined by the remote server.
 func (c *Client) OpenFile(path string, f int) (*File, error) {
-	return c.open(path, flags(f))
+	return c.open(path, flags(f), 0, 0)
 }
 
-func (c *Client) open(path string, pflags uint32) (*File, error) {
+// OpenFileWithMode opens a file. The flag set f consists of open flags from
+// the os package, os.O_RDONLY, os.O_RDWR, etc. If it includes the flag
+// os.O_CREATE, the initial file permissions are set to perm.
+//
+// Creating a file with OpenFileWithMode is equivalent to creating it with
+// OpenFile followed by Chmod, but without leaving open a window in which
+// the remote file has the wrong permissions.
+//
+// See Client.Chmod for details on how perm is handled.
+func (c *Client) OpenFileWithMode(path string, f int, perm os.FileMode) (*File, error) {
+	return c.open(path, flags(f), sshFileXferAttrPermissions, perm)
+}
+
+func (c *Client) open(path string, pflags, flags uint32, perm os.FileMode) (*File, error) {
 	id := c.nextID()
 	typ, data, err := c.sendPacket(nil, &sshFxpOpenPacket{
 		ID:     id,
 		Path:   path,
 		Pflags: pflags,
+		Flags:  flags,
+		Perm:   toChmodPerm(perm),
 	})
 	if err != nil {
 		return nil, err

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -567,6 +567,37 @@ func TestClientFileStat(t *testing.T) {
 	}
 }
 
+func TestClientOpenFileWithMode(t *testing.T) {
+	t.Skipf("skipping with -testserver")
+
+	sftp, cmd := testClient(t, READWRITE, NODELAY)
+	defer cmd.Wait()
+	defer sftp.Close()
+
+	d, err := ioutil.TempDir("", "sftptest-openfilemode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(d)
+
+	filename := filepath.Join(d, "foo")
+	f, err := sftp.OpenFileWithMode(filename, os.O_RDWR|os.O_CREATE|os.O_EXCL,
+		0) // Mode 0 works with every umask.
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	info, err := os.Stat(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if mode := info.Mode(); mode != 0 {
+		t.Error("wanted mode 0, got", mode)
+	}
+}
+
 func TestClientStatLink(t *testing.T) {
 	skipIfWindows(t) // Windows does not support links.
 


### PR DESCRIPTION
This allows creating a file with specific permissions. Fixes #335.

The name of the new method is the one suggested by @puellanivis over at #335.

It's tempting to immediately declare `os.OpenFile` deprecated, but there may be a reason to keep it indefinitely: the protocol apparently allows opening a file with or without a mode, letting the server determine the mode in the former case.