### PR TITLE
More context for EOF during client setup

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -226,15 +227,22 @@ func NewClientPipe(rd io.Reader, wr io.WriteCloser, opts ...ClientOption) (*Clie
 
 	if err := sftp.sendInit(); err != nil {
 		wr.Close()
-		return nil, err
+		return nil, fmt.Errorf("error sending init packet to server: %w", err)
 	}
+
 	if err := sftp.recvVersion(); err != nil {
 		wr.Close()
-		return nil, err
+		return nil, fmt.Errorf("error receiving version packet from server: %w", err)
 	}
 
 	sftp.clientConn.wg.Add(1)
-	go sftp.loop()
+	go func() {
+		defer sftp.clientConn.wg.Done()
+
+		if err := sftp.clientConn.recv(); err != nil {
+			sftp.clientConn.broadcastErr(err)
+		}
+	}()
 
 	return sftp, nil
 }
@@ -267,8 +275,13 @@ func (c *Client) nextID() uint32 {
 func (c *Client) recvVersion() error {
 	typ, data, err := c.recvPacket(0)
 	if err != nil {
+		if err == io.EOF {
+			return io.ErrUnexpectedEOF
+		}
+
 		return err
 	}
+
 	if typ != sshFxpVersion {
 		return &unexpectedPacketErr{sshFxpVersion, typ}
 	}
@@ -277,6 +290,7 @@ func (c *Client) recvVersion() error {
 	if err != nil {
 		return err
 	}
+
 	if version != sftpProtocolVersion {
 		return &unexpectedVersionErr{sftpProtocolVersion, version}
 	}

--- a/client.go
+++ b/client.go
@@ -276,7 +276,7 @@ func (c *Client) recvVersion() error {
 	typ, data, err := c.recvPacket(0)
 	if err != nil {
 		if err == io.EOF {
-			return io.ErrUnexpectedEOF
+			return fmt.Errorf("server unexpectedly closed connection: %w", io.ErrUnexpectedEOF)
 		}
 
 		return err

--- a/conn.go
+++ b/conn.go
@@ -61,14 +61,6 @@ func (c *clientConn) Close() error {
 	return c.conn.Close()
 }
 
-func (c *clientConn) loop() {
-	defer c.wg.Done()
-	err := c.recv()
-	if err != nil {
-		c.broadcastErr(err)
-	}
-}
-
 // recv continuously reads from the server and forwards responses to the
 // appropriate channel.
 func (c *clientConn) recv() error {


### PR DESCRIPTION
Addresses concerns raised from #506 where a bare EOF was being returned, and thus being quite unclear about where the EOF happened.

This adds more context to the returned errors, and replaces `EOF` with `UnexpectedEOF` since we definitely aren’t expecting one.

However, I’m thinking a better message should be returned than even unexpected EOF. I’ll be digging through documentation to see what the best option here is.