### PR TITLE
Document the weirdness of the reversal of arguments to SSH_FXP_SYMLINK

### DIFF
--- a/internal/encoding/ssh/filexfer/path_packets.go
+++ b/internal/encoding/ssh/filexfer/path_packets.go
@@ -323,7 +323,7 @@ func (p *ReadLinkPacket) UnmarshalPacketBody(buf *Buffer) (err error) {
 //
 // The order of the arguments to the SSH_FXP_SYMLINK method was inadvertently reversed.
 // Unfortunately, the reversal was not noticed until the server was widely deployed.
-// Covered in Section 3.1 of https://github.com/openssh/openssh-portable/blob/master/PROTOCOL
+// Covered in Section 4.1 of https://github.com/openssh/openssh-portable/blob/master/PROTOCOL
 type SymlinkPacket struct {
 	LinkPath   string
 	TargetPath string

--- a/packet.go
+++ b/packet.go
@@ -522,7 +522,12 @@ func (p *sshFxpRmdirPacket) UnmarshalBinary(b []byte) error {
 }
 
 type sshFxpSymlinkPacket struct {
-	ID         uint32
+	ID uint32
+
+	// The order of the arguments to the SSH_FXP_SYMLINK method was inadvertently reversed.
+	// Unfortunately, the reversal was not noticed until the server was widely deployed.
+	// Covered in Section 4.1 of https://github.com/openssh/openssh-portable/blob/master/PROTOCOL
+
 	Targetpath string
 	Linkpath   string
 }


### PR DESCRIPTION
The reversal of arguments was documented in the `encoding/ssh/filexfer.SymlinkPacket` but had an unnoticed bug (odd coincidences) that pointed people to section 3.1 not 4.1.

The full comment with fix has been also brought into the `sshFxpSymlinkPacket` body to document also there why the arguments are reversed.