### PR TITLE
Add support for z/OS

### DIFF
--- a/attrs_unix.go
+++ b/attrs_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || dragonfly || freebsd || (!android && linux) || netbsd || openbsd || solaris || aix || js
-// +build darwin dragonfly freebsd !android,linux netbsd openbsd solaris aix js
+//go:build darwin || dragonfly || freebsd || (!android && linux) || netbsd || openbsd || solaris || aix || js || zos
+// +build darwin dragonfly freebsd !android,linux netbsd openbsd solaris aix js zos
 
 package sftp
 

--- a/ls_unix.go
+++ b/ls_unix.go
@@ -1,5 +1,5 @@
-//go:build aix || darwin || dragonfly || freebsd || (!android && linux) || netbsd || openbsd || solaris || js
-// +build aix darwin dragonfly freebsd !android,linux netbsd openbsd solaris js
+//go:build aix || darwin || dragonfly || freebsd || (!android && linux) || netbsd || openbsd || solaris || js || zos
+// +build aix darwin dragonfly freebsd !android,linux netbsd openbsd solaris js zos
 
 package sftp
 


### PR DESCRIPTION
From the single report, this does seem to work for z/OS without further changes, and the additional build flags do not break the existing builds.