### PR TITLE
request server: add WithStartDirectory option

### DIFF
--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -90,6 +90,8 @@ type LstatFileLister interface {
 // We use "/" as start directory for relative paths, implementing this
 // interface you can customize the start directory.
 // You have to return an absolute POSIX path.
+//
+// Deprecated: if you want to set a start directory use WithStartDirectory RequestServerOption instead.
 type RealPathFileLister interface {
 	FileLister
 	RealPath(string) string

--- a/request-server.go
+++ b/request-server.go
@@ -27,6 +27,8 @@ type RequestServer struct {
 	*serverConn
 	pktMgr *packetManager
 
+	startDirectory string
+
 	mu           sync.RWMutex
 	handleCount  int
 	openRequests map[string]*Request
@@ -47,6 +49,14 @@ func WithRSAllocator() RequestServerOption {
 	}
 }
 
+// WithStartDirectory sets a start directory to use as base for relative paths.
+// If unset the default is "/"
+func WithStartDirectory(startDirectory string) RequestServerOption {
+	return func(rs *RequestServer) {
+		rs.startDirectory = cleanPath(startDirectory)
+	}
+}
+
 // NewRequestServer creates/allocates/returns new RequestServer.
 // Normally there will be one server per user-session.
 func NewRequestServer(rwc io.ReadWriteCloser, h Handlers, options ...RequestServerOption) *RequestServer {
@@ -61,6 +71,8 @@ func NewRequestServer(rwc io.ReadWriteCloser, h Handlers, options ...RequestServ
 
 		serverConn: svrConn,
 		pktMgr:     newPktMgr(svrConn),
+
+		startDirectory: "/",
 
 		openRequests: make(map[string]*Request),
 	}
@@ -210,11 +222,11 @@ func (rs *RequestServer) packetWorker(ctx context.Context, pktChan chan orderedR
 			if realPather, ok := rs.Handlers.FileList.(RealPathFileLister); ok {
 				realPath = realPather.RealPath(pkt.getPath())
 			} else {
-				realPath = cleanPath(pkt.getPath())
+				realPath = cleanPathWithBase(rs.startDirectory, pkt.getPath())
 			}
 			rpkt = cleanPacketPath(pkt, realPath)
 		case *sshFxpOpendirPacket:
-			request := requestFromPacket(ctx, pkt)
+			request := requestFromPacket(ctx, pkt, rs.startDirectory)
 			handle := rs.nextRequest(request)
 			rpkt = request.opendir(rs.Handlers, pkt)
 			if _, ok := rpkt.(*sshFxpHandlePacket); !ok {
@@ -222,7 +234,7 @@ func (rs *RequestServer) packetWorker(ctx context.Context, pktChan chan orderedR
 				rs.closeRequest(handle)
 			}
 		case *sshFxpOpenPacket:
-			request := requestFromPacket(ctx, pkt)
+			request := requestFromPacket(ctx, pkt, rs.startDirectory)
 			handle := rs.nextRequest(request)
 			rpkt = request.open(rs.Handlers, pkt)
 			if _, ok := rpkt.(*sshFxpHandlePacket); !ok {
@@ -235,7 +247,10 @@ func (rs *RequestServer) packetWorker(ctx context.Context, pktChan chan orderedR
 			if !ok {
 				rpkt = statusFromError(pkt.ID, EBADF)
 			} else {
-				request = NewRequest("Stat", request.Filepath)
+				request = &Request{
+					Method:   "Stat",
+					Filepath: cleanPathWithBase(rs.startDirectory, request.Filepath),
+				}
 				rpkt = request.call(rs.Handlers, pkt, rs.pktMgr.alloc, orderID)
 			}
 		case *sshFxpFsetstatPacket:
@@ -244,15 +259,24 @@ func (rs *RequestServer) packetWorker(ctx context.Context, pktChan chan orderedR
 			if !ok {
 				rpkt = statusFromError(pkt.ID, EBADF)
 			} else {
-				request = NewRequest("Setstat", request.Filepath)
+				request = &Request{
+					Method:   "Setstat",
+					Filepath: cleanPathWithBase(rs.startDirectory, request.Filepath),
+				}
 				rpkt = request.call(rs.Handlers, pkt, rs.pktMgr.alloc, orderID)
 			}
 		case *sshFxpExtendedPacketPosixRename:
-			request := NewRequest("PosixRename", pkt.Oldpath)
-			request.Target = pkt.Newpath
+			request := &Request{
+				Method:   "PosixRename",
+				Filepath: cleanPathWithBase(rs.startDirectory, pkt.Oldpath),
+				Target:   cleanPathWithBase(rs.startDirectory, pkt.Newpath),
+			}
 			rpkt = request.call(rs.Handlers, pkt, rs.pktMgr.alloc, orderID)
 		case *sshFxpExtendedPacketStatVFS:
-			request := NewRequest("StatVFS", pkt.Path)
+			request := &Request{
+				Method:   "StatVFS",
+				Filepath: cleanPathWithBase(rs.startDirectory, pkt.Path),
+			}
 			rpkt = request.call(rs.Handlers, pkt, rs.pktMgr.alloc, orderID)
 		case hasHandle:
 			handle := pkt.getHandle()
@@ -263,7 +287,7 @@ func (rs *RequestServer) packetWorker(ctx context.Context, pktChan chan orderedR
 				rpkt = request.call(rs.Handlers, pkt, rs.pktMgr.alloc, orderID)
 			}
 		case hasPath:
-			request := requestFromPacket(ctx, pkt)
+			request := requestFromPacket(ctx, pkt, rs.startDirectory)
 			rpkt = request.call(rs.Handlers, pkt, rs.pktMgr.alloc, orderID)
 			request.close()
 		default:


### PR DESCRIPTION
Alternative approach to support a start directory.

I tested #497 and it works fine but I don't like that pkg/sftp clean the path and I have to clean the raw path again in my code.

This approach seems cleaner and the `RealPathFileLister` is useless if we go this way, we can remove this interface.

The only drawback is that [NewRequest](https://github.com/pkg/sftp/blob/aa9a37d6394f61dbcfadf3478acf028a4f39b866/request.go#L147) now requires an already cleaned path. Prior to this patch the path passed to NewRequest was converted to an absolute UNIX path using `/` as base. I'll try to fix this compatibility issue later

