### PR TITLE
Stop ReadFromWithConcurrency sending more data than it needs to

### DIFF
--- a/client.go
+++ b/client.go
@@ -1674,7 +1674,7 @@ func (f *File) ReadFromWithConcurrency(r io.Reader, concurrency int) (read int64
 					Handle: f.handle,
 					Offset: uint64(off),
 					Length: uint32(n),
-					Data:   b,
+					Data:   b[:n],
 				})
 
 				select {


### PR DESCRIPTION
It was discovered that the ReadFrom method for uploading files in
pkg/sftp was sending more data than it needed to.

This was tracked down to the ReadFromWithConcurrency method forgetting
to truncate the packets it was sending to the size Read.

This was giving the remote server more work to do as it was writing
and re-writing parts of a file.

See: https://github.com/rclone/rclone/issues/6763
