### PR TITLE
add CloserListerAt

### DIFF
--- a/request-interfaces.go
+++ b/request-interfaces.go
@@ -144,6 +144,8 @@ type NameLookupFileLister interface {
 //
 // If a populated entry implements [FileInfoExtendedData], extended attributes will also be returned to the client.
 //
+// The request server code will call Close() on ListerAt if an io.Closer type assertion succeeds.
+//
 // Note in cases of an error, the error text will be sent to the client.
 type ListerAt interface {
 	ListAt([]os.FileInfo, int64) (int, error)

--- a/request-server_test.go
+++ b/request-server_test.go
@@ -793,6 +793,37 @@ func TestRequestReaddir(t *testing.T) {
 	checkRequestServerAllocator(t, p)
 }
 
+type testListerAtCloser struct {
+	isClosed bool
+}
+
+func (l *testListerAtCloser) ListAt([]os.FileInfo, int64) (int, error) {
+	return 0, io.EOF
+}
+
+func (l *testListerAtCloser) Close() error {
+	l.isClosed = true
+	return nil
+}
+
+func TestRequestServerListerAtCloser(t *testing.T) {
+	p := clientRequestServerPair(t)
+	defer p.Close()
+
+	handle, err := p.cli.opendir(context.Background(), "/")
+	require.NoError(t, err)
+	require.Len(t, p.svr.openRequests, 1)
+	req, ok := p.svr.getRequest(handle)
+	require.True(t, ok)
+	listerAt := &testListerAtCloser{}
+	req.setListerAt(listerAt)
+	assert.NotNil(t, req.state.getListerAt())
+	err = p.cli.close(handle)
+	assert.NoError(t, err)
+	require.Len(t, p.svr.openRequests, 0)
+	assert.True(t, listerAt.isClosed)
+}
+
 func TestRequestStatVFS(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("StatVFS is implemented on linux and darwin")


### PR DESCRIPTION
The `ListerAt` is stored in the `Request` state and reused across requests. Some implementations don't store the entire `[]os.FileInfo` buffer in the `ListerAt` implementation but instead return an open file and get/return `[]os.FileInfo` on request. For these implementation a `Close` method is required.

The use case is if you want to list a large directory on memory constrained systems.