### PR TITLE
Client connection recv() waitgroup fix

### DIFF
--- a/client.go
+++ b/client.go
@@ -244,6 +244,8 @@ func NewClientPipe(rd io.Reader, wr io.WriteCloser, opts ...ClientOption) (*Clie
 		}
 	}()
 
+  sftp.clientConn.wg.Wait() // Wait for go routine to complete recv() call
+
 	return sftp, nil
 }
 


### PR DESCRIPTION
In GoRoutine Client is calling  sftp.clientConn.recv() call at line 242 and Wait group is incremented by one before go routine starts at line 238 but main thread is not waiting for go routine to complete the recv() api call and eventually returning at line 247.