### PR TITLE
Issue #609 - clarify what 'path contains a regular file' actually means

### DIFF
--- a/client.go
+++ b/client.go
@@ -909,7 +909,7 @@ func (c *Client) Mkdir(path string) error {
 // MkdirAll creates a directory named path, along with any necessary parents,
 // and returns nil, or else returns an error.
 // If path is already a directory, MkdirAll does nothing and returns nil.
-// If path contains a regular file, an error is returned
+// If, while making any directory, that path is found to already be a regular file, an error is returned.
 func (c *Client) MkdirAll(path string) error {
 	// Most of this code mimics https://golang.org/src/os/path.go?s=514:561#L13
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.


### PR DESCRIPTION
The text of the `sftp.Client.MkdirAll` was found to be unclear as to what precisely “path contains a regular file” means. It means that if any path element in the chain of path elements is a regular file, that an error is returned. However, it could be mistakenly interpreted as “if any of the parent directories contains a regular file”. This new language is intended to exclude this possible reading.

Resolves #609 

The dev-v2 branch does not include such language, instead paralleling the `os.MkdirAll` language, which also does not explicitly call out this error condition.