### PR TITLE
Fix Windows path detection in cleanPathWithBase

### DIFF
--- a/request-server.go
+++ b/request-server.go
@@ -347,8 +347,12 @@ func cleanPath(p string) string {
 }
 
 func cleanPathWithBase(base, p string) string {
+	// Check if original path is absolute before converting to forward slashes.
+	// This correctly handles Windows paths like "C:\foo" which filepath.IsAbs
+	// recognizes but path.IsAbs (after ToSlash conversion to "C:/foo") does not.
+	isAbs := filepath.IsAbs(p)
 	p = filepath.ToSlash(filepath.Clean(p))
-	if !path.IsAbs(p) {
+	if !isAbs {
 		return path.Join(base, p)
 	}
 	return p


### PR DESCRIPTION
## Summary

Fix `cleanPathWithBase` to use `filepath.IsAbs` on the original path before converting to forward slashes. This correctly handles Windows paths like `C:\foo` which `filepath.IsAbs` recognizes but `path.IsAbs` (after `ToSlash` conversion to `C:/foo`) does not.

## Problem

When using `WithStartDirectory` on Windows, absolute paths like `C:\Users\foo` are incorrectly treated as relative paths because:

1. `filepath.ToSlash(filepath.Clean("C:\\Users\\foo"))` → `C:/Users/foo`
2. `path.IsAbs("C:/Users/foo")` → `false` (only checks for `/` prefix)
3. Result: path gets joined with start directory, causing doubled paths

## Solution

Check `filepath.IsAbs(p)` on the original path before the `ToSlash` conversion. `filepath.IsAbs` is platform-aware and correctly identifies Windows absolute paths.

## Related

This fix resolves Windows SFTP path handling issues in https://github.com/owenthereal/upterm/pull/440