### PR TITLE
expose the SSH_FXP_READDIR longname

### DIFF
--- a/attrs.go
+++ b/attrs.go
@@ -54,6 +54,7 @@ type FileStat struct {
 	UID      uint32
 	GID      uint32
 	Extended []StatExtended
+	Longname string
 }
 
 // ModTime returns the Mtime SFTP file attribute converted to a time.Time

--- a/client.go
+++ b/client.go
@@ -405,12 +405,14 @@ func (c *Client) ReadDirContext(ctx context.Context, p string) ([]os.FileInfo, e
 			for i := uint32(0); i < count; i++ {
 				var filename string
 				filename, data = unmarshalString(data)
-				_, data = unmarshalString(data) // discard longname
+				var longname string
+				longname, data = unmarshalString(data)
 				var attr *FileStat
 				attr, data, err = unmarshalAttrs(data)
 				if err != nil {
 					return nil, err
 				}
+				attr.Longname = longname
 				if filename == "." || filename == ".." {
 					continue
 				}


### PR DESCRIPTION
Each entry in a SSH_FXP_NAME reply carries three fields: filename, longname and attrs ([source](https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-7)). The client currently ignore the longname field with:
```
_, data = unmarshalString(data) // discard longname
```

I have a use case which require to display things similarly to what the open ssh cli shows:
```
sftp> ls -l
drwxrwxr-x    ? mickael  mickael      4096 Jul  3 18:34 Android
drwxr-xr-x    ? mickael  mickael      4096 Jun  3 00:03 Desktop
drwxr-xr-x    ? mickael  mickael      4096 Jul  8 14:14 Documents
```
As of today, this is not possible and this PR fixes that