### PR TITLE
go.mod: set the minimum version to 1.23.0 as x/crypto

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.22', '1.21']
+        go: ['1.24', '1.23']
         exclude:
           - os: macos-latest
-            go: '1.21'
+            go: '1.24'
 
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pkg/sftp
 
-go 1.24.0
+go 1.23.0
 
 require (
 	github.com/kr/fs v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/kr/fs v0.1.0
-	github.com/stretchr/testify v1.8.0
-	golang.org/x/crypto v0.35.0
-	golang.org/x/sys v0.30.0
+	github.com/stretchr/testify v1.10.0
+	golang.org/x/crypto v0.36.0
+	golang.org/x/sys v0.31.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,16 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
 golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=
 golang.org/x/term v0.29.0/go.mod h1:6bl4lRlvVuDgSf3179VpIxBF0o10JUpXWOnI7nErv7s=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
after #626 we require Go 1.24, check the CI [logs](https://github.com/pkg/sftp/actions/runs/14118749980/job/39554848010):

```
Setup go version spec 1.22
Found in cache @ /opt/hostedtoolcache/go/1.22.12/x64
Added go to the path
Successfully set up Go version 1.22
go: downloading go1.24.0 (linux/amd64)
/opt/hostedtoolcache/go/1.22.[12](https://github.com/pkg/sftp/actions/runs/14118749980/job/39554848010#step:3:13)/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.22.12/x64/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Cache is not found
go version go1.24.0 linux/amd64
```