### PR TITLE
fix: maybe hang for process *sshfx.ReadPacket for *Server.handle()"

### DIFF
--- a/server.go
+++ b/server.go
@@ -700,7 +700,7 @@ func (srv *Server) handle(req sshfx.Packet, hint []byte, maxDataLen uint32) (ssh
 				return nil, fmt.Errorf("read length request too large: %d", req.Length)
 			}
 
-			hint = slices.Grow(hint[:0], req.Length)[:req.Length]
+			hint = slices.Grow(hint[:0], int(req.Length))[:req.Length]
 			 
 			n, err := file.ReadAt(hint, int64(req.Offset))
 			if err != nil {

--- a/server.go
+++ b/server.go
@@ -699,7 +699,9 @@ func (srv *Server) handle(req sshfx.Packet, hint []byte, maxDataLen uint32) (ssh
 				return nil, fmt.Errorf("read length request too large: %d", req.Length)
 			}
 
-			n, err := file.ReadAt(hint[:req.Length], int64(req.Offset))
+			hint = slices.Grow(hint[:0], req.Length)[:req.Length]
+			 
+			n, err := file.ReadAt(hint, int64(req.Offset))
 			if err != nil {
 				// We cannot return results AND a status like SSH_FX_EOF,
 				// so we return io.EOF only if we didn't read anything at all.

--- a/server.go
+++ b/server.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"math"
+	"slices"
 	"time"
 
 	sshfx "github.com/pkg/sftp/v2/encoding/ssh/filexfer"

--- a/server.go
+++ b/server.go
@@ -699,7 +699,7 @@ func (srv *Server) handle(req sshfx.Packet, hint []byte, maxDataLen uint32) (ssh
 				return nil, fmt.Errorf("read length request too large: %d", req.Length)
 			}
 
-			n, err := file.ReadAt(hint, int64(req.Offset))
+			n, err := file.ReadAt(hint[:req.Length], int64(req.Offset))
 			if err != nil {
 				// We cannot return results AND a status like SSH_FX_EOF,
 				// so we return io.EOF only if we didn't read anything at all.


### PR DESCRIPTION
In `*Server.handle`, if the *sshfx.ReadPacket's Length is less than maxDataLen, the client may get stuck during data reading.