### PR TITLE
writeToSequential: improve tests for write errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -1176,11 +1176,13 @@ func (f *File) writeToSequential(w io.Writer) (written int64, err error) {
 		if n > 0 {
 			f.offset += int64(n)
 
-			m, err2 := w.Write(b[:n])
+			m, wErr := w.Write(b[:n])
 			written += int64(m)
 
-			if err == nil {
-				err = err2
+			if wErr != nil {
+				if err == nil || err == io.EOF {
+					err = wErr
+				}
 			}
 		}
 

--- a/client.go
+++ b/client.go
@@ -1176,11 +1176,11 @@ func (f *File) writeToSequential(w io.Writer) (written int64, err error) {
 		if n > 0 {
 			f.offset += int64(n)
 
-			m, wErr := w.Write(b[:n])
+			m, err := w.Write(b[:n])
 			written += int64(m)
 
-			if wErr != nil {
-				return written, wErr
+			if err != nil {
+				return written, err
 			}
 		}
 

--- a/client.go
+++ b/client.go
@@ -1180,9 +1180,7 @@ func (f *File) writeToSequential(w io.Writer) (written int64, err error) {
 			written += int64(m)
 
 			if wErr != nil {
-				if err == nil || err == io.EOF {
-					err = wErr
-				}
+				return written, wErr
 			}
 		}
 


### PR DESCRIPTION
I tryed to improve test cases for write errors as requested in #494

Of course I kept the author for the original commits