### PR TITLE
Marshal extended data if file info supports it

### DIFF
--- a/attrs.go
+++ b/attrs.go
@@ -69,6 +69,20 @@ func fileInfoFromStat(stat *FileStat, name string) os.FileInfo {
 	}
 }
 
+// FileInfoUidGid extends os.FileInfo and adds callbacks for Uid and Gid retrieval,
+// as an alternative to *syscall.Stat_t objects on unix systems.
+type FileInfoUidGid interface {
+	os.FileInfo
+	Uid() uint32
+	Gid() uint32
+}
+
+// FileInfoUidGid extends os.FileInfo and adds a callbacks for extended data retrieval.
+type FileInfoExtendedData interface {
+	os.FileInfo
+	Extended() []StatExtended
+}
+
 func fileStatFromInfo(fi os.FileInfo) (uint32, *FileStat) {
 	mtime := fi.ModTime().Unix()
 	atime := mtime
@@ -85,6 +99,23 @@ func fileStatFromInfo(fi os.FileInfo) (uint32, *FileStat) {
 
 	// os specific file stat decoding
 	fileStatFromInfoOs(fi, &flags, fileStat)
+
+	// The call above will include the sshFileXferAttrUIDGID in case
+	// the os.FileInfo can be casted to *syscall.Stat_t on unix.
+	// If fi implements FileInfoUidGid, retrieve Uid, Gid from it instead.
+	if fiExt, ok := fi.(FileInfoUidGid); ok {
+		flags |= sshFileXferAttrUIDGID
+		fileStat.UID = fiExt.Uid()
+		fileStat.GID = fiExt.Gid()
+	}
+
+	// if fi implements FileInfoExtendedData, retrieve extended data from it
+	if fiExt, ok := fi.(FileInfoExtendedData); ok {
+		fileStat.Extended = fiExt.Extended()
+		if len(fileStat.Extended) > 0 {
+			flags |= sshFileXferAttrExtended
+		}
+	}
 
 	return flags, fileStat
 }

--- a/ls_formatting.go
+++ b/ls_formatting.go
@@ -60,6 +60,13 @@ func runLs(idLookup NameLookupFileLister, dirent os.FileInfo) string {
 		uid = lsFormatID(sys.UID)
 		gid = lsFormatID(sys.GID)
 	default:
+		if fiExt, ok := dirent.(FileInfoUidGid); ok {
+			uid = lsFormatID(fiExt.Uid())
+			gid = lsFormatID(fiExt.Gid())
+
+			break
+		}
+
 		numLinks, uid, gid = lsLinksUIDGID(dirent)
 	}
 

--- a/packet.go
+++ b/packet.go
@@ -71,6 +71,15 @@ func marshalFileInfo(b []byte, fi os.FileInfo) []byte {
 		b = marshalUint32(b, fileStat.Mtime)
 	}
 
+	if flags&sshFileXferAttrExtended != 0 {
+		b = marshalUint32(b, uint32(len(fileStat.Extended)))
+
+		for _, attr := range fileStat.Extended {
+			b = marshalString(b, attr.ExtType)
+			b = marshalString(b, attr.ExtData)
+		}
+	}
+
 	return b
 }
 


### PR DESCRIPTION
If the file information returned by ListAt supports the FileInfoExtendedData interface, use it to retrieve extended data and pass it back to the client. In similar fashion, we add the FileInfoUidGid interface to allow for implementations to return uid and gid data, even if the os lacks support in syscall.Stat_t.