### PR TITLE
Don't translate StatusPacket to os.Err(NotExist|Permission)

### DIFF
--- a/client.go
+++ b/client.go
@@ -490,10 +490,6 @@ func statusToError(status *sshfx.StatusPacket, okExpected bool) error {
 
 	case sshfx.StatusEOF:
 		return io.EOF
-	case sshfx.StatusNoSuchFile:
-		return fs.ErrNotExist
-	case sshfx.StatusPermissionDenied:
-		return fs.ErrPermission
 	}
 
 	return status


### PR DESCRIPTION
Doing this loses potentially useful information for the client. They should instead check with errors.Is(err, fs.ErrNotExist), etc.; the StatusPacket type has an Is method for this already.