### PR TITLE
A bit of a refactor, match a similar signature to protobuf opaque API

### DIFF
--- a/client.go
+++ b/client.go
@@ -749,7 +749,7 @@ func (cl *Client) Remove(name string) error {
 
 	// Both failed: figure out which error to return.
 
-	if errF == errD {
+	if errors.Is(errF, errD) {
 		// If they are the same error, then just return that.
 		return wrapPathError("remove", name, errF)
 	}
@@ -761,8 +761,10 @@ func (cl *Client) Remove(name string) error {
 		return wrapPathError("remove", name, err)
 	}
 
-	if perm, ok := attrs.GetPermissions(); ok && perm.IsDir() {
-		return wrapPathError("remove", name, errD)
+	if attrs.HasPermissions() {
+		if perm := attrs.GetPermissions(); perm.IsDir() {
+			return wrapPathError("remove", name, errD)
+		}
 	}
 
 	return wrapPathError("remove", name, errF)

--- a/encoding/ssh/filexfer/attrs.go
+++ b/encoding/ssh/filexfer/attrs.go
@@ -37,131 +37,241 @@ type Attributes struct {
 	MTime uint32
 
 	// AttrExtended
-	ExtendedAttributes []ExtendedAttribute
+	Extended ExtendedAttributes
 }
 
-// GetSize returns the Size field and a bool that is true if and only if the value is valid/defined.
-func (a *Attributes) GetSize() (size uint64, ok bool) {
-	return a.Size, a.Flags&AttrSize != 0
+// GetSize returns the size field.
+// It returns zero if the field is not set.
+func (a *Attributes) GetSize() (size uint64) {
+	if a == nil {
+		return 0
+	}
+
+	return a.Size
 }
 
-// SetSize is a convenience function that sets the Size field,
-// and marks the field as valid/defined in Flags.
+// HasSize returns true if the Attributes has a size defined.
+func (a *Attributes) HasSize() bool {
+	if a == nil {
+		return false
+	}
+
+	return a.Flags&AttrSize != 0
+}
+
+// SetSize sets the size field to a specific value.
 func (a *Attributes) SetSize(size uint64) {
-	a.Flags |= AttrSize
 	a.Size = size
+	a.Flags |= AttrSize
 }
 
-// GetUIDGID returns the UID and GID fields and a bool that is true if and only if the values are valid/defined.
-func (a *Attributes) GetUIDGID() (uid, gid uint32, ok bool) {
-	return a.UID, a.GID, a.Flags&AttrUIDGID != 0
+// ClearSize clears the size field, so that it is no longer set.
+func (a *Attributes) ClearSize() {
+	a.Size = 0
+	a.Flags &^= AttrSize
 }
 
-// SetUIDGID is a convenience function that sets the UID and GID fields,
-// and marks the fields as valid/defined in Flags.
+// GetUIDGID returns the uid and gid field.
+// It returns zeros if the field is not set.
+func (a *Attributes) GetUIDGID() (uid, gid uint32) {
+	if a == nil {
+		return 0, 0
+	}
+
+	return a.UID, a.GID
+}
+
+// HasUIDGID returns true if the uid and gid fields are set.
+func (a *Attributes) HasUIDGID() bool {
+	if a == nil {
+		return false
+	}
+
+	return a.Flags&AttrUIDGID != 0
+}
+
+// SetUIDGID sets the uid and gid fields to specific values.
 func (a *Attributes) SetUIDGID(uid, gid uint32) {
-	a.Flags |= AttrUIDGID
 	a.UID = uid
 	a.GID = gid
+	a.Flags |= AttrUIDGID
 }
 
-// GetPermissions returns the Permissions field and a bool that is true if and only if the value is valid/defined.
-func (a *Attributes) GetPermissions() (perms FileMode, ok bool) {
-	return a.Permissions, a.Flags&AttrPermissions != 0
+// ClearUIDGID clears the uid and gid fields, so that they are no longer set.
+func (a *Attributes) ClearUIDGID() {
+	a.UID = 0
+	a.GID = 0
+	a.Flags &^= AttrUIDGID
 }
 
-// SetPermissions is a convenience function that sets the Permissions field,
-// and marks the field as valid/defined in Flags.
+// GetPermissions returns the permissions field.
+// It returns zero if the field is not set.
+func (a *Attributes) GetPermissions() FileMode {
+	if a == nil {
+		return 0
+	}
+
+	return a.Permissions
+}
+
+// HasPermissions returns true if the permissions field is set.
+func (a *Attributes) HasPermissions() bool {
+	if a == nil {
+		return false
+	}
+
+	return a.Flags&AttrPermissions != 0
+}
+
+// SetPermissions sets the permissions field to a specific value.
 func (a *Attributes) SetPermissions(perms FileMode) {
-	a.Flags |= AttrPermissions
 	a.Permissions = perms
+	a.Flags |= AttrPermissions
 }
 
-// GetACModTime returns the ATime and MTime fields and a bool that is true if and only if the values are valid/defined.
-func (a *Attributes) GetACModTime() (atime, mtime uint32, ok bool) {
-	return a.ATime, a.MTime, a.Flags&AttrACModTime != 0
+// ClearPermissions clears the permissions field, so that it is no longer set.
+func (a *Attributes) ClearPermissions() {
+	a.Permissions = 0
+	a.Flags &^= AttrPermissions
 }
 
-// SetACModTime is a convenience function that sets the ATime and MTime fields,
-// and marks the fields as valid/defined in Flags.
+// GetACModTime returns the atime and mtime fields.
+// It returns zeros if the fields are not set.
+func (a *Attributes) GetACModTime() (atime, mtime uint32) {
+	return a.ATime, a.MTime
+}
+
+// HasACModTime returns true if the atime and mtime fields are set.
+func (a *Attributes) HasACModTime() bool {
+	return a.Flags&AttrACModTime != 0
+}
+
+// SetACModTime sets the atime and mtime fields to specific values.
 func (a *Attributes) SetACModTime(atime, mtime uint32) {
-	a.Flags |= AttrACModTime
 	a.ATime = atime
 	a.MTime = mtime
+	a.Flags |= AttrACModTime
 }
 
-// Len returns the number of bytes a would marshal into.
-func (a *Attributes) Len() int {
+// ClearACModTime clears the atime and mtime fields, so that they are no longer set.
+func (a *Attributes) ClearACModTime() {
+	a.ATime = 0
+	a.MTime = 0
+	a.Flags &^= AttrACModTime
+}
+
+// GetExtended returns the extended field.
+// It returns a nil slice if not set.
+func (a *Attributes) GetExtended() ExtendedAttributes {
+	if a == nil {
+		return nil
+	}
+
+	return a.Extended
+}
+
+// GetExtendedAsMap returns the extended field converted into a map[string]string.
+// Since this will deduplicate each key value to the last extended attribute specified and involves extra allocation,
+// it is recommended to use [GetExtended], which returns a rich slice that can be iterated on as if it were a map.
+func (a *Attributes) GetExtendedAsMap() map[string]string {
+	if a == nil {
+		return nil
+	}
+
+	return a.Extended.AsMap()
+}
+
+// HasExtended returns true if the extended field is set.
+func (a *Attributes) HasExtended() bool {
+	if a == nil {
+		return false
+	}
+
+	return a.Flags&AttrExtended != 0
+}
+
+// SetExtended sets the extended field to the specific slice.
+func (a *Attributes) SetExtended(exts ExtendedAttributes) {
+	a.Extended = exts
+	a.Flags |= AttrExtended
+}
+
+// SetExtendedFromMap sets the extended field to the specific map.
+// The resulting slice will be sorted by type key value.
+func (a *Attributes) SetExtendedFromMap(exts map[string]string) {
+	var tmp ExtendedAttributes
+	tmp.SetFromMap(exts)
+	a.SetExtended(tmp)
+}
+
+// ClearExtended clears the extended field, so that it is no longer set.
+func (a *Attributes) ClearExtended() {
+	a.Extended = nil
+	a.Flags &^= AttrExtended
+}
+
+// MarshalSize returns the number of bytes the attributes would marshal into.
+func (a *Attributes) MarshalSize() int {
 	length := 4
 
-	if a.Flags&AttrSize != 0 {
+	if a.HasSize() {
 		length += 8
 	}
 
-	if a.Flags&AttrUIDGID != 0 {
+	if a.HasUIDGID() {
 		length += 4 + 4
 	}
 
-	if a.Flags&AttrPermissions != 0 {
+	if a.HasPermissions() {
 		length += 4
 	}
 
-	if a.Flags&AttrACModTime != 0 {
+	if a.HasACModTime() {
 		length += 4 + 4
 	}
 
-	if a.Flags&AttrExtended != 0 {
-		length += 4
-
-		for _, ext := range a.ExtendedAttributes {
-			length += ext.Len()
-		}
+	if a.HasExtended() {
+		length += a.Extended.MarshalSize()
 	}
 
 	return length
 }
 
-// MarshalInto marshals e onto the end of the given Buffer.
+// MarshalInto marshals the attributes onto the end of the buffer.
 func (a *Attributes) MarshalInto(buf *Buffer) {
 	buf.AppendUint32(a.Flags)
 
-	if a.Flags&AttrSize != 0 {
+	if a.HasSize() {
 		buf.AppendUint64(a.Size)
 	}
 
-	if a.Flags&AttrUIDGID != 0 {
+	if a.HasUIDGID() {
 		buf.AppendUint32(a.UID)
 		buf.AppendUint32(a.GID)
 	}
 
-	if a.Flags&AttrPermissions != 0 {
+	if a.HasPermissions() {
 		buf.AppendUint32(uint32(a.Permissions))
 	}
 
-	if a.Flags&AttrACModTime != 0 {
+	if a.HasACModTime() {
 		buf.AppendUint32(a.ATime)
 		buf.AppendUint32(a.MTime)
 	}
 
-	if a.Flags&AttrExtended != 0 {
-		buf.AppendUint32(uint32(len(a.ExtendedAttributes)))
-
-		for _, ext := range a.ExtendedAttributes {
-			ext.MarshalInto(buf)
-		}
+	if a.HasExtended() {
+		a.Extended.MarshalInto(buf)
 	}
 }
 
-// MarshalBinary returns a as the binary encoding of a.
+// MarshalBinary returns the binary encoding of attributes.
 func (a *Attributes) MarshalBinary() ([]byte, error) {
-	buf := NewBuffer(make([]byte, 0, a.Len()))
+	buf := NewBuffer(make([]byte, 0, a.MarshalSize()))
 	a.MarshalInto(buf)
 	return buf.Bytes(), nil
 }
 
-// UnmarshalFrom unmarshals an Attributes from the given Buffer into e.
-//
-// NOTE: The values of fields not covered in the a.Flags are explicitly undefined.
+// UnmarshalFrom unmarshals the attributes from the buffer.
 func (a *Attributes) UnmarshalFrom(buf *Buffer) (err error) {
 	a.Flags = buf.ConsumeUint32()
 
@@ -170,42 +280,153 @@ func (a *Attributes) UnmarshalFrom(buf *Buffer) (err error) {
 		return buf.Err
 	}
 
-	if a.Flags&AttrSize != 0 {
+	if a.HasSize() {
 		a.Size = buf.ConsumeUint64()
 	}
 
-	if a.Flags&AttrUIDGID != 0 {
+	if a.HasUIDGID() {
 		a.UID = buf.ConsumeUint32()
 		a.GID = buf.ConsumeUint32()
 	}
 
-	if a.Flags&AttrPermissions != 0 {
+	if a.HasPermissions() {
 		a.Permissions = FileMode(buf.ConsumeUint32())
 	}
 
-	if a.Flags&AttrACModTime != 0 {
+	if a.HasACModTime() {
 		a.ATime = buf.ConsumeUint32()
 		a.MTime = buf.ConsumeUint32()
 	}
 
-	if a.Flags&AttrExtended != 0 {
-		count, err := buf.ConsumeCount()
-		if err != nil {
-			return err
-		}
-
-		a.ExtendedAttributes = make([]ExtendedAttribute, count)
-		for i := range a.ExtendedAttributes {
-			a.ExtendedAttributes[i].UnmarshalFrom(buf)
-		}
+	if a.HasExtended() {
+		a.Extended.UnmarshalFrom(buf)
 	}
 
 	return buf.Err
 }
 
-// UnmarshalBinary decodes the binary encoding of Attributes into e.
+// UnmarshalBinary decodes the binary encoding of the attributes.
 func (a *Attributes) UnmarshalBinary(data []byte) error {
 	return a.UnmarshalFrom(NewBuffer(data))
+}
+
+// ExtendedAttributes is a rich slice, which provides iterators and accesssors that operate as if it were a map:
+//
+//	for typ, data := range attrs.GetExtended().Seq2() {
+//		// Do something with the typ and data here.
+//	}
+type ExtendedAttributes []ExtendedAttribute
+
+// MarshalSize returns the number of bytes the extended attributes would marshal into.
+func (a ExtendedAttributes) MarshalSize() int {
+	length := 4
+
+	for _, ext := range a {
+		length += ext.MarshalSize()
+	}
+
+	return length
+}
+
+// MarshalInto marshals the extended attributes onto the end of the buffer.
+func (a ExtendedAttributes) MarshalInto(buf *Buffer) {
+	buf.AppendUint32(uint32(len(a)))
+
+	for _, ext := range a {
+		ext.MarshalInto(buf)
+	}
+}
+
+// MarshalBinary returns the binary encoding of the extended attributes.
+func (a ExtendedAttributes) MarshalBinary() ([]byte, error) {
+	buf := NewBuffer(make([]byte, 0, a.MarshalSize()))
+	a.MarshalInto(buf)
+	return buf.Bytes(), nil
+}
+
+// UnmarshalFrom unmarshals the extended attributes from the buffer.
+func (a *ExtendedAttributes) UnmarshalFrom(buf *Buffer) (err error) {
+	count, err := buf.ConsumeCount()
+	if err != nil {
+		return err
+	}
+
+	*a = make([]ExtendedAttribute, count)
+	for i := range count {
+		(*a)[i].UnmarshalFrom(buf)
+	}
+
+	return buf.Err
+}
+
+// UnmarshalBinary decodes the binary encoding of the extended attributes.
+func (a ExtendedAttributes) UnmarshalBinary(data []byte) error {
+	return a.UnmarshalFrom(NewBuffer(data))
+}
+
+// Len returns the length of the extended attributes slice.
+func (a ExtendedAttributes) Len() int {
+	return len(a)
+}
+
+// AsMap converts the extended attributes into a map[string]string,
+// where the type field is the key, and the data field is the value.
+func (a ExtendedAttributes) AsMap() map[string]string {
+	if len(a) == 0 {
+		return nil
+	}
+
+	m := make(map[string]string, len(a))
+	for _, ext := range a {
+		m[ext.Type] = ext.Data
+	}
+	return m
+}
+
+// SetFromMap sets the extended attributes to an equivalent of the given map,
+// where the key becomes the type field, and the value becomes the data field.
+// For efficency the order is unspecified.
+func (a *ExtendedAttributes) SetFromMap(m map[string]string) {
+	*a = make(ExtendedAttributes, 0, len(m))
+	for k, v := range m {
+		*a = append(*a, ExtendedAttribute{
+			Type: k,
+			Data: v,
+		})
+	}
+}
+
+// Get returns the data field of the extended attribute where the key matches the type field.
+//
+// Since this method operates in linear time,
+// if you are regularly accessing specific extended attributes,
+// you may want to use [AsMap] instead.
+func (a ExtendedAttributes) Get(key string) (data string, ok bool) {
+	for _, ext := range a {
+		if key == ext.Type {
+			return ext.Data, true
+		}
+	}
+
+	return "", false
+}
+
+// Seq is an iterator that yields the type field from each extended attribute.
+func (a ExtendedAttributes) Seq(yield func(string) bool) {
+	for _, ext := range a {
+		if !yield(ext.Type) {
+			return
+		}
+	}
+}
+
+// Seq2 is an iterator that yields the type and data fields from each extended attribute.
+func (a ExtendedAttributes) Seq2(yield func(string, string) bool) {
+	for _, ext := range a {
+		if !yield(ext.Type, ext.Data) {
+			return
+		}
+	}
 }
 
 // ExtendedAttribute defines the extended file attribute type defined in draft-ietf-secsh-filexfer-02
@@ -216,25 +437,25 @@ type ExtendedAttribute struct {
 	Data string
 }
 
-// Len returns the number of bytes e would marshal into.
-func (e *ExtendedAttribute) Len() int {
+// MarshalSize returns the number of bytes the extended attribute would marshal into.
+func (e *ExtendedAttribute) MarshalSize() int {
 	return 4 + len(e.Type) + 4 + len(e.Data)
 }
 
-// MarshalInto marshals e onto the end of the given Buffer.
+// MarshalInto marshals the extended attribute onto the end of the buffer.
 func (e *ExtendedAttribute) MarshalInto(buf *Buffer) {
 	buf.AppendString(e.Type)
 	buf.AppendString(e.Data)
 }
 
-// MarshalBinary returns e as the binary encoding of e.
+// MarshalBinary returns the binary encoding of the extended attribute.
 func (e *ExtendedAttribute) MarshalBinary() ([]byte, error) {
-	buf := NewBuffer(make([]byte, 0, e.Len()))
+	buf := NewBuffer(make([]byte, 0, e.MarshalSize()))
 	e.MarshalInto(buf)
 	return buf.Bytes(), nil
 }
 
-// UnmarshalFrom unmarshals an ExtendedAattribute from the given Buffer into e.
+// UnmarshalFrom unmarshals the extended attribute from the buffer.
 func (e *ExtendedAttribute) UnmarshalFrom(buf *Buffer) (err error) {
 	*e = ExtendedAttribute{
 		Type: buf.ConsumeString(),
@@ -244,7 +465,7 @@ func (e *ExtendedAttribute) UnmarshalFrom(buf *Buffer) (err error) {
 	return buf.Err
 }
 
-// UnmarshalBinary decodes the binary encoding of ExtendedAttribute into e.
+// UnmarshalBinary decodes the binary encoding of the extended attribute.
 func (e *ExtendedAttribute) UnmarshalBinary(data []byte) error {
 	return e.UnmarshalFrom(NewBuffer(data))
 }
@@ -301,12 +522,12 @@ func (e *NameEntry) Info() (fs.FileInfo, error) {
 	return e, nil
 }
 
-// Len returns the number of bytes e would marshal into.
-func (e *NameEntry) Len() int {
-	return 4 + len(e.Filename) + 4 + len(e.Longname) + e.Attrs.Len()
+// MarshalSize returns the number of bytes the name entry would marshal into.
+func (e *NameEntry) MarshalSize() int {
+	return 4 + len(e.Filename) + 4 + len(e.Longname) + e.Attrs.MarshalSize()
 }
 
-// MarshalInto marshals e onto the end of the given Buffer.
+// MarshalInto marshals the name entry onto the end of the buffer.
 func (e *NameEntry) MarshalInto(buf *Buffer) {
 	buf.AppendString(e.Filename)
 	buf.AppendString(e.Longname)
@@ -314,16 +535,14 @@ func (e *NameEntry) MarshalInto(buf *Buffer) {
 	e.Attrs.MarshalInto(buf)
 }
 
-// MarshalBinary returns e as the binary encoding of e.
+// MarshalBinary returns the binary encoding of the name entry.
 func (e *NameEntry) MarshalBinary() ([]byte, error) {
-	buf := NewBuffer(make([]byte, 0, e.Len()))
+	buf := NewBuffer(make([]byte, 0, e.MarshalSize()))
 	e.MarshalInto(buf)
 	return buf.Bytes(), nil
 }
 
-// UnmarshalFrom unmarshals an NameEntry from the given Buffer into e.
-//
-// NOTE: The values of fields not covered in the a.Flags are explicitly undefined.
+// UnmarshalFrom unmarshals the name entry from the buffer.
 func (e *NameEntry) UnmarshalFrom(buf *Buffer) (err error) {
 	*e = NameEntry{
 		Filename: buf.ConsumeString(),
@@ -333,7 +552,7 @@ func (e *NameEntry) UnmarshalFrom(buf *Buffer) (err error) {
 	return e.Attrs.UnmarshalFrom(buf)
 }
 
-// UnmarshalBinary decodes the binary encoding of NameEntry into e.
+// UnmarshalBinary decodes the binary encoding of the name entry.
 func (e *NameEntry) UnmarshalBinary(data []byte) error {
 	return e.UnmarshalFrom(NewBuffer(data))
 }

--- a/encoding/ssh/filexfer/attrs_test.go
+++ b/encoding/ssh/filexfer/attrs_test.go
@@ -30,7 +30,7 @@ func TestAttributes(t *testing.T) {
 		Permissions: perms,
 		ATime:       atime,
 		MTime:       mtime,
-		ExtendedAttributes: []ExtendedAttribute{
+		Extended: []ExtendedAttribute{
 			extAttr,
 		},
 	}
@@ -164,7 +164,7 @@ func TestAttributes(t *testing.T) {
 			}
 
 			if attr.Flags&AttrExtended != 0 {
-				extAttrs := attr.ExtendedAttributes
+				extAttrs := attr.Extended
 
 				if count := len(extAttrs); count != 1 {
 					t.Fatalf("UnmarshalBinary(): len(ExtendedAttributes) was %d, but wanted %d", count, 1)

--- a/encoding/ssh/filexfer/extensions.go
+++ b/encoding/ssh/filexfer/extensions.go
@@ -9,8 +9,8 @@ type ExtensionPair struct {
 	Data string
 }
 
-// Len returns the number of bytes e would marshal into.
-func (e *ExtensionPair) Len() int {
+// MarshalSize returns the number of bytes e would marshal into.
+func (e *ExtensionPair) MarshalSize() int {
 	return 4 + len(e.Name) + 4 + len(e.Data)
 }
 
@@ -22,7 +22,7 @@ func (e *ExtensionPair) MarshalInto(buf *Buffer) {
 
 // MarshalBinary returns e as the binary encoding of e.
 func (e *ExtensionPair) MarshalBinary() ([]byte, error) {
-	buf := NewBuffer(make([]byte, 0, e.Len()))
+	buf := NewBuffer(make([]byte, 0, e.MarshalSize()))
 	e.MarshalInto(buf)
 	return buf.Bytes(), nil
 }

--- a/encoding/ssh/filexfer/filexfer.go
+++ b/encoding/ssh/filexfer/filexfer.go
@@ -41,7 +41,7 @@ type Packet interface {
 	UnmarshalPacketBody(buf *Buffer) error
 }
 
-// ComposePacket converts returns from MarshalPacket into an equivalent call to MarshalBinary.
+// ComposePacket converts the returns from a MarshalPacket call into an equivalent call to MarshalBinary.
 func ComposePacket(header, payload []byte, err error) ([]byte, error) {
 	return append(header, payload...), err
 }

--- a/encoding/ssh/filexfer/fx.go
+++ b/encoding/ssh/filexfer/fx.go
@@ -68,8 +68,15 @@ func (s Status) Error() string {
 	return s.String()
 }
 
-// Is returns true if the target is the same Status code,
-// or target is a StatusPacket with the same Status code.
+// Is returns true if the status code is the same error as target.
+// If target is a *StatusPacket, then we return true if its StatusCode is the same status code.
+// If target is a Status, then we return true if they are the same status code.
+//
+// Special cases:
+//
+//	StatusEOF is io.EOF
+//	StatusNoSuchFile is fs.ErrNotExist
+//	StatusPermissionDenied is fs.ErrPermission
 func (s Status) Is(target error) bool {
 	var status *StatusPacket
 	if errors.As(target, &status) {
@@ -82,8 +89,8 @@ func (s Status) Is(target error) bool {
 	}
 
 	switch s {
-	case StatusOK:
-		return target == nil
+	// We cannot test for s == StatusOK && target == nil here.
+	// errors.Is short-circuits such a case to to `err == target`.
 	case StatusEOF:
 		return errors.Is(target, io.EOF)
 	case StatusNoSuchFile:

--- a/encoding/ssh/filexfer/fx_test.go
+++ b/encoding/ssh/filexfer/fx_test.go
@@ -3,6 +3,8 @@ package sshfx
 import (
 	"bufio"
 	"errors"
+	"io"
+	"io/fs"
 	"regexp"
 	"strconv"
 	"strings"
@@ -85,18 +87,33 @@ func TestFxNames(t *testing.T) {
 }
 
 func TestStatusIs(t *testing.T) {
-	status := StatusFailure
+	if !errors.Is(StatusFailure, StatusFailure) {
+		t.Error("errors.Is(StatusFailure, StatusFailure) should be true")
+	}
+	if !errors.Is(StatusFailure, &StatusPacket{StatusCode: StatusFailure}) {
+		t.Error("errors.Is(StatusFailure, StatusPacket{StatusFailure}) should be true")
+	}
 
-	if !errors.Is(status, StatusFailure) {
-		t.Error("errors.Is(StatusFailure, StatusFailure) != true")
+	if errors.Is(StatusFailure, StatusOK) {
+		t.Error("errors.Is(StatusFailure, StatusOK) should not be true")
 	}
-	if !errors.Is(status, &StatusPacket{StatusCode: StatusFailure}) {
-		t.Error("errors.Is(StatusFailure, StatusPacket{StatusFailure}) != true")
+	if errors.Is(StatusFailure, &StatusPacket{StatusCode: StatusOK}) {
+		t.Error("errors.Is(StatusFailure, StatusPacket{StatusOK}) should not be true")
 	}
-	if errors.Is(status, StatusOK) {
-		t.Error("errors.Is(StatusFailure, StatusFailure) == true")
+
+	/*// This test makes no sense to test, as its behavior is dictated by errors.Is.
+	if !errors.Is(StatusOK, nil) {
+		t.Error("errors.Is(StatusOK, nil) should be true")
 	}
-	if errors.Is(status, &StatusPacket{StatusCode: StatusOK}) {
-		t.Error("errors.Is(StatusFailure, StatusPacket{StatusFailure}) == true")
+	//*/
+
+	if !errors.Is(StatusEOF, io.EOF) {
+		t.Error("errors.Is(StatusEOF, io.EOF) should be true")
+	}
+	if !errors.Is(StatusNoSuchFile, fs.ErrNotExist) {
+		t.Error("errors.Is(StatusNoSuchFile, fs.ErrNotExist) should be true")
+	}
+	if !errors.Is(StatusPermissionDenied, fs.ErrPermission) {
+		t.Error("errors.Is(StatusPermissionDenied, fs.ErrPermission) should be true")
 	}
 }

--- a/encoding/ssh/filexfer/handle_packets.go
+++ b/encoding/ssh/filexfer/handle_packets.go
@@ -135,7 +135,7 @@ func (p *WritePacket) UnmarshalPacketBody(buf *Buffer) (err error) {
 	*p = WritePacket{
 		Handle: buf.ConsumeString(),
 		Offset: buf.ConsumeUint64(),
-		Data:   buf.ConsumeByteSliceCopy(hint),
+		Data:   buf.ConsumeBytesCopy(hint),
 	}
 
 	return buf.Err
@@ -200,7 +200,7 @@ func (p *FSetStatPacket) GetHandle() string {
 func (p *FSetStatPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	buf := NewBuffer(b)
 	if buf.Cap() < 9 {
-		size := 4 + len(p.Handle) + p.Attrs.Len() // string(handle) + ATTRS(attrs)
+		size := 4 + len(p.Handle) + p.Attrs.MarshalSize() // string(handle) + ATTRS(attrs)
 		buf = NewMarshalBuffer(size)
 	}
 

--- a/encoding/ssh/filexfer/init_packets.go
+++ b/encoding/ssh/filexfer/init_packets.go
@@ -16,7 +16,7 @@ func (p *InitPacket) MarshalBinary() ([]byte, error) {
 	size := 1 + 4 // byte(type) + uint32(version)
 
 	for _, ext := range p.Extensions {
-		size += ext.Len()
+		size += ext.MarshalSize()
 	}
 
 	b := NewBuffer(make([]byte, 4, 4+size))
@@ -104,7 +104,7 @@ func (p *VersionPacket) MarshalBinary() ([]byte, error) {
 	size := 1 + 4 // byte(type) + uint32(version)
 
 	for _, ext := range p.Extensions {
-		size += ext.Len()
+		size += ext.MarshalSize()
 	}
 
 	b := NewBuffer(make([]byte, 4, 4+size))

--- a/encoding/ssh/filexfer/open_packets.go
+++ b/encoding/ssh/filexfer/open_packets.go
@@ -27,7 +27,7 @@ func (p *OpenPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []by
 	buf := NewBuffer(b)
 	if buf.Cap() < 9 {
 		// string(filename) + uint32(pflags) + ATTRS(attrs)
-		size := 4 + len(p.Filename) + 4 + p.Attrs.Len()
+		size := 4 + len(p.Filename) + 4 + p.Attrs.MarshalSize()
 		buf = NewMarshalBuffer(size)
 	}
 

--- a/encoding/ssh/filexfer/packets.go
+++ b/encoding/ssh/filexfer/packets.go
@@ -127,7 +127,7 @@ func readPacket(r io.Reader, b []byte, maxPacketLength uint32) ([]byte, error) {
 		return nil, err
 	}
 
-	length := unmarshalUint32(b)
+	length := unmarshalPacketLength(b)
 	if int(length) < 5 {
 		// Must have at least uint8(type) and uint32(request-id)
 

--- a/encoding/ssh/filexfer/path_packets.go
+++ b/encoding/ssh/filexfer/path_packets.go
@@ -49,7 +49,7 @@ func (p *SetStatPacket) Type() PacketType {
 func (p *SetStatPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	buf := NewBuffer(b)
 	if buf.Cap() < 9 {
-		size := 4 + len(p.Path) + p.Attrs.Len() // string(path) + ATTRS(attrs)
+		size := 4 + len(p.Path) + p.Attrs.MarshalSize() // string(path) + ATTRS(attrs)
 		buf = NewMarshalBuffer(size)
 	}
 
@@ -120,7 +120,7 @@ func (p *MkdirPacket) Type() PacketType {
 func (p *MkdirPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	buf := NewBuffer(b)
 	if buf.Cap() < 9 {
-		size := 4 + len(p.Path) + p.Attrs.Len() // string(path) + ATTRS(attrs)
+		size := 4 + len(p.Path) + p.Attrs.MarshalSize() // string(path) + ATTRS(attrs)
 		buf = NewMarshalBuffer(size)
 	}
 

--- a/encoding/ssh/filexfer/response_packets.go
+++ b/encoding/ssh/filexfer/response_packets.go
@@ -22,9 +22,15 @@ func (p *StatusPacket) Error() string {
 	return "sftp: " + p.StatusCode.String() + ": " + p.ErrorMessage
 }
 
-// Is returns true if target is a StatusPacket with the same StatusCode,
-// or target is a Status code which is the same as SatusCode.
+// Is returns true if the status packet is the same error as target.
+// If target is a *StatusPacket, then we return true if all fields are equal.
+// Otherwise, we return true if [Status.Is] of the status code returns true for the same target.
 func (p *StatusPacket) Is(target error) bool {
+	var status *StatusPacket
+	if errors.As(target, &status) {
+		return *p == *status
+	}
+
 	return p.StatusCode.Is(target)
 }
 

--- a/encoding/ssh/filexfer/response_packets.go
+++ b/encoding/ssh/filexfer/response_packets.go
@@ -132,7 +132,7 @@ func (p *DataPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []by
 // This means this _does not_ alias any of the data buffer that is passed in.
 func (p *DataPacket) UnmarshalPacketBody(buf *Buffer) (err error) {
 	*p = DataPacket{
-		Data: buf.ConsumeByteSliceCopy(p.Data),
+		Data: buf.ConsumeBytesCopy(p.Data),
 	}
 
 	return buf.Err
@@ -155,7 +155,7 @@ func (p *NamePacket) MarshalPacket(reqid uint32, b []byte) (header, payload []by
 		size := 4 // uint32(len(entries))
 
 		for _, e := range p.Entries {
-			size += e.Len()
+			size += e.MarshalSize()
 		}
 
 		buf = NewMarshalBuffer(size)
@@ -275,7 +275,7 @@ func (p *AttrsPacket) Type() PacketType {
 func (p *AttrsPacket) MarshalPacket(reqid uint32, b []byte) (header, payload []byte, err error) {
 	buf := NewBuffer(b)
 	if buf.Cap() < 9 {
-		size := p.Attrs.Len() // ATTRS(attrs)
+		size := p.Attrs.MarshalSize() // ATTRS(attrs)
 		buf = NewMarshalBuffer(size)
 	}
 

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,27 @@
+// go:build gofuzz
+//go:build gofuzz
+// +build gofuzz
+
+package sftp
+
+import (
+	"bytes"
+	"context"
+)
+
+type sinkfuzz struct{}
+
+func (*sinkfuzz) Close() error                { return nil }
+func (*sinkfuzz) Write(p []byte) (int, error) { return len(p), nil }
+
+var devnull = &sinkfuzz{}
+
+// To run: go-fuzz-build && go-fuzz
+func Fuzz(data []byte) int {
+	c, err := NewClientPipe(context.Background(), bytes.NewReader(data), devnull)
+	if err != nil {
+		return 0
+	}
+	c.Close()
+	return 1
+}

--- a/localfs/attrs_atim.go
+++ b/localfs/attrs_atim.go
@@ -13,6 +13,6 @@ import (
 func fileStatFromInfoOs(fi fs.FileInfo, attrs *sshfx.Attributes) {
 	if statt, ok := fi.Sys().(*syscall.Stat_t); ok {
 		attrs.SetUIDGID(statt.Uid, statt.Gid)
-		attrs.ATime = uint32(statt.Atim.Sec)
+		attrs.SetACModTime(uint32(statt.Atim.Sec), uint32(statt.Mtim.Sec))
 	}
 }

--- a/localfs/attrs_atime.go
+++ b/localfs/attrs_atime.go
@@ -13,6 +13,6 @@ import (
 func fileStatFromInfoOs(fi fs.FileInfo, attrs *sshfx.Attributes) {
 	if statt, ok := fi.Sys().(*syscall.Stat_t); ok {
 		attrs.SetUIDGID(statt.Uid, statt.Gid)
-		attrs.ATime = uint32(statt.Atime)
+		attrs.SetACModTime(uint32(statt.Atime), uint32(statt.Mtime))
 	}
 }

--- a/localfs/attrs_atimespec.go
+++ b/localfs/attrs_atimespec.go
@@ -13,6 +13,6 @@ import (
 func fileStatFromInfoOs(fi fs.FileInfo, attrs *sshfx.Attributes) {
 	if statt, ok := fi.Sys().(*syscall.Stat_t); ok {
 		attrs.SetUIDGID(statt.Uid, statt.Gid)
-		attrs.ATime = uint32(statt.Atimespec.Sec)
+		attrs.SetACModTime(uint32(statt.Atimespec.Sec), uint32(statt.Mtimespec.Sec))
 	}
 }

--- a/localfs/attrs_plan9.go
+++ b/localfs/attrs_plan9.go
@@ -9,6 +9,6 @@ import (
 
 func fileStatFromInfoOs(fi fs.FileInfo, attrs *sshfx.Attributes) {
 	if dir, ok := fi.Sys().(*syscall.Dir); ok {
-		attrs.ATime = dir.Atime
+		attrs.SetACModTime(dir.Atime, dir.Mtime)
 	}
 }

--- a/localfs/attrs_windows.go
+++ b/localfs/attrs_windows.go
@@ -10,6 +10,8 @@ import (
 
 func fileStatFromInfoOs(fi fs.FileInfo, attrs *sshfx.Attributes) {
 	if fad, ok := fi.Sys().(*syscall.Win32FileAttributeData); ok {
-		attrs.ATime = uint32(time.Duration(fad.LastAccessTime.Nanoseconds()).Seconds())
+		atime := uint32(time.Duration(fad.LastAccessTime.Nanoseconds()).Seconds())
+		mtime := uint32(time.Duration(fad.LastWriteTime.Nanoseconds()).Seconds())
+		attrs.SetACModTime(atime, mtime)
 	}
 }

--- a/localfs/server_plan9.go
+++ b/localfs/server_plan9.go
@@ -7,15 +7,15 @@ import (
 
 func toLocalPath(p string) (string, error) {
 	if path.IsAbs(p) {
-		tmp := lp[1:]
+		tmp := p[1:]
 
 		if filepath.IsAbs(tmp) {
 			// If the FromSlash without any starting slashes is absolute,
 			// then we have a filepath encoded with a prefix '/'.
 			// e.g. "/#s/boot" to "#s/boot"
-			return tmp
+			return tmp, nil
 		}
 	}
 
-	return lp
+	return p, nil
 }

--- a/localfs/server_windows.go
+++ b/localfs/server_windows.go
@@ -149,14 +149,11 @@ func (f *winRoot) Handle() string {
 }
 
 func (f *winRoot) Stat() (*sshfx.Attributes, error) {
-	return &sshfx.Attributes{
-		Flags: sshfx.AttrSize | sshfx.AttrPermissions | sshfx.AttrACModTime,
-
-		MTime: f.mtime,
-		ATime: f.mtime,
-
-		Permissions: 0555,
-	}, nil
+	attrs := new(sshfx.Attributes)
+	attrs.SetSize(0)
+	attrs.SetACModTime(f.mtime, f.mtime)
+	attrs.SetPermissions(0555)
+	return attrs, nil
 }
 
 func (f *winRoot) ReadDir(maxDataLen uint32) ([]*sshfx.NameEntry, error) {
@@ -167,7 +164,7 @@ func (f *winRoot) ReadDir(maxDataLen uint32) ([]*sshfx.NameEntry, error) {
 	for len(f.entries) > 0 {
 		entry := f.entries[0]
 
-		if size+entry.Len() > int(maxDataLen) {
+		if size+entry.MarshalSize() > int(maxDataLen) {
 			return ret, nil
 		}
 

--- a/longname.go
+++ b/longname.go
@@ -32,9 +32,12 @@ func FormatLongname(fi fs.FileInfo, idLookup NameLookup) string {
 
 	switch sys := fi.Sys().(type) {
 	case *sshfx.Attributes:
-		symPerms = sys.Permissions.String()
-		uid = fmt.Sprint(sys.UID)
-		gid = fmt.Sprint(sys.GID)
+		symPerms = sys.GetPermissions().String()
+
+		sysUID, sysGID := sys.GetUIDGID()
+		uid = fmt.Sprint(sysUID)
+		gid = fmt.Sprint(sysGID)
+
 	default:
 		symPerms = sshfx.FromGoFileMode(fi.Mode()).String()
 	}

--- a/server.go
+++ b/server.go
@@ -85,10 +85,11 @@ type TruncateFileHandler interface {
 }
 
 func trunc(attr *sshfx.Attributes, f FileHandler) (func() error, error) {
-	sz, has := attr.GetSize()
-	if !has {
+	if !attr.HasSize() {
 		return noop, nil
 	}
+
+	sz := attr.GetSize()
 
 	if truncater, ok := f.(TruncateFileHandler); ok {
 		return func() error {
@@ -109,10 +110,11 @@ type ChownFileHandler interface {
 }
 
 func chown(attr *sshfx.Attributes, f FileHandler) (func() error, error) {
-	uid, gid, has := attr.GetUIDGID()
-	if !has {
+	if !attr.HasUIDGID() {
 		return noop, nil
 	}
+
+	uid, gid := attr.GetUIDGID()
 
 	if chowner, ok := f.(ChownFileHandler); ok {
 		return func() error {
@@ -133,10 +135,11 @@ type ChmodFileHandler interface {
 }
 
 func chmod(attr *sshfx.Attributes, f FileHandler) (func() error, error) {
-	mode, has := attr.GetPermissions()
-	if !has {
+	if !attr.HasPermissions() {
 		return noop, nil
 	}
+
+	mode := attr.GetPermissions()
 
 	if chmoder, ok := f.(ChmodFileHandler); ok {
 		return func() error {
@@ -157,10 +160,11 @@ type ChtimesFileHandler interface {
 }
 
 func chtimes(attr *sshfx.Attributes, f FileHandler) (func() error, error) {
-	atime, mtime, has := attr.GetACModTime()
-	if !has {
+	if !attr.HasACModTime() {
 		return noop, nil
 	}
+
+	atime, mtime := attr.GetACModTime()
 
 	if chtimeser, ok := f.(ChtimesFileHandler); ok {
 		return func() error {
@@ -749,7 +753,7 @@ func (srv *Server) handle(req sshfx.Packet, hint []byte, maxDataLen uint32) (ssh
 				return nil, file.SetStat(&req.Attrs)
 			}
 
-			if len(req.Attrs.ExtendedAttributes) > 0 {
+			if len(req.Attrs.Extended) > 0 {
 				return nil, &sshfx.StatusPacket{
 					StatusCode:   sshfx.StatusOpUnsupported,
 					ErrorMessage: "unsupported fsetstat: extended attributes",


### PR DESCRIPTION
There are a few code improvements, but mostly this is changing signatures on the `sshfx.Attributes` object.