### PR TITLE
Export RemoveFile method

### DIFF
--- a/client.go
+++ b/client.go
@@ -728,7 +728,7 @@ func (c *Client) Join(elem ...string) string { return path.Join(elem...) }
 // file or directory with the specified path exists, or if the specified directory
 // is not empty.
 func (c *Client) Remove(path string) error {
-	err := c.removeFile(path)
+	err := c.RemoveFile(path)
 	// some servers, *cough* osx *cough*, return EPERM, not ENODIR.
 	// serv-u returns ssh_FX_FILE_IS_A_DIRECTORY
 	// EPERM is converted to os.ErrPermission so it is not a StatusError
@@ -744,7 +744,7 @@ func (c *Client) Remove(path string) error {
 	return err
 }
 
-func (c *Client) removeFile(path string) error {
+func (c *Client) RemoveFile(path string) error {
 	id := c.nextID()
 	typ, data, err := c.sendPacket(nil, &sshFxpRemovePacket{
 		ID:       id,

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -689,6 +689,45 @@ func TestClientRemoveFailed(t *testing.T) {
 	}
 }
 
+func TestClientRemoveFile(t *testing.T) {
+	sftp, cmd := testClient(t, READWRITE, NODELAY)
+	defer cmd.Wait()
+	defer sftp.Close()
+
+	f, err := ioutil.TempFile("", "sftptest-remove")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.Close()
+
+	if err := sftp.RemoveFile(f.Name()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(f.Name()); !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+}
+
+func TestClientRemoveFileFailed(t *testing.T) {
+	sftp, cmd := testClient(t, READONLY, NODELAY)
+	defer cmd.Wait()
+	defer sftp.Close()
+
+	f, err := ioutil.TempFile("", "sftptest-removefailed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	if err := sftp.RemoveFile(f.Name()); err == nil {
+		t.Fatalf("Remove(%v): want: permission denied, got %v", f.Name(), err)
+	}
+	if _, err := os.Lstat(f.Name()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestClientRename(t *testing.T) {
 	sftp, cmd := testClient(t, READWRITE, NODELAY)
 	defer cmd.Wait()


### PR DESCRIPTION
This tries to address partially similar to issue #468 in our case.

In the same way we have the `RemoveDirectory` method as an exported method, we put the decision in the hands of the developer of which one to choose.

What do you think?