### PR TITLE
[bug] Write error not returned if reader already signals EOF

### DIFF
--- a/client.go
+++ b/client.go
@@ -1176,11 +1176,13 @@ func (f *File) writeToSequential(w io.Writer) (written int64, err error) {
 		if n > 0 {
 			f.offset += int64(n)
 
-			m, err2 := w.Write(b[:n])
+			m, wErr := w.Write(b[:n])
 			written += int64(m)
 
-			if err == nil {
-				err = err2
+			if wErr != nil {
+				if err == nil || err == io.EOF {
+					err = wErr
+				}
 			}
 		}
 

--- a/client.go
+++ b/client.go
@@ -1180,9 +1180,7 @@ func (f *File) writeToSequential(w io.Writer) (written int64, err error) {
 			written += int64(m)
 
 			if wErr != nil {
-				if err == nil || err == io.EOF {
-					err = wErr
-				}
+				return written, wErr
 			}
 		}
 


### PR DESCRIPTION
During the last chunk of a sequential write, when the reader already returned `io.EOF`, if the writer fails, the error is lost.

This happens due to `err` being already `io.EOF` so the condition to overwrite the error with the write error is false
```go
if err == nil { // write error lost if err == io.EOF
    err = err2
}
```

I've provided a new test, not sure if it could be tested as a test case on another one though.