### PR TITLE
Backport v2/Client.Remove and File.Sync

### DIFF
--- a/client.go
+++ b/client.go
@@ -772,9 +772,15 @@ func (c *Client) Remove(path string) error {
 
 	// Both failed: figure out which error to return.
 
-	if errF == errD {
-		// If they are the same error, then just return that.
-		return errF
+	if errF, ok := errF.(*os.PathError); ok {
+		// The only time it makes sense to compare errors, is when both are `*os.PathError`.
+		// We cannot test these directly with errF == errD, as that would be a pointer comparison.
+
+		if errD, ok := errD.(*os.PathError); ok && errors.Is(errF.Err, errD.Err) {
+			// If they are both pointers to PathError,
+			// and the same underlying error, then return that.
+			return errF
+		}
 	}
 
 	fi, err := c.Stat(path)

--- a/client.go
+++ b/client.go
@@ -800,10 +800,14 @@ func (c *Client) removeFile(path string) error {
 	}
 	switch typ {
 	case sshFxpStatus:
-		return &PathError{
+		err = normaliseError(unmarshalStatus(id, data))
+		if err == nil {
+			return nil
+		}
+		return &os.PathError{
 			Op:   "remove",
 			Path: path,
-			Err:  normaliseError(unmarshalStatus(id, data)),
+			Err:  err,
 		}
 	default:
 		return unimplementedPacketErr(typ)
@@ -822,10 +826,14 @@ func (c *Client) RemoveDirectory(path string) error {
 	}
 	switch typ {
 	case sshFxpStatus:
-		return &PathError{
-			Op:   "rmdir",
+		err = normaliseError(unmarshalStatus(id, data))
+		if err == nil {
+			return nil
+		}
+		return &os.PathError{
+			Op:   "remove",
 			Path: path,
-			Err:  normaliseError(unmarshalStatus(id, data)),
+			Err:  err,
 		}
 	default:
 		return unimplementedPacketErr(typ)

--- a/client.go
+++ b/client.go
@@ -2122,6 +2122,13 @@ func (f *File) Sync() error {
 		return os.ErrClosed
 	}
 
+	if data, ok := f.c.HasExtension(openssh.ExtensionFSync().Name); !ok || data != "1" {
+		return &StatusError{
+			Code: sshFxOPUnsupported,
+			msg:  "fsync not supported",
+		}
+	}
+
 	id := f.c.nextID()
 	typ, data, err := f.c.sendPacket(context.Background(), nil, &sshFxpFsyncPacket{
 		ID:     id,

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/kr/fs v0.1.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.31.0
-	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/sys v0.28.0
 )


### PR DESCRIPTION
Three-ish changes:
* `Client.Remove` and `Client.RemoveDirectory` now return a `PathError` (this could be extended wider, but I’m avoiding more scope creep)
* Addresses #468 (finally) by backporting the v2 implementation
* Short-circuits `File.Sync` to return `SSH_FX_OP_UNSUPPORTED` if the server did not announce support (addresses #617)