### PR TITLE
Add build tag to omit the x/crypto/ssh dependency

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/kr/fs"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/pkg/sftp/internal/encoding/ssh/filexfer/openssh"
 )
@@ -190,34 +189,6 @@ type Client struct {
 	useConcurrentWrites    bool
 	useFstat               bool
 	disableConcurrentReads bool
-}
-
-// NewClient creates a new SFTP client on conn, using zero or more option
-// functions.
-func NewClient(conn *ssh.Client, opts ...ClientOption) (*Client, error) {
-	s, err := conn.NewSession()
-	if err != nil {
-		return nil, err
-	}
-
-	pw, err := s.StdinPipe()
-	if err != nil {
-		return nil, err
-	}
-	pr, err := s.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-	perr, err := s.StderrPipe()
-	if err != nil {
-		return nil, err
-	}
-
-	if err := s.RequestSubsystem("sftp"); err != nil {
-		return nil, err
-	}
-
-	return newClientPipe(pr, perr, pw, s.Wait, opts...)
 }
 
 // NewClientPipe creates a new SFTP client given a Reader and a WriteCloser.

--- a/client_ssh.go
+++ b/client_ssh.go
@@ -1,0 +1,33 @@
+//go:build !pkg_sftp.omit_ssh
+
+package sftp
+
+import "golang.org/x/crypto/ssh"
+
+// NewClient creates a new SFTP client on conn, using zero or more option
+// functions.
+func NewClient(conn *ssh.Client, opts ...ClientOption) (*Client, error) {
+	s, err := conn.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	pw, err := s.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	pr, err := s.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	perr, err := s.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.RequestSubsystem("sftp"); err != nil {
+		return nil, err
+	}
+
+	return newClientPipe(pr, perr, pw, s.Wait, opts...)
+}


### PR DESCRIPTION
The only use of `golang.org/x/crypto/ssh` (and, transitively, of any package in `crypto/...`) is in the `NewClient` function, which is a small wrapper around running a subsystem request with an `ssh.Client` to then run a sftp client on the channel.

For binaries that don't otherwise depend on `x/crypto/ssh` (for example utility binaries that only do sftp through stdio) this can be a somewhat significant chunk of binary size; for example a stripped cgoless build of `server_standalone` (darwin arm64, go 1.26.1) goes from 2.9 to 2.0 MiB, which is (relatively) significant.

This PR moves `NewClient` to a new file which is omitted from the build if a new `pkg_sftp.omit_ssh` build tag is set during the build, so users of the library that don't use `x/crypto/ssh` can omit that dependency.