### PR TITLE
fix: add support for attrs in `sshFxpOpenPacket` for `Server`

### DIFF
--- a/packet_test.go
+++ b/packet_test.go
@@ -388,6 +388,24 @@ func TestSendPacket(t *testing.T) {
 			},
 		},
 		{
+			packet: &sshFxpOpenPacket{
+				ID:     3,
+				Path:   "/foo",
+				Pflags: flags(os.O_WRONLY | os.O_CREATE | os.O_TRUNC),
+				Flags:  sshFileXferAttrPermissions,
+				Attrs:  []uint8{0x0, 0x0, 0x1, 0xed}, // 0o755
+			},
+			want: []byte{
+				0x0, 0x0, 0x0, 0x19,
+				0x3,
+				0x0, 0x0, 0x0, 0x3,
+				0x0, 0x0, 0x0, 0x4, '/', 'f', 'o', 'o',
+				0x0, 0x0, 0x0, 0x1a,
+				0x0, 0x0, 0x0, 0x4,
+				0x0, 0x0, 0x1, 0xed,
+			},
+		},
+		{
 			packet: &sshFxpWritePacket{
 				ID:     124,
 				Handle: "foo",

--- a/request-attrs.go
+++ b/request-attrs.go
@@ -52,7 +52,7 @@ func (r *Request) AttrFlags() FileAttrFlags {
 
 // FileMode returns the Mode SFTP file attributes wrapped as os.FileMode
 func (a FileStat) FileMode() os.FileMode {
-	return os.FileMode(a.Mode)
+	return toFileMode(a.Mode)
 }
 
 // Attributes parses file attributes byte blob and return them in a

--- a/server.go
+++ b/server.go
@@ -467,7 +467,7 @@ func (p *sshFxpOpenPacket) respond(svr *Server) responsePacket {
 	// being created. Otherwise, the permissions are ignored.
 	if b, ok := p.Attrs.([]byte); ok && (p.Flags&sshFileXferAttrPermissions) != 0 {
 		fs, _ := unmarshalFileStat(p.Flags, b)
-		mode = os.FileMode(fs.Mode)
+		mode = toFileMode(fs.Mode)
 	}
 
 	name := svr.toLocalPath(p.Path)
@@ -536,7 +536,7 @@ func (p *sshFxpSetstatPacket) respond(svr *Server) responsePacket {
 	if (p.Flags & sshFileXferAttrPermissions) != 0 {
 		var mode uint32
 		if mode, b, err = unmarshalUint32Safe(b); err == nil {
-			err = os.Chmod(p.Path, os.FileMode(mode))
+			err = os.Chmod(p.Path, toFileMode(mode))
 		}
 	}
 	if err != nil {
@@ -591,7 +591,7 @@ func (p *sshFxpFsetstatPacket) respond(svr *Server) responsePacket {
 	if (p.Flags & sshFileXferAttrPermissions) != 0 {
 		var mode uint32
 		if mode, b, err = unmarshalUint32Safe(b); err == nil {
-			err = f.Chmod(os.FileMode(mode))
+			err = f.Chmod(toFileMode(mode))
 		}
 	}
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -462,83 +462,18 @@ func (p *sshFxpOpenPacket) respond(svr *Server) responsePacket {
 		osFlags |= os.O_EXCL
 	}
 
-	name := svr.toLocalPath(p.Path)
 	mode := os.FileMode(0o644)
-
-	var applyAttrs []func(*os.File) error
-
-	// Both `sshFileXferAttrPermissions` and `sshFileXferAttrACmodTime` are set
-	// by e.g. `sftp`. Just in case, we handle all other cases as well.
-	// Only apply for newly created files.
-	var err error
-	useAttrs := true
-	if _, err := os.Stat(name); err == nil {
-		useAttrs = false
-	}
-	if b, ok := p.Attrs.([]byte); useAttrs && ok {
-		if (p.Flags & sshFileXferAttrSize) != 0 {
-			var size uint64
-			if size, b, err = unmarshalUint64Safe(b); err == nil {
-				applyAttrs = append(applyAttrs, func(f *os.File) error {
-					return f.Truncate(int64(size))
-				})
-			}
-		}
-		if err != nil {
-			return statusFromError(p.ID, err)
-		}
-		if (p.Flags & sshFileXferAttrUIDGID) != 0 {
-			var uid uint32
-			var gid uint32
-			if uid, b, err = unmarshalUint32Safe(b); err != nil {
-			} else if gid, b, err = unmarshalUint32Safe(b); err != nil {
-			} else {
-				applyAttrs = append(applyAttrs, func(f *os.File) error {
-					return f.Chown(int(uid), int(gid))
-				})
-			}
-		}
-		if err != nil {
-			return statusFromError(p.ID, err)
-		}
-		if (p.Flags & sshFileXferAttrPermissions) != 0 {
-			var attrMode uint32
-			if attrMode, b, err = unmarshalUint32Safe(b); err == nil {
-				// Optionally, we could apply umask here.
-				mode = os.FileMode(attrMode)
-			}
-		}
-		if err != nil {
-			return statusFromError(p.ID, err)
-		}
-		if (p.Flags & sshFileXferAttrACmodTime) != 0 {
-			var atime uint32
-			var mtime uint32
-			if atime, b, err = unmarshalUint32Safe(b); err != nil {
-			} else if mtime, _, err = unmarshalUint32Safe(b); err != nil {
-			} else {
-				atimeT := time.Unix(int64(atime), 0)
-				mtimeT := time.Unix(int64(mtime), 0)
-				applyAttrs = append(applyAttrs, func(f *os.File) error {
-					return os.Chtimes(f.Name(), atimeT, mtimeT)
-				})
-			}
-		}
-		if err != nil {
-			return statusFromError(p.ID, err)
-		}
+	// Like OpenSSH, we only handle permissions here if the file is
+	// being created. Otherwise, the permissions are ignored.
+	if b, ok := p.Attrs.([]byte); ok && (p.Flags&sshFileXferAttrPermissions) != 0 {
+		fs, _ := unmarshalFileStat(p.Flags, b)
+		mode = os.FileMode(fs.Mode)
 	}
 
+	name := svr.toLocalPath(p.Path)
 	f, err := os.OpenFile(name, osFlags, mode)
 	if err != nil {
 		return statusFromError(p.ID, err)
-	}
-
-	for _, applyAttr := range applyAttrs {
-		if err := applyAttr(f); err != nil {
-			_ = f.Close()
-			return statusFromError(p.ID, err)
-		}
 	}
 
 	handle := svr.nextHandle(f)


### PR DESCRIPTION
Sending permissions (chmod) and atime/mtime is not uncommon for sftp clients via the `sshFxpOpenPacket`, however, flags/attrs seems to have been explicitly ignored even though they're part of the RFC (https://filezilla-project.org/specs/draft-ietf-secsh-filexfer-02.txt).

This leads to issues like https://github.com/mutagen-io/mutagen/issues/459, where the client is relying on the attrs being applied.

This only adds support for the feature in the old `Server` implementation, which is what I used. Further work is most likely required to support it in the `RequestServer` as well (however, I have no experience with that part of the code base). I believe no backwards-incompatible changes were introduced since all we're doing is parsing more of the packet.

A bug was also fixed in `sshFxpSetstatPacket` and `sshFxpFsetstatPacket` where attrs were parsed in the wrong order.