### PR TITLE
Fix missing io.EOF when concurency is disabled #489

### DIFF
--- a/client.go
+++ b/client.go
@@ -999,9 +999,6 @@ func (f *File) readAtSequential(b []byte, off int64) (read int, err error) {
 			read += n
 		}
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return read, nil // return nil explicitly.
-			}
 			return read, err
 		}
 	}

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -1203,7 +1203,7 @@ func TestClientReadSequential(t *testing.T) {
 
 		stuff := make([]byte, 32)
 		n, err := sftpFile.Read(stuff)
-		require.NoError(t, err)
+		require.ErrorIs(t, err, io.EOF)
 		require.Equal(t, len(content), n)
 		require.Equal(t, content, stuff[0:len(content)])
 


### PR DESCRIPTION
Removed suppression of io.EOF in readAtSequential and updated tests