### PR TITLE
ISSUE #627: convert typed-nils to untyped-nils on error

### DIFF
--- a/client.go
+++ b/client.go
@@ -892,6 +892,19 @@ func (cl *Client) hasExtension(ext *sshfx.ExtensionPair) bool {
 	return cl.exts[ext.Name] == ext.Data
 }
 
+// StatVFS retrieves VFS statistics from a remote host.
+//
+// It implements the statvfs@openssh.com SSH_FXP_EXTENDED feature from
+// https://github.com/openssh/openssh-portable/blob/master/PROTOCOL
+func (cl *Client) StatVFS(path string) (*openssh.StatVFSExtendedReplyPacket, error) {
+	resp, err := getPacket[*openssh.StatVFSExtendedReplyPacket](context.Background(), nil, cl,
+		&openssh.StatVFSExtendedPacket{
+			Path: path,
+		},
+	)
+	return valOrPathError("statvfs", path, resp, err)
+}
+
 // Link creates newname as a hard link to oldname file.
 //
 // If the server did not announce support for the "hardlink@openssh.com" extension,

--- a/localfs/localfs_integration_test.go
+++ b/localfs/localfs_integration_test.go
@@ -769,10 +769,12 @@ func TestStatVFS(t *testing.T) {
 		t.Fatalf("unexpected error, got %v, should be fs.ErrNotFound", err)
 	}
 
-	_, err = cl.StatVFS(toRemotePath(dir))
+	resp, err := cl.StatVFS(toRemotePath(dir))
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	t.Logf("%+v", resp)
 }
 
 var benchBuf []byte

--- a/localfs/localfs_integration_test.go
+++ b/localfs/localfs_integration_test.go
@@ -751,6 +751,30 @@ func TestReadFrom(t *testing.T) {
 	}
 }
 
+func TestStatVFS(t *testing.T) {
+	if !*testServerImpl {
+		t.Skip("not testing against localfs server implementation")
+	}
+
+	if _, ok := any(handler).(sftp.StatVFSServerHandler); !ok {
+		t.Skip("handler does not implement statvfs")
+	}
+
+	dir := t.TempDir()
+
+	targetNotExist := filepath.Join(dir, "statvfs-does-not-exist")
+
+	_, err := cl.StatVFS(toRemotePath(targetNotExist))
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("unexpected error, got %v, should be fs.ErrNotFound", err)
+	}
+
+	_, err = cl.StatVFS(toRemotePath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 var benchBuf []byte
 
 func benchHelperWriteTo(b *testing.B, length int) {

--- a/server.go
+++ b/server.go
@@ -622,7 +622,13 @@ func (srv *Server) handle(req sshfx.Packet, hint []byte, maxDataLen uint32) (ssh
 
 			case *openssh.FStatVFSExtendedPacket:
 				if statvfser, ok := file.(StatVFSFileHandler); ok {
-					return statvfser.StatVFS()
+					resp, err := statvfser.StatVFS()
+					if err != nil {
+						// We have to convert typed-nil to untyped-nil.
+						return nil, err
+					}
+
+					return resp, nil
 				}
 
 				if statvfser, ok := srv.Handler.(StatVFSServerHandler); ok {
@@ -747,7 +753,8 @@ func (srv *Server) handle(req sshfx.Packet, hint []byte, maxDataLen uint32) (ssh
 				return nil, io.ErrShortWrite
 			}
 
-			return nil, nil
+			// explicitly return statusOK here, rather than both nil.
+			return statusOK, nil
 
 		case *sshfx.FStatPacket:
 			attrs, err := file.Stat()


### PR DESCRIPTION
Addresses #627 , we handle converting certain getters into an untyped-nil `sshfx.Packet` on non-nil error.