### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/attrs.go
+++ b/attrs.go
@@ -40,7 +40,7 @@ func (fi *fileInfo) ModTime() time.Time { return fi.stat.ModTime() }
 // IsDir returns true if the file is a directory.
 func (fi *fileInfo) IsDir() bool { return fi.Mode().IsDir() }
 
-func (fi *fileInfo) Sys() interface{} { return fi.stat }
+func (fi *fileInfo) Sys() any { return fi.stat }
 
 // FileStat holds the original unmarshalled values from a call to READDIR or
 // *STAT. It is exported for the purposes of accessing the raw values via

--- a/client.go
+++ b/client.go
@@ -561,7 +561,7 @@ func (c *Client) Symlink(oldname, newname string) error {
 	}
 }
 
-func (c *Client) fsetstat(handle string, flags uint32, attrs interface{}) error {
+func (c *Client) fsetstat(handle string, flags uint32, attrs any) error {
 	id := c.nextID()
 	typ, data, err := c.sendPacket(context.Background(), nil, &sshFxpFsetstatPacket{
 		ID:     id,
@@ -581,7 +581,7 @@ func (c *Client) fsetstat(handle string, flags uint32, attrs interface{}) error 
 }
 
 // setstat is a convience wrapper to allow for changing of various parts of the file descriptor.
-func (c *Client) setstat(path string, flags uint32, attrs interface{}) error {
+func (c *Client) setstat(path string, flags uint32, attrs any) error {
 	id := c.nextID()
 	typ, data, err := c.sendPacket(context.Background(), nil, &sshFxpSetstatPacket{
 		ID:    id,

--- a/debug.go
+++ b/debug.go
@@ -5,6 +5,6 @@ package sftp
 
 import "log"
 
-func debug(fmt string, args ...interface{}) {
+func debug(fmt string, args ...any) {
 	log.Printf(fmt, args...)
 }

--- a/packet.go
+++ b/packet.go
@@ -95,7 +95,7 @@ func marshalStatus(b []byte, err StatusError) []byte {
 	return b
 }
 
-func marshal(b []byte, v interface{}) []byte {
+func marshal(b []byte, v any) []byte {
 	switch v := v.(type) {
 	case nil:
 		return b
@@ -690,7 +690,7 @@ func (p *sshFxpRealpathPacket) UnmarshalBinary(b []byte) error {
 type sshFxpNameAttr struct {
 	Name     string
 	LongName string
-	Attrs    []interface{}
+	Attrs    []any
 }
 
 func (p *sshFxpNameAttr) MarshalBinary() ([]byte, error) {
@@ -740,7 +740,7 @@ type sshFxpOpenPacket struct {
 	Path   string
 	Pflags uint32
 	Flags  uint32
-	Attrs  interface{}
+	Attrs  any
 }
 
 func (p *sshFxpOpenPacket) id() uint32 { return p.ID }
@@ -1006,14 +1006,14 @@ type sshFxpSetstatPacket struct {
 	ID    uint32
 	Flags uint32
 	Path  string
-	Attrs interface{}
+	Attrs any
 }
 
 type sshFxpFsetstatPacket struct {
 	ID     uint32
 	Flags  uint32
 	Handle string
-	Attrs  interface{}
+	Attrs  any
 }
 
 func (p *sshFxpSetstatPacket) id() uint32  { return p.ID }

--- a/packet_test.go
+++ b/packet_test.go
@@ -84,7 +84,7 @@ func TestMarshal(t *testing.T) {
 	}
 
 	var tests = []struct {
-		v    interface{}
+		v    any
 		want []byte
 	}{
 		{uint8(42), []byte{42}},

--- a/release.go
+++ b/release.go
@@ -3,4 +3,4 @@
 
 package sftp
 
-func debug(fmt string, args ...interface{}) {}
+func debug(fmt string, args ...any) {}

--- a/request-example.go
+++ b/request-example.go
@@ -573,7 +573,7 @@ func (f *memFile) Mode() os.FileMode {
 }
 func (f *memFile) ModTime() time.Time { return f.modtime }
 func (f *memFile) IsDir() bool        { return f.isdir }
-func (f *memFile) Sys() interface{} {
+func (f *memFile) Sys() any {
 	return fakeFileInfoSys()
 }
 

--- a/request-plan9.go
+++ b/request-plan9.go
@@ -7,10 +7,10 @@ import (
 	"syscall"
 )
 
-func fakeFileInfoSys() interface{} {
+func fakeFileInfoSys() any {
 	return &syscall.Dir{}
 }
 
-func testOsSys(sys interface{}) error {
+func testOsSys(sys any) error {
 	return nil
 }

--- a/request-unix.go
+++ b/request-unix.go
@@ -8,11 +8,11 @@ import (
 	"syscall"
 )
 
-func fakeFileInfoSys() interface{} {
+func fakeFileInfoSys() any {
 	return &syscall.Stat_t{Uid: 65534, Gid: 65534}
 }
 
-func testOsSys(sys interface{}) error {
+func testOsSys(sys any) error {
 	fstat := sys.(*FileStat)
 	if fstat.UID != uint32(65534) {
 		return errors.New("Uid failed to match")

--- a/request.go
+++ b/request.go
@@ -538,7 +538,7 @@ func filelist(h FileLister, r *Request, pkt requestPacket) responsePacket {
 			nameAttrs = append(nameAttrs, &sshFxpNameAttr{
 				Name:     fi.Name(),
 				LongName: runLs(idLookup, fi),
-				Attrs:    []interface{}{fi},
+				Attrs:    []any{fi},
 			})
 		}
 

--- a/request_test.go
+++ b/request_test.go
@@ -114,11 +114,11 @@ func (h *Handlers) returnError(err error) {
 	handler.err = err
 }
 
-func getStatusMsg(p interface{}) string {
+func getStatusMsg(p any) string {
 	pkt := p.(*sshFxpStatusPacket)
 	return pkt.StatusError.msg
 }
-func checkOkStatus(t *testing.T, p interface{}) {
+func checkOkStatus(t *testing.T, p any) {
 	pkt := p.(*sshFxpStatusPacket)
 	assert.Equal(t, pkt.StatusError.Code, uint32(sshFxOk),
 		"sshFxpStatusPacket not OK\n", pkt.StatusError.msg)

--- a/request_windows.go
+++ b/request_windows.go
@@ -4,10 +4,10 @@ import (
 	"syscall"
 )
 
-func fakeFileInfoSys() interface{} {
+func fakeFileInfoSys() any {
 	return syscall.Win32FileAttributeData{}
 }
 
-func testOsSys(sys interface{}) error {
+func testOsSys(sys any) error {
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -463,7 +463,7 @@ func (p *sshFxpStatResponse) MarshalBinary() ([]byte, error) {
 	return append(header, payload...), err
 }
 
-var emptyFileStat = []interface{}{uint32(0)}
+var emptyFileStat = []any{uint32(0)}
 
 func (p *sshFxpOpenPacket) readonly() bool {
 	return !p.hasPflags(sshFxfWrite)
@@ -542,7 +542,7 @@ func (p *sshFxpReaddirPacket) respond(svr *Server) responsePacket {
 		ret.NameAttrs = append(ret.NameAttrs, &sshFxpNameAttr{
 			Name:     dirent.Name(),
 			LongName: runLs(idLookup, dirent),
-			Attrs:    []interface{}{dirent},
+			Attrs:    []any{dirent},
 		})
 	}
 	return ret
@@ -597,7 +597,7 @@ func (p *sshFxpFsetstatPacket) respond(svr *Server) responsePacket {
 			Chtimes(atime, mtime time.Time) error
 		}
 
-		switch f := interface{}(f).(type) {
+		switch f := any(f).(type) {
 		case chtimer:
 			// future-compatible, for when/if *os.File supports Chtimes.
 			err = f.Chtimes(fs.AccessTime(), fs.ModTime())

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -265,7 +265,7 @@ func rejectRequest(req *ssh.Request) error {
 	return err
 }
 
-func rejectRequestUnmarshalError(req *ssh.Request, s interface{}, err error) error {
+func rejectRequestUnmarshalError(req *ssh.Request, s any, err error) error {
 	fmt.Fprintf(sshServerDebugStream, "ssh request unmarshaling error, type '%T': %v\n", s, err)
 	rejectRequest(req)
 	return err

--- a/server_windows.go
+++ b/server_windows.go
@@ -170,7 +170,7 @@ func (w *winRootFileInfo) Size() int64        { return 0 }
 func (w *winRootFileInfo) Mode() fs.FileMode  { return fs.ModeDir | 0555 } // read+execute for all
 func (w *winRootFileInfo) ModTime() time.Time { return w.modTime }
 func (w *winRootFileInfo) IsDir() bool        { return true }
-func (w *winRootFileInfo) Sys() interface{}   { return nil }
+func (w *winRootFileInfo) Sys() any   { return nil }
 
 // Create a new root FileInfo
 var rootFileInfo = &winRootFileInfo{


### PR DESCRIPTION
Since Go 1.18, `any` is the built-in alias for `interface{}`. This change modernizes the codebase.